### PR TITLE
AM031: reduce false positives and harden fixer routing

### DIFF
--- a/docs/ANALYZER_REVIEW_TRACKER.md
+++ b/docs/ANALYZER_REVIEW_TRACKER.md
@@ -15,9 +15,10 @@ Tracks analyzer-by-analyzer improvement passes focused on false positives, contr
 | AM020 | Complex Mappings | [#51](https://github.com/georgepwall1991/automapper-analyser/pull/51) | [v2.12.0](https://github.com/georgepwall1991/automapper-analyser/releases/tag/v2.12.0) | Unified analyzer/fixer suppression logic and direction-aware handling for `ForMember`/`ForPath`/construct-convert configuration. |
 | AM021 | Complex Mappings | [#52](https://github.com/georgepwall1991/automapper-analyser/pull/52) | [v2.13.0](https://github.com/georgepwall1991/automapper-analyser/releases/tag/v2.13.0) | Direction-aware reverse-map handling, better custom-conversion suppression, and safer fixer type inference/output for collection element mismatches. |
 | AM022 | Complex Mappings | [#53](https://github.com/georgepwall1991/automapper-analyser/pull/53) | [v2.14.0](https://github.com/georgepwall1991/automapper-analyser/releases/tag/v2.14.0) | Direction-aware reverse-map suppression, stricter ignore-all handling for recursion risks, and collection-aware recursion fixer behavior. |
+| AM030 | Complex Mappings | [#54](https://github.com/georgepwall1991/automapper-analyser/pull/54) | [v2.15.0](https://github.com/georgepwall1991/automapper-analyser/releases/tag/v2.15.0) | Exact `ForMember` property matching (including case-insensitive suppression), `Ignore`/`ConstructUsing` suppression support, stronger converter signature/null-check analysis, and safer code-fix routing for missing-converter diagnostics. |
 
 ## In Progress
 
 | Analyzer | Area | Branch | Goal |
 |---|---|---|---|
-| AM030 | Complex Mappings | `codex/am030-next-pass` | Next analyzer pass for false positives/fixer reliability improvements. |
+| AM031 | Performance | `codex/am031-next-pass` | Next analyzer pass for false positives/fixer reliability improvements. |

--- a/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningAnalyzer.cs
@@ -14,6 +14,18 @@ namespace AutoMapperAnalyzer.Analyzers.Performance;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
 {
+    private const string IssueTypePropertyName = "IssueType";
+    private const string PropertyNamePropertyName = "PropertyName";
+    private const string OperationTypePropertyName = "OperationType";
+    private const string CollectionNamePropertyName = "CollectionName";
+
+    private const string ExpensiveOperationIssueType = "ExpensiveOperation";
+    private const string MultipleEnumerationIssueType = "MultipleEnumeration";
+    private const string ExpensiveComputationIssueType = "ExpensiveComputation";
+    private const string TaskResultIssueType = "TaskResult";
+    private const string ComplexLinqIssueType = "ComplexLinq";
+    private const string NonDeterministicIssueType = "NonDeterministic";
+
     /// <summary>
     ///     Diagnostic rule for expensive operations in MapFrom expressions.
     /// </summary>
@@ -121,7 +133,7 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
         }
 
         // Find all ForMember calls in the method chain
-        List<InvocationExpressionSyntax> forMemberCalls = GetForMemberInvocations(invocationExpr);
+        List<InvocationExpressionSyntax> forMemberCalls = GetForMemberInvocations(invocationExpr, context.SemanticModel);
 
         foreach (InvocationExpressionSyntax? forMemberCall in forMemberCalls)
         {
@@ -130,7 +142,8 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
     }
 
     private static List<InvocationExpressionSyntax> GetForMemberInvocations(
-        InvocationExpressionSyntax createMapInvocation)
+        InvocationExpressionSyntax createMapInvocation,
+        SemanticModel semanticModel)
     {
         var forMemberCalls = new List<InvocationExpressionSyntax>();
 
@@ -147,7 +160,8 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
         foreach (InvocationExpressionSyntax? invocation in allInvocations)
         {
             if (invocation.Expression is MemberAccessExpressionSyntax memberAccess &&
-                memberAccess.Name.Identifier.Text == "ForMember")
+                memberAccess.Name.Identifier.Text == "ForMember" &&
+                IsAutoMapperMethodInvocation(invocation, semanticModel, "ForMember"))
             {
                 // Check if this ForMember is part of the CreateMap chain
                 if (IsPartOfCreateMapChain(invocation, createMapInvocation))
@@ -189,7 +203,7 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
         InvocationExpressionSyntax forMemberInvocation)
     {
         // Get the lambda expression from MapFrom
-        LambdaExpressionSyntax? mapFromLambda = GetMapFromLambda(forMemberInvocation);
+        LambdaExpressionSyntax? mapFromLambda = GetMapFromLambda(forMemberInvocation, context.SemanticModel);
         if (mapFromLambda == null)
         {
             return;
@@ -203,10 +217,12 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
         }
 
         // Analyze the lambda body for performance issues
-        AnalyzeLambdaExpression(context, mapFromLambda, propertyName, forMemberInvocation);
+        AnalyzeLambdaExpression(context, mapFromLambda, propertyName);
     }
 
-    private static LambdaExpressionSyntax? GetMapFromLambda(InvocationExpressionSyntax forMemberInvocation)
+    private static LambdaExpressionSyntax? GetMapFromLambda(
+        InvocationExpressionSyntax forMemberInvocation,
+        SemanticModel semanticModel)
     {
         // Look for the second argument which should contain the MapFrom call
         if (forMemberInvocation.ArgumentList.Arguments.Count < 2)
@@ -216,17 +232,18 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
 
         ArgumentSyntax optionsArg = forMemberInvocation.ArgumentList.Arguments[1];
 
-        // Navigate through the lambda to find MapFrom
-        if (optionsArg.Expression is not SimpleLambdaExpressionSyntax optionsLambda)
+        CSharpSyntaxNode? optionsBody = GetLambdaBody(optionsArg.Expression);
+        if (optionsBody == null)
         {
             return null;
         }
 
-        // Look for MapFrom invocation in the lambda body
-        InvocationExpressionSyntax? mapFromInvocation = optionsLambda.DescendantNodes()
+        // Look for MapFrom invocation in the options lambda body
+        InvocationExpressionSyntax? mapFromInvocation = optionsBody.DescendantNodesAndSelf()
             .OfType<InvocationExpressionSyntax>()
             .FirstOrDefault(inv => inv.Expression is MemberAccessExpressionSyntax mae &&
-                                   mae.Name.Identifier.Text == "MapFrom");
+                                   mae.Name.Identifier.Text == "MapFrom" &&
+                                   IsAutoMapperMethodInvocation(inv, semanticModel, "MapFrom"));
 
         if (mapFromInvocation == null)
         {
@@ -246,12 +263,13 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
         }
 
         ArgumentSyntax firstArg = forMemberInvocation.ArgumentList.Arguments[0];
-        if (firstArg.Expression is not SimpleLambdaExpressionSyntax destLambda)
+        CSharpSyntaxNode? destLambdaBody = GetLambdaBody(firstArg.Expression);
+        if (destLambdaBody == null)
         {
             return null;
         }
 
-        if (destLambda.Body is MemberAccessExpressionSyntax memberAccess)
+        if (destLambdaBody is MemberAccessExpressionSyntax memberAccess)
         {
             return memberAccess.Name.Identifier.Text;
         }
@@ -259,11 +277,20 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
         return null;
     }
 
+    private static CSharpSyntaxNode? GetLambdaBody(ExpressionSyntax lambdaExpression)
+    {
+        return lambdaExpression switch
+        {
+            SimpleLambdaExpressionSyntax simpleLambda => simpleLambda.Body,
+            ParenthesizedLambdaExpressionSyntax parenthesizedLambda => parenthesizedLambda.Body,
+            _ => null
+        };
+    }
+
     private static void AnalyzeLambdaExpression(
         SyntaxNodeAnalysisContext context,
         LambdaExpressionSyntax lambda,
-        string propertyName,
-        InvocationExpressionSyntax forMemberInvocation)
+        string propertyName)
     {
         // Check for method invocations
         var invocations = lambda.DescendantNodes().OfType<InvocationExpressionSyntax>().ToList();
@@ -273,6 +300,7 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
 
         // Track collection accesses for multiple enumeration detection
         var collectionAccesses = new Dictionary<string, int>();
+        var reportedIssueTypes = new HashSet<string>(StringComparer.Ordinal);
 
         foreach (InvocationExpressionSyntax? invocation in invocations)
         {
@@ -286,50 +314,78 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
             string methodName = methodSymbol.Name;
 
             // Check for database operations
-            if (IsDatabaseOperation(containingType, methodName))
+            if (IsDatabaseOperation(containingType))
             {
-                ReportDiagnostic(context, lambda, ExpensiveOperationInMapFromRule, propertyName, "database query");
+                if (reportedIssueTypes.Add(ExpensiveOperationIssueType))
+                {
+                    ReportExpensiveOperationDiagnostic(context, lambda, propertyName, "database query");
+                }
+
                 continue;
             }
 
             // Check for file I/O
             if (IsFileIOOperation(containingType, methodName))
             {
-                ReportDiagnostic(context, lambda, ExpensiveOperationInMapFromRule, propertyName, "file I/O operation");
+                if (reportedIssueTypes.Add(ExpensiveOperationIssueType))
+                {
+                    ReportExpensiveOperationDiagnostic(context, lambda, propertyName, "file I/O operation");
+                }
+
                 continue;
             }
 
             // Check for HTTP requests
-            if (IsHttpOperation(containingType, methodName))
+            if (IsHttpOperation(containingType))
             {
-                ReportDiagnostic(context, lambda, ExpensiveOperationInMapFromRule, propertyName, "HTTP request");
+                if (reportedIssueTypes.Add(ExpensiveOperationIssueType))
+                {
+                    ReportExpensiveOperationDiagnostic(context, lambda, propertyName, "HTTP request");
+                }
+
                 continue;
             }
 
             // Check for reflection
             if (IsReflectionOperation(methodName))
             {
-                ReportDiagnostic(context, lambda, ExpensiveOperationInMapFromRule, propertyName,
-                    "reflection operation");
+                if (reportedIssueTypes.Add(ExpensiveOperationIssueType))
+                {
+                    ReportExpensiveOperationDiagnostic(context, lambda, propertyName, "reflection operation");
+                }
+
                 continue;
             }
 
             // Check for Task.Result
             if (IsTaskResultAccess(invocation, context.SemanticModel))
             {
-                ReportDiagnostic(context, lambda, TaskResultSynchronousAccessRule, propertyName);
+                if (reportedIssueTypes.Add(TaskResultIssueType))
+                {
+                    ReportTaskResultDiagnostic(context, lambda, propertyName);
+                }
+
+                continue;
+            }
+
+            if (IsTaskWaitAccess(containingType, methodName))
+            {
+                if (reportedIssueTypes.Add(TaskResultIssueType))
+                {
+                    ReportTaskResultDiagnostic(context, lambda, propertyName);
+                }
+
                 continue;
             }
 
             // Check for non-deterministic operations
             if (IsNonDeterministicOperation(containingType, methodName, out string operationType))
             {
-                var diagnostic = Diagnostic.Create(
-                    NonDeterministicOperationRule,
-                    lambda.GetLocation(),
-                    propertyName,
-                    operationType);
-                context.ReportDiagnostic(diagnostic);
+                if (reportedIssueTypes.Add(NonDeterministicIssueType))
+                {
+                    ReportNonDeterministicDiagnostic(context, lambda, propertyName, operationType);
+                }
+
                 continue;
             }
 
@@ -342,14 +398,21 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
             // Check for complex LINQ operations
             if (IsComplexLinqOperation(methodName, invocation))
             {
-                ReportDiagnostic(context, lambda, ComplexLinqOperationRule, propertyName);
+                if (reportedIssueTypes.Add(ComplexLinqIssueType))
+                {
+                    ReportComplexLinqDiagnostic(context, lambda, propertyName);
+                }
+
                 continue;
             }
 
             // Check for external method calls (not on source properties)
             if (IsExternalMethodCall(invocation, context.SemanticModel))
             {
-                ReportDiagnostic(context, lambda, ExpensiveOperationInMapFromRule, propertyName, "method call");
+                if (reportedIssueTypes.Add(ExpensiveOperationIssueType))
+                {
+                    ReportExpensiveOperationDiagnostic(context, lambda, propertyName, "method call");
+                }
             }
         }
 
@@ -366,12 +429,10 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
                 if (containingType == "System.DateTime" &&
                     (propertyName_member == "Now" || propertyName_member == "UtcNow"))
                 {
-                    var diagnostic = Diagnostic.Create(
-                        NonDeterministicOperationRule,
-                        lambda.GetLocation(),
-                        propertyName,
-                        "DateTime.Now");
-                    context.ReportDiagnostic(diagnostic);
+                    if (reportedIssueTypes.Add(NonDeterministicIssueType))
+                    {
+                        ReportNonDeterministicDiagnostic(context, lambda, propertyName, "DateTime.Now");
+                    }
                 }
             }
         }
@@ -379,45 +440,162 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
         // Check for multiple enumerations
         foreach (KeyValuePair<string, int> kvp in collectionAccesses)
         {
-            if (kvp.Value > 1)
+            if (kvp.Value > 1 && reportedIssueTypes.Add(MultipleEnumerationIssueType))
             {
-                var diagnostic = Diagnostic.Create(
-                    MultipleEnumerationRule,
-                    lambda.GetLocation(),
-                    propertyName,
-                    kvp.Key);
-                context.ReportDiagnostic(diagnostic);
+                ReportMultipleEnumerationDiagnostic(context, lambda, propertyName, kvp.Key);
             }
         }
 
         // Check for expensive computations (complex expressions with multiple operations)
-        if (IsExpensiveComputation(lambda))
+        if (IsExpensiveComputation(lambda) && reportedIssueTypes.Add(ExpensiveComputationIssueType))
         {
-            ReportDiagnostic(context, lambda, ExpensiveComputationRule, propertyName);
+            ReportExpensiveComputationDiagnostic(context, lambda, propertyName);
         }
+    }
+
+    private static void ReportExpensiveOperationDiagnostic(
+        SyntaxNodeAnalysisContext context,
+        LambdaExpressionSyntax lambda,
+        string propertyName,
+        string operationType)
+    {
+        ReportDiagnostic(
+            context,
+            lambda.GetLocation(),
+            ExpensiveOperationInMapFromRule,
+            ExpensiveOperationIssueType,
+            propertyName,
+            messageArgs: [propertyName, operationType],
+            operationType: operationType);
+    }
+
+    private static void ReportMultipleEnumerationDiagnostic(
+        SyntaxNodeAnalysisContext context,
+        LambdaExpressionSyntax lambda,
+        string propertyName,
+        string collectionName)
+    {
+        ReportDiagnostic(
+            context,
+            lambda.GetLocation(),
+            MultipleEnumerationRule,
+            MultipleEnumerationIssueType,
+            propertyName,
+            messageArgs: [propertyName, collectionName],
+            collectionName: collectionName);
+    }
+
+    private static void ReportExpensiveComputationDiagnostic(
+        SyntaxNodeAnalysisContext context,
+        LambdaExpressionSyntax lambda,
+        string propertyName)
+    {
+        ReportDiagnostic(
+            context,
+            lambda.GetLocation(),
+            ExpensiveComputationRule,
+            ExpensiveComputationIssueType,
+            propertyName,
+            messageArgs: [propertyName]);
+    }
+
+    private static void ReportTaskResultDiagnostic(
+        SyntaxNodeAnalysisContext context,
+        LambdaExpressionSyntax lambda,
+        string propertyName)
+    {
+        ReportDiagnostic(
+            context,
+            lambda.GetLocation(),
+            TaskResultSynchronousAccessRule,
+            TaskResultIssueType,
+            propertyName,
+            messageArgs: [propertyName]);
+    }
+
+    private static void ReportComplexLinqDiagnostic(
+        SyntaxNodeAnalysisContext context,
+        LambdaExpressionSyntax lambda,
+        string propertyName)
+    {
+        ReportDiagnostic(
+            context,
+            lambda.GetLocation(),
+            ComplexLinqOperationRule,
+            ComplexLinqIssueType,
+            propertyName,
+            messageArgs: [propertyName]);
+    }
+
+    private static void ReportNonDeterministicDiagnostic(
+        SyntaxNodeAnalysisContext context,
+        LambdaExpressionSyntax lambda,
+        string propertyName,
+        string operationType)
+    {
+        ReportDiagnostic(
+            context,
+            lambda.GetLocation(),
+            NonDeterministicOperationRule,
+            NonDeterministicIssueType,
+            propertyName,
+            messageArgs: [propertyName, operationType],
+            operationType: operationType);
     }
 
     private static void ReportDiagnostic(
         SyntaxNodeAnalysisContext context,
-        LambdaExpressionSyntax lambda,
+        Location location,
         DiagnosticDescriptor rule,
-        params string[] messageArgs)
+        string issueType,
+        string propertyName,
+        string[] messageArgs,
+        string? operationType = null,
+        string? collectionName = null)
     {
-        var diagnostic = Diagnostic.Create(rule, lambda.GetLocation(), messageArgs);
+        ImmutableDictionary<string, string?> properties =
+            CreateDiagnosticProperties(issueType, propertyName, operationType, collectionName);
+        var diagnostic = Diagnostic.Create(rule, location, properties, messageArgs);
         context.ReportDiagnostic(diagnostic);
     }
 
-    private static bool IsDatabaseOperation(string containingType, string methodName)
+    private static ImmutableDictionary<string, string?> CreateDiagnosticProperties(
+        string issueType,
+        string propertyName,
+        string? operationType,
+        string? collectionName)
     {
-        // Check for Entity Framework, NHibernate, Dapper, etc.
-        return containingType.Contains("DbSet") ||
-               containingType.Contains("DbContext") ||
-               containingType.Contains("IQueryable") ||
-               containingType.Contains("ISession") ||
-               containingType.Contains("SqlConnection") ||
-               methodName.Contains("Query") ||
-               methodName.Contains("Execute") ||
-               methodName.Contains("Load");
+        ImmutableDictionary<string, string?>.Builder properties =
+            ImmutableDictionary.CreateBuilder<string, string?>();
+        properties.Add(IssueTypePropertyName, issueType);
+        properties.Add(PropertyNamePropertyName, propertyName);
+
+        if (!string.IsNullOrEmpty(operationType))
+        {
+            properties.Add(OperationTypePropertyName, operationType);
+        }
+
+        if (!string.IsNullOrEmpty(collectionName))
+        {
+            properties.Add(CollectionNamePropertyName, collectionName);
+        }
+
+        return properties.ToImmutable();
+    }
+
+    private static bool IsDatabaseOperation(string containingType)
+    {
+        // Restrict to known data-access namespaces/types to avoid method-name false positives.
+        return containingType.Contains("DbSet", StringComparison.Ordinal) ||
+               containingType.Contains("DbContext", StringComparison.Ordinal) ||
+               containingType.Contains("IQueryable", StringComparison.Ordinal) ||
+               containingType == "System.Linq.Queryable" ||
+               containingType.Contains("EntityFrameworkQueryableExtensions", StringComparison.Ordinal) ||
+               containingType.Contains("ISession", StringComparison.Ordinal) ||
+               containingType.Contains("SqlConnection", StringComparison.Ordinal) ||
+               containingType.Contains("System.Data", StringComparison.Ordinal) ||
+               containingType.Contains("Dapper", StringComparison.Ordinal) ||
+               containingType.Contains("NHibernate", StringComparison.Ordinal);
     }
 
     private static bool IsFileIOOperation(string containingType, string methodName)
@@ -429,13 +607,11 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
                (methodName.Contains("Write") && containingType.Contains("System.IO"));
     }
 
-    private static bool IsHttpOperation(string containingType, string methodName)
+    private static bool IsHttpOperation(string containingType)
     {
         return containingType.Contains("HttpClient") ||
                containingType.Contains("WebClient") ||
-               methodName.Contains("GetAsync") ||
-               methodName.Contains("PostAsync") ||
-               methodName.Contains("GetString");
+               containingType.Contains("HttpMessageInvoker");
     }
 
     private static bool IsReflectionOperation(string methodName)
@@ -450,18 +626,26 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
 
     private static bool IsTaskResultAccess(InvocationExpressionSyntax invocation, SemanticModel semanticModel)
     {
-        // Check if accessing .Result property on a Task
-        if (invocation.Expression is MemberAccessExpressionSyntax memberAccess)
+        // Check if this invocation is used with .Result (e.g., SomeTask().Result)
+        if (invocation.Parent is MemberAccessExpressionSyntax memberAccess &&
+            memberAccess.Name.Identifier.Text == "Result")
         {
-            if (memberAccess.Name.Identifier.Text == "Result")
+            SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(memberAccess);
+            if (symbolInfo.Symbol is IPropertySymbol propertySymbol &&
+                propertySymbol.Name == "Result")
             {
-                TypeInfo typeInfo = semanticModel.GetTypeInfo(memberAccess.Expression);
-                string typeName = typeInfo.Type?.ToDisplayString() ?? "";
-                return typeName.Contains("System.Threading.Tasks.Task");
+                string containingType = propertySymbol.ContainingType?.ToDisplayString() ?? "";
+                return containingType.StartsWith("System.Threading.Tasks.Task", StringComparison.Ordinal);
             }
         }
 
         return false;
+    }
+
+    private static bool IsTaskWaitAccess(string containingType, string methodName)
+    {
+        return methodName == "Wait" &&
+               containingType.StartsWith("System.Threading.Tasks.Task", StringComparison.Ordinal);
     }
 
     private static bool IsNonDeterministicOperation(string containingType, string methodName, out string operationType)
@@ -474,7 +658,8 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
             return true;
         }
 
-        if (containingType == "System.Random" || methodName.Contains("Random"))
+        if (containingType == "System.Random" &&
+            methodName is "Next" or "NextDouble" or "NextInt64" or "NextSingle" or "NextBytes")
         {
             operationType = "Random";
             return true;
@@ -604,5 +789,43 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
+    }
+
+    private static bool IsAutoMapperMethodInvocation(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        string methodName)
+    {
+        IMethodSymbol? methodSymbol = GetMethodSymbol(invocation, semanticModel);
+        if (methodSymbol == null || methodSymbol.Name != methodName)
+        {
+            return false;
+        }
+
+        string? namespaceName = methodSymbol.ContainingNamespace?.ToDisplayString();
+        return namespaceName == "AutoMapper" ||
+               (namespaceName?.StartsWith("AutoMapper.", StringComparison.Ordinal) ?? false);
+    }
+
+    private static IMethodSymbol? GetMethodSymbol(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel)
+    {
+        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(invocation);
+
+        if (symbolInfo.Symbol is IMethodSymbol methodSymbol)
+        {
+            return methodSymbol;
+        }
+
+        foreach (ISymbol candidateSymbol in symbolInfo.CandidateSymbols)
+        {
+            if (candidateSymbol is IMethodSymbol candidateMethod)
+            {
+                return candidateMethod;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningCodeFixProvider.cs
@@ -1,7 +1,6 @@
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
-using System.Text.RegularExpressions;
 using AutoMapperAnalyzer.Analyzers.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
@@ -20,6 +19,17 @@ namespace AutoMapperAnalyzer.Analyzers.Performance;
 [Shared]
 public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProviderBase
 {
+    private const string IssueTypePropertyName = "IssueType";
+    private const string PropertyNamePropertyName = "PropertyName";
+    private const string OperationTypePropertyName = "OperationType";
+
+    private const string ExpensiveOperationIssueType = "ExpensiveOperation";
+    private const string MultipleEnumerationIssueType = "MultipleEnumeration";
+    private const string ExpensiveComputationIssueType = "ExpensiveComputation";
+    private const string TaskResultIssueType = "TaskResult";
+    private const string ComplexLinqIssueType = "ComplexLinq";
+    private const string NonDeterministicIssueType = "NonDeterministic";
+
     /// <summary>
     ///     Gets the diagnostic IDs that this provider can fix.
     /// </summary>
@@ -36,10 +46,19 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
             return;
         }
 
-        Diagnostic diagnostic = context.Diagnostics.First();
+        SyntaxTree documentTree = operationContext.Root.SyntaxTree;
+        Diagnostic? diagnostic = context.Diagnostics.FirstOrDefault(diag =>
+            diag.Location.IsInSource &&
+            diag.Location.SourceTree == documentTree &&
+            diag.Location.SourceSpan.IntersectsWith(context.Span));
+
+        if (diagnostic == null)
+        {
+            return;
+        }
+
         TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
 
-        // Find the lambda expression that triggered the diagnostic
         LambdaExpressionSyntax? lambda = operationContext.Root.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf()
             .OfType<LambdaExpressionSyntax>()
             .FirstOrDefault();
@@ -49,7 +68,6 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
             return;
         }
 
-        // Find the ForMember invocation
         InvocationExpressionSyntax? forMemberInvocation = lambda.AncestorsAndSelf()
             .OfType<InvocationExpressionSyntax>()
             .FirstOrDefault(inv => inv.Expression is MemberAccessExpressionSyntax mae &&
@@ -60,34 +78,33 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
             return;
         }
 
-        // Extract property name from diagnostic message
-        string? propertyName = ExtractPropertyNameFromDiagnostic(diagnostic);
+        string? propertyName = GetPropertyName(diagnostic);
         if (string.IsNullOrEmpty(propertyName))
         {
             return;
         }
 
-        // After null check, we know propertyName is not null
         string safePropertyName = propertyName!;
+        string issueType = diagnostic.Properties.TryGetValue(IssueTypePropertyName, out string? storedIssueType)
+            ? storedIssueType ?? string.Empty
+            : string.Empty;
 
-        // Register fixes based on diagnostic descriptor
-        DiagnosticDescriptor descriptor = diagnostic.Descriptor;
-
-        if (descriptor == AM031_PerformanceWarningAnalyzer.ExpensiveOperationInMapFromRule)
+        switch (issueType)
         {
-            RegisterExpensiveOperationFix(context, forMemberInvocation, safePropertyName, diagnostic);
-        }
-        else if (descriptor == AM031_PerformanceWarningAnalyzer.MultipleEnumerationRule)
-        {
-            RegisterMultipleEnumerationFix(context, operationContext.Root, forMemberInvocation, lambda, diagnostic);
-        }
-        else if (descriptor == AM031_PerformanceWarningAnalyzer.TaskResultSynchronousAccessRule)
-        {
-            RegisterTaskResultFix(context, forMemberInvocation, safePropertyName, diagnostic);
-        }
-        else if (descriptor == AM031_PerformanceWarningAnalyzer.NonDeterministicOperationRule)
-        {
-            RegisterNonDeterministicOperationFix(context, forMemberInvocation, safePropertyName, diagnostic);
+            case ExpensiveOperationIssueType:
+            case ExpensiveComputationIssueType:
+            case ComplexLinqIssueType:
+                RegisterExpensiveOperationFix(context, forMemberInvocation, safePropertyName, diagnostic);
+                break;
+            case MultipleEnumerationIssueType:
+                RegisterMultipleEnumerationFix(context, operationContext.Root, lambda, diagnostic);
+                break;
+            case TaskResultIssueType:
+                RegisterTaskResultFix(context, forMemberInvocation, safePropertyName, diagnostic);
+                break;
+            case NonDeterministicIssueType:
+                RegisterNonDeterministicOperationFix(context, forMemberInvocation, safePropertyName, diagnostic);
+                break;
         }
     }
 
@@ -114,7 +131,6 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
     private void RegisterMultipleEnumerationFix(
         CodeFixContext context,
         SyntaxNode root,
-        InvocationExpressionSyntax forMemberInvocation,
         LambdaExpressionSyntax lambda,
         Diagnostic diagnostic)
     {
@@ -122,7 +138,7 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
             CodeAction.Create(
                 "Cache collection with ToList() to avoid multiple enumerations",
                 cancellationToken =>
-                    AddCollectionCaching(context.Document, root, lambda, forMemberInvocation, cancellationToken),
+                    AddCollectionCaching(context.Document, root, lambda, cancellationToken),
                 "AM031_CacheCollection"),
             diagnostic);
     }
@@ -205,67 +221,83 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
         var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
         if (semanticModel == null) return document.Project.Solution;
 
-        // Find the Source class via Symbol
+        // Find the Source/Destination types via CreateMap<TSource, TDestination>
         SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(createMapInvocation);
-        if (symbolInfo.Symbol is not IMethodSymbol methodSymbol || methodSymbol.TypeArguments.Length < 1)
+        if (symbolInfo.Symbol is not IMethodSymbol methodSymbol || methodSymbol.TypeArguments.Length < 2)
         {
             return document.Project.Solution;
         }
+
         ITypeSymbol sourceType = methodSymbol.TypeArguments[0];
-        
+        ITypeSymbol destinationType = methodSymbol.TypeArguments[1];
+
         // Get Syntax Reference for Source Class
         var syntaxRef = sourceType.DeclaringSyntaxReferences.FirstOrDefault();
         if (syntaxRef == null) return document.Project.Solution;
-        
-        // Determine if Source Class is in the same document
-        bool sameDocument = syntaxRef.SyntaxTree == root.SyntaxTree;
-        
-        // Prepare changes for Profile (removing ForMember)
-        InvocationExpressionSyntax newCreateMapInvocation = RemoveForMemberFromChain(createMapInvocation, forMemberInvocation);
-        
+
+        string propertyTypeName = GetDestinationPropertyTypeName(destinationType, propertyName);
+
+        Document? sourceDocument = document.Project.Solution.GetDocument(syntaxRef.SyntaxTree);
+        if (sourceDocument == null)
+        {
+            return document.Project.Solution;
+        }
+
+        // Determine if Source Class is in the same document as the diagnostic.
+        bool sameDocument = sourceDocument.Id == document.Id;
+
+        InvocationExpressionSyntax? updatedMappingInvocation = GetInvocationWithoutForMember(forMemberInvocation);
+        if (updatedMappingInvocation == null)
+        {
+            return document.Project.Solution;
+        }
+
         if (sameDocument)
         {
             var sourceClass = root.FindNode(syntaxRef.Span) as ClassDeclarationSyntax;
             if (sourceClass == null) return document.Project.Solution;
-            
-            PropertyDeclarationSyntax newProperty = CreatePropertyWithComment(propertyName, todoComment);
-            ClassDeclarationSyntax newSourceClass = sourceClass.AddMembers(newProperty);
-            
+
+            ClassDeclarationSyntax newSourceClass = AddPropertyIfMissing(
+                sourceClass,
+                propertyName,
+                propertyTypeName,
+                todoComment);
+
             SyntaxNode newRoot = root.ReplaceNodes(
-                new SyntaxNode[] { sourceClass, createMapInvocation },
+                new SyntaxNode[] { sourceClass, forMemberInvocation },
                 (original, _) =>
                 {
                     if (original == sourceClass) return newSourceClass;
-                    if (original == createMapInvocation) return newCreateMapInvocation;
+                    if (original == forMemberInvocation) return updatedMappingInvocation;
                     return original;
                 });
-                
+
             return document.Project.Solution.WithDocumentSyntaxRoot(document.Id, newRoot);
         }
         else
         {
             // Multi-document change
-            
+
             // 1. Update Source Document
             var sourceRoot = await syntaxRef.SyntaxTree.GetRootAsync(cancellationToken);
             var sourceClass = sourceRoot.FindNode(syntaxRef.Span) as ClassDeclarationSyntax;
             if (sourceClass == null) return document.Project.Solution; // Should check if editable
-            
-            PropertyDeclarationSyntax newProperty = CreatePropertyWithComment(propertyName, todoComment);
-            ClassDeclarationSyntax newSourceClass = sourceClass.AddMembers(newProperty);
+
+            ClassDeclarationSyntax newSourceClass = AddPropertyIfMissing(
+                sourceClass,
+                propertyName,
+                propertyTypeName,
+                todoComment);
             SyntaxNode newSourceRoot = sourceRoot.ReplaceNode(sourceClass, newSourceClass);
-            
-            var sourceDocument = document.Project.Solution.GetDocument(sourceRoot.SyntaxTree);
-            if (sourceDocument == null) return document.Project.Solution;
-            
+
             // 2. Update Profile Document
-            SyntaxNode newProfileRoot = root.ReplaceNode(createMapInvocation, newCreateMapInvocation);
-            
+            SyntaxNode newProfileRoot = root.ReplaceNode(forMemberInvocation, updatedMappingInvocation);
+
             // Apply changes
             var solution = document.Project.Solution;
             solution = solution.WithDocumentSyntaxRoot(sourceDocument.Id, newSourceRoot);
             solution = solution.WithDocumentSyntaxRoot(document.Id, newProfileRoot);
-            
+
             return solution;
         }
     }
@@ -274,7 +306,6 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
         Document document,
         SyntaxNode root,
         LambdaExpressionSyntax lambda,
-        InvocationExpressionSyntax forMemberInvocation,
         CancellationToken cancellationToken)
     {
         // Find the collection name that's being enumerated multiple times
@@ -326,10 +357,29 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
         return Task.FromResult(document.WithSyntaxRoot(newRoot));
     }
 
-    private PropertyDeclarationSyntax CreatePropertyWithComment(string propertyName, string comment)
+    private static ClassDeclarationSyntax AddPropertyIfMissing(
+        ClassDeclarationSyntax sourceClass,
+        string propertyName,
+        string propertyTypeName,
+        string comment)
+    {
+        bool hasProperty = sourceClass.Members
+            .OfType<PropertyDeclarationSyntax>()
+            .Any(property => string.Equals(property.Identifier.ValueText, propertyName, StringComparison.OrdinalIgnoreCase));
+
+        if (hasProperty)
+        {
+            return sourceClass;
+        }
+
+        PropertyDeclarationSyntax newProperty = CreatePropertyWithComment(propertyTypeName, propertyName, comment);
+        return sourceClass.AddMembers(newProperty);
+    }
+
+    private static PropertyDeclarationSyntax CreatePropertyWithComment(string propertyTypeName, string propertyName, string comment)
     {
         return SyntaxFactory.PropertyDeclaration(
-                SyntaxFactory.IdentifierName("string"),
+                SyntaxFactory.ParseTypeName(propertyTypeName),
                 SyntaxFactory.Identifier(propertyName))
             .WithModifiers(
                 SyntaxFactory.TokenList(
@@ -347,44 +397,14 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
                 SyntaxFactory.Comment($" // {comment}"));
     }
 
-    private InvocationExpressionSyntax RemoveForMemberFromChain(
-        InvocationExpressionSyntax createMapInvocation,
-        InvocationExpressionSyntax forMemberToRemove)
+    private static InvocationExpressionSyntax? GetInvocationWithoutForMember(InvocationExpressionSyntax forMemberToRemove)
     {
-        // If the ForMember is directly on CreateMap, just return CreateMap
-        if (createMapInvocation ==
-            forMemberToRemove.DescendantNodes().OfType<InvocationExpressionSyntax>().FirstOrDefault())
-        {
-            return createMapInvocation;
-        }
-
-        // Navigate through the chain and find the node to remove
-        InvocationExpressionSyntax? current = createMapInvocation;
-        InvocationExpressionSyntax? previous = null;
-
-        while (current != null)
-        {
-            if (current == forMemberToRemove)
+        return forMemberToRemove.Expression is MemberAccessExpressionSyntax
             {
-                // Found it - return the previous node (or CreateMap if this is the first ForMember)
-                return previous ?? createMapInvocation;
+                Expression: InvocationExpressionSyntax previousInvocation
             }
-
-            // Move to the next node in the chain
-            previous = current;
-            if (current.Expression is MemberAccessExpressionSyntax memberAccess &&
-                memberAccess.Expression is InvocationExpressionSyntax nextInvocation)
-            {
-                current = nextInvocation;
-            }
-            else
-            {
-                break;
-            }
-        }
-
-        // If we didn't find it, just return CreateMap
-        return createMapInvocation;
+            ? previousInvocation
+            : null;
     }
 
     private string? ExtractCollectionNameFromLambda(LambdaExpressionSyntax lambda)
@@ -419,16 +439,39 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
         return SyntaxFactory.ParseExpression(expressionString);
     }
 
-    private string? ExtractPropertyNameFromDiagnostic(Diagnostic diagnostic)
+    private string GetDestinationPropertyTypeName(ITypeSymbol destinationType, string propertyName)
     {
-        // Extract from diagnostic message
-        string message = diagnostic.GetMessage();
-        Match match = Regex.Match(message, @"Property '(\w+)'");
-        return match.Success ? match.Groups[1].Value : null;
+        IPropertySymbol? destinationProperty = AutoMapperAnalysisHelpers
+            .GetMappableProperties(destinationType, false)
+            .FirstOrDefault(property => string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase));
+
+        if (destinationProperty == null)
+        {
+            return "string";
+        }
+
+        return destinationProperty.Type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+    }
+
+    private string? GetPropertyName(Diagnostic diagnostic)
+    {
+        if (diagnostic.Properties.TryGetValue(PropertyNamePropertyName, out string? propertyName) &&
+            !string.IsNullOrEmpty(propertyName))
+        {
+            return propertyName;
+        }
+
+        return null;
     }
 
     private string ExtractOperationTypeFromDiagnostic(Diagnostic diagnostic)
     {
+        if (diagnostic.Properties.TryGetValue(OperationTypePropertyName, out string? operationType) &&
+            !string.IsNullOrEmpty(operationType))
+        {
+            return operationType!;
+        }
+
         string message = diagnostic.GetMessage();
         if (message.Contains("DateTime.Now"))
         {

--- a/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningCodeFixProvider.cs
@@ -88,6 +88,10 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
         string issueType = diagnostic.Properties.TryGetValue(IssueTypePropertyName, out string? storedIssueType)
             ? storedIssueType ?? string.Empty
             : string.Empty;
+        if (string.IsNullOrEmpty(issueType))
+        {
+            issueType = InferIssueTypeFromDescriptor(diagnostic.Descriptor);
+        }
 
         switch (issueType)
         {
@@ -489,5 +493,40 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
         }
 
         return "non-deterministic operation";
+    }
+
+    private static string InferIssueTypeFromDescriptor(DiagnosticDescriptor descriptor)
+    {
+        if (descriptor == AM031_PerformanceWarningAnalyzer.MultipleEnumerationRule)
+        {
+            return MultipleEnumerationIssueType;
+        }
+
+        if (descriptor == AM031_PerformanceWarningAnalyzer.TaskResultSynchronousAccessRule)
+        {
+            return TaskResultIssueType;
+        }
+
+        if (descriptor == AM031_PerformanceWarningAnalyzer.NonDeterministicOperationRule)
+        {
+            return NonDeterministicIssueType;
+        }
+
+        if (descriptor == AM031_PerformanceWarningAnalyzer.ExpensiveComputationRule)
+        {
+            return ExpensiveComputationIssueType;
+        }
+
+        if (descriptor == AM031_PerformanceWarningAnalyzer.ComplexLinqOperationRule)
+        {
+            return ComplexLinqIssueType;
+        }
+
+        if (descriptor == AM031_PerformanceWarningAnalyzer.ExpensiveOperationInMapFromRule)
+        {
+            return ExpensiveOperationIssueType;
+        }
+
+        return string.Empty;
     }
 }


### PR DESCRIPTION
## Summary
- tighten AM031 performance analyzer detection to reduce false positives:
  - require AutoMapper symbols for `ForMember`/`MapFrom`
  - support parenthesized lambdas in `ForMember`/`MapFrom`
  - replace broad DB and Random method-name heuristics with type/operation checks
  - deduplicate per-issue diagnostics in a single mapping lambda to avoid contradictory duplicates
- enrich AM031 diagnostics with issue metadata (`IssueType`, `PropertyName`, `OperationType`, `CollectionName`)
- update AM031 codefix routing to use diagnostic metadata and safer local-diagnostic binding
- harden source-property insertion in fixer:
  - infer destination property type when adding source property
  - avoid duplicate property insertion (case-insensitive)
  - remove only targeted `ForMember` invocation in chain rewrites
- add AM031 regression tests for:
  - non-AutoMapper lookalike API false-positive guard
  - parenthesized lambda support
  - direct `Task.Result` detection on async method result
  - deterministic method containing `Random` in name

## Validation
- `dotnet test --nologo -v q --filter "FullyQualifiedName~AM031_"`
- `dotnet test --nologo -v q`
