### PR TITLE
AM001: reduce false positives and harden code fixes

### DIFF
--- a/docs/ANALYZER_REVIEW_TRACKER.md
+++ b/docs/ANALYZER_REVIEW_TRACKER.md
@@ -16,9 +16,10 @@ Tracks analyzer-by-analyzer improvement passes focused on false positives, contr
 | AM021 | Complex Mappings | [#52](https://github.com/georgepwall1991/automapper-analyser/pull/52) | [v2.13.0](https://github.com/georgepwall1991/automapper-analyser/releases/tag/v2.13.0) | Direction-aware reverse-map handling, better custom-conversion suppression, and safer fixer type inference/output for collection element mismatches. |
 | AM022 | Complex Mappings | [#53](https://github.com/georgepwall1991/automapper-analyser/pull/53) | [v2.14.0](https://github.com/georgepwall1991/automapper-analyser/releases/tag/v2.14.0) | Direction-aware reverse-map suppression, stricter ignore-all handling for recursion risks, and collection-aware recursion fixer behavior. |
 | AM030 | Complex Mappings | [#54](https://github.com/georgepwall1991/automapper-analyser/pull/54) | [v2.15.0](https://github.com/georgepwall1991/automapper-analyser/releases/tag/v2.15.0) | Exact `ForMember` property matching (including case-insensitive suppression), `Ignore`/`ConstructUsing` suppression support, stronger converter signature/null-check analysis, and safer code-fix routing for missing-converter diagnostics. |
+| AM031 | Performance | [#55](https://github.com/georgepwall1991/automapper-analyser/pull/55) | [v2.16.0](https://github.com/georgepwall1991/automapper-analyser/releases/tag/v2.16.0) | Stricter AutoMapper semantic checks, reduced heuristic false positives (`Random`/reflection/database), richer diagnostic metadata for fixer routing, and broader performance regression coverage (`Task.Wait`, parenthesized lambdas, `DateTime.UtcNow`). |
 
 ## In Progress
 
 | Analyzer | Area | Branch | Goal |
 |---|---|---|---|
-| AM031 | Performance | `codex/am031-next-pass` | Next analyzer pass for false positives/fixer reliability improvements. |
+| AM001 | Type Safety | `codex/am001-next-pass` | Next analyzer pass for false positives/fixer reliability improvements. |

--- a/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM001_PropertyTypeMismatchAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM001_PropertyTypeMismatchAnalyzer.cs
@@ -13,6 +13,10 @@ namespace AutoMapperAnalyzer.Analyzers.TypeSafety;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class AM001_PropertyTypeMismatchAnalyzer : DiagnosticAnalyzer
 {
+    private const string PropertyNamePropertyName = "PropertyName";
+    private const string SourcePropertyTypePropertyName = "SourcePropertyType";
+    private const string DestinationPropertyTypePropertyName = "DestinationPropertyType";
+
     /// <summary>
     ///     Diagnostic rule for property type mismatches.
     /// </summary>
@@ -51,6 +55,12 @@ public class AM001_PropertyTypeMismatchAnalyzer : DiagnosticAnalyzer
 
         // Check if this is a CreateMap<TSource, TDestination>() call
         if (!AutoMapperAnalysisHelpers.IsCreateMapInvocation(invocationExpr, context.SemanticModel))
+        {
+            return;
+        }
+
+        // Ensure this invocation resolves to AutoMapper APIs to avoid lookalike false positives.
+        if (!IsAutoMapperCreateMapInvocation(invocationExpr, context.SemanticModel))
         {
             return;
         }
@@ -94,8 +104,7 @@ public class AM001_PropertyTypeMismatchAnalyzer : DiagnosticAnalyzer
             }
 
             // Check if explicit mapping is configured for this property
-            if (AutoMapperAnalysisHelpers.IsPropertyConfiguredWithForMember(invocation, sourceProp.Name,
-                    context.SemanticModel))
+            if (IsPropertyConfiguredWithForMember(invocation, sourceProp.Name, context.SemanticModel))
             {
                 continue;
             }
@@ -149,9 +158,15 @@ public class AM001_PropertyTypeMismatchAnalyzer : DiagnosticAnalyzer
         // Check for basic type incompatibilities
         if (!AreTypesCompatible(sourceProperty.Type, destinationProperty.Type))
         {
+            var properties = ImmutableDictionary.CreateBuilder<string, string?>();
+            properties.Add(PropertyNamePropertyName, sourceProperty.Name);
+            properties.Add(SourcePropertyTypePropertyName, sourceTypeName);
+            properties.Add(DestinationPropertyTypePropertyName, destTypeName);
+
             var diagnostic = Diagnostic.Create(
                 PropertyTypeMismatchRule,
                 invocation.GetLocation(),
+                properties.ToImmutable(),
                 sourceProperty.Name,
                 GetTypeName(sourceType),
                 sourceTypeName,
@@ -164,9 +179,16 @@ public class AM001_PropertyTypeMismatchAnalyzer : DiagnosticAnalyzer
 
     private static bool IsNullableCompatibilityIssue(ITypeSymbol sourceType, ITypeSymbol destinationType)
     {
-        // Check if source is nullable reference type and destination is non-nullable
-        return sourceType is { CanBeReferencedByName: true, NullableAnnotation: NullableAnnotation.Annotated } &&
-               destinationType.NullableAnnotation == NullableAnnotation.NotAnnotated;
+        if (!IsNullableType(sourceType) || IsNullableType(destinationType))
+        {
+            return false;
+        }
+
+        // Only suppress AM001 when the underlying types are otherwise compatible.
+        // This leaves purely nullability concerns to AM002 but still reports true type mismatches.
+        ITypeSymbol sourceUnderlyingType = AutoMapperAnalysisHelpers.GetUnderlyingType(sourceType);
+        ITypeSymbol destinationUnderlyingType = AutoMapperAnalysisHelpers.GetUnderlyingType(destinationType);
+        return AutoMapperAnalysisHelpers.AreTypesCompatible(sourceUnderlyingType, destinationUnderlyingType);
     }
 
     private static bool IsGenericTypeMismatch(ITypeSymbol sourceType, ITypeSymbol destinationType)
@@ -191,6 +213,17 @@ public class AM001_PropertyTypeMismatchAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
+    }
+
+    private static bool IsNullableType(ITypeSymbol type)
+    {
+        if (type.NullableAnnotation == NullableAnnotation.Annotated)
+        {
+            return true;
+        }
+
+        return type is INamedTypeSymbol namedType &&
+               namedType.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T;
     }
 
     private static bool IsComplexTypeMappingRequired(ITypeSymbol sourceType, ITypeSymbol destinationType)
@@ -252,5 +285,95 @@ public class AM001_PropertyTypeMismatchAnalyzer : DiagnosticAnalyzer
         }
 
         return type.Name;
+    }
+
+    private static bool IsPropertyConfiguredWithForMember(
+        InvocationExpressionSyntax createMapInvocation,
+        string propertyName,
+        SemanticModel semanticModel)
+    {
+        IEnumerable<InvocationExpressionSyntax> forMemberCalls = AutoMapperAnalysisHelpers.GetForMemberCalls(createMapInvocation);
+
+        foreach (InvocationExpressionSyntax forMemberCall in forMemberCalls)
+        {
+            if (!IsAutoMapperMethodInvocation(forMemberCall, semanticModel, "ForMember"))
+            {
+                continue;
+            }
+
+            if (forMemberCall.ArgumentList.Arguments.Count == 0)
+            {
+                continue;
+            }
+
+            ArgumentSyntax destinationArgument = forMemberCall.ArgumentList.Arguments[0];
+            CSharpSyntaxNode? lambdaBody = GetLambdaBody(destinationArgument.Expression);
+            if (lambdaBody is not MemberAccessExpressionSyntax memberAccess)
+            {
+                continue;
+            }
+
+            if (string.Equals(memberAccess.Name.Identifier.Text, propertyName, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static CSharpSyntaxNode? GetLambdaBody(ExpressionSyntax expression)
+    {
+        return expression switch
+        {
+            SimpleLambdaExpressionSyntax simpleLambda => simpleLambda.Body,
+            ParenthesizedLambdaExpressionSyntax parenthesizedLambda => parenthesizedLambda.Body,
+            _ => null
+        };
+    }
+
+    private static bool IsAutoMapperCreateMapInvocation(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel)
+    {
+        return IsAutoMapperMethodInvocation(invocation, semanticModel, "CreateMap");
+    }
+
+    private static bool IsAutoMapperMethodInvocation(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        string methodName)
+    {
+        IMethodSymbol? methodSymbol = GetMethodSymbol(invocation, semanticModel);
+        if (methodSymbol == null || methodSymbol.Name != methodName)
+        {
+            return false;
+        }
+
+        string? namespaceName = methodSymbol.ContainingNamespace?.ToDisplayString();
+        return namespaceName == "AutoMapper" ||
+               (namespaceName?.StartsWith("AutoMapper.", StringComparison.Ordinal) ?? false);
+    }
+
+    private static IMethodSymbol? GetMethodSymbol(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel)
+    {
+        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(invocation);
+
+        if (symbolInfo.Symbol is IMethodSymbol methodSymbol)
+        {
+            return methodSymbol;
+        }
+
+        foreach (ISymbol candidateSymbol in symbolInfo.CandidateSymbols)
+        {
+            if (candidateSymbol is IMethodSymbol candidateMethod)
+            {
+                return candidateMethod;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM001_PropertyTypeMismatchCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM001_PropertyTypeMismatchCodeFixProvider.cs
@@ -17,10 +17,6 @@ namespace AutoMapperAnalyzer.Analyzers.TypeSafety;
 [Shared]
 public class AM001_PropertyTypeMismatchCodeFixProvider : AutoMapperCodeFixProviderBase
 {
-    private const string PropertyNamePropertyName = "PropertyName";
-    private const string SourcePropertyTypePropertyName = "SourcePropertyType";
-    private const string DestinationPropertyTypePropertyName = "DestinationPropertyType";
-
     /// <summary>
     ///     Gets the diagnostic IDs that this provider can fix.
     /// </summary>
@@ -216,7 +212,8 @@ public class AM001_PropertyTypeMismatchCodeFixProvider : AutoMapperCodeFixProvid
     private string? ExtractPropertyNameFromDiagnostic(Diagnostic diagnostic)
     {
         // Try to get property name from diagnostic properties
-        if (diagnostic.Properties.TryGetValue(PropertyNamePropertyName, out string? propertyName))
+        if (diagnostic.Properties.TryGetValue(AM001_PropertyTypeMismatchAnalyzer.PropertyNamePropertyName,
+                out string? propertyName))
         {
             return propertyName;
         }
@@ -231,9 +228,11 @@ public class AM001_PropertyTypeMismatchCodeFixProvider : AutoMapperCodeFixProvid
     {
         // Try to get from diagnostic properties first
         string? sourceType =
-            diagnostic.Properties.TryGetValue(SourcePropertyTypePropertyName, out string? st) ? st : null;
+            diagnostic.Properties.TryGetValue(AM001_PropertyTypeMismatchAnalyzer.SourcePropertyTypePropertyName,
+                out string? st) ? st : null;
         string? destType =
-            diagnostic.Properties.TryGetValue(DestinationPropertyTypePropertyName, out string? dt) ? dt : null;
+            diagnostic.Properties.TryGetValue(AM001_PropertyTypeMismatchAnalyzer.DestinationPropertyTypePropertyName,
+                out string? dt) ? dt : null;
 
         if (!string.IsNullOrEmpty(sourceType) && !string.IsNullOrEmpty(destType))
         {

--- a/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM001_PropertyTypeMismatchCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM001_PropertyTypeMismatchCodeFixProvider.cs
@@ -17,6 +17,10 @@ namespace AutoMapperAnalyzer.Analyzers.TypeSafety;
 [Shared]
 public class AM001_PropertyTypeMismatchCodeFixProvider : AutoMapperCodeFixProviderBase
 {
+    private const string PropertyNamePropertyName = "PropertyName";
+    private const string SourcePropertyTypePropertyName = "SourcePropertyType";
+    private const string DestinationPropertyTypePropertyName = "DestinationPropertyType";
+
     /// <summary>
     ///     Gets the diagnostic IDs that this provider can fix.
     /// </summary>
@@ -33,9 +37,13 @@ public class AM001_PropertyTypeMismatchCodeFixProvider : AutoMapperCodeFixProvid
             return;
         }
 
-        Diagnostic diagnostic = context.Diagnostics.First();
+        Diagnostic? diagnostic = context.Diagnostics.FirstOrDefault(diag =>
+            diag.Id == "AM001" &&
+            diag.Location.IsInSource &&
+            diag.Location.SourceTree == operationContext.Root.SyntaxTree &&
+            diag.Location.SourceSpan.IntersectsWith(context.Span));
 
-        if (diagnostic.Descriptor != AM001_PropertyTypeMismatchAnalyzer.PropertyTypeMismatchRule)
+        if (diagnostic == null)
         {
             return;
         }
@@ -134,13 +142,6 @@ public class AM001_PropertyTypeMismatchCodeFixProvider : AutoMapperCodeFixProvid
 
         string destinationTypeName = destinationType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
 
-        // Nullable source to non-nullable destination -> coalesce to default literal
-        if (sourceType.NullableAnnotation == NullableAnnotation.Annotated)
-        {
-            string fallback = TypeConversionHelper.GetDefaultValueForType(destinationTypeName);
-            return $"src.{propertyName} ?? {fallback}";
-        }
-
         // Numeric conversions: add cast
         if (IsNumericConversion(sourceType.SpecialType) && IsNumericConversion(destinationType.SpecialType))
         {
@@ -151,13 +152,30 @@ public class AM001_PropertyTypeMismatchCodeFixProvider : AutoMapperCodeFixProvid
         if (IsString(sourceType) && IsNumericConversion(destinationType.SpecialType))
         {
             return
-                $"src.{propertyName} is not null ? {destinationTypeName}.Parse(src.{propertyName}) : {TypeConversionHelper.GetDefaultValueForType(destinationTypeName)}";
+                $"src.{propertyName} != null ? {destinationTypeName}.Parse(src.{propertyName}) : {TypeConversionHelper.GetDefaultValueForType(destinationTypeName)}";
         }
 
         // Primitive -> string: use ToString with invariant culture for numeric types
         if (IsNumericConversion(sourceType.SpecialType) && IsString(destinationType))
         {
             return $"src.{propertyName}.ToString()";
+        }
+
+        // Nullable source to non-nullable destination where underlying types are compatible.
+        ITypeSymbol sourceUnderlyingType = AutoMapperAnalysisHelpers.GetUnderlyingType(sourceType);
+        if (IsNullableType(sourceType) &&
+            !IsNullableType(destinationType) &&
+            AutoMapperAnalysisHelpers.AreTypesCompatible(sourceUnderlyingType, destinationType))
+        {
+            string fallback = TypeConversionHelper.GetDefaultValueForType(destinationTypeName);
+            if (IsNumericConversion(sourceUnderlyingType.SpecialType) &&
+                IsNumericConversion(destinationType.SpecialType) &&
+                !SymbolEqualityComparer.Default.Equals(sourceUnderlyingType, destinationType))
+            {
+                return $"({destinationTypeName})(src.{propertyName} ?? {fallback})";
+            }
+
+            return $"src.{propertyName} ?? {fallback}";
         }
 
         // As a safe catch-all, allow cast when the destination is assignable from source
@@ -184,10 +202,21 @@ public class AM001_PropertyTypeMismatchCodeFixProvider : AutoMapperCodeFixProvid
         return typeSymbol.SpecialType == SpecialType.System_String;
     }
 
+    private static bool IsNullableType(ITypeSymbol type)
+    {
+        if (type.NullableAnnotation == NullableAnnotation.Annotated)
+        {
+            return true;
+        }
+
+        return type is INamedTypeSymbol namedType &&
+               namedType.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T;
+    }
+
     private string? ExtractPropertyNameFromDiagnostic(Diagnostic diagnostic)
     {
         // Try to get property name from diagnostic properties
-        if (diagnostic.Properties.TryGetValue("PropertyName", out string? propertyName))
+        if (diagnostic.Properties.TryGetValue(PropertyNamePropertyName, out string? propertyName))
         {
             return propertyName;
         }
@@ -201,8 +230,10 @@ public class AM001_PropertyTypeMismatchCodeFixProvider : AutoMapperCodeFixProvid
     private (string? sourceType, string? destType) ExtractTypesFromDiagnostic(Diagnostic diagnostic)
     {
         // Try to get from diagnostic properties first
-        string? sourceType = diagnostic.Properties.TryGetValue("SourceType", out string? st) ? st : null;
-        string? destType = diagnostic.Properties.TryGetValue("DestType", out string? dt) ? dt : null;
+        string? sourceType =
+            diagnostic.Properties.TryGetValue(SourcePropertyTypePropertyName, out string? st) ? st : null;
+        string? destType =
+            diagnostic.Properties.TryGetValue(DestinationPropertyTypePropertyName, out string? dt) ? dt : null;
 
         if (!string.IsNullOrEmpty(sourceType) && !string.IsNullOrEmpty(destType))
         {


### PR DESCRIPTION
## Summary
- gate AM001 analysis on semantic AutoMapper  symbols to avoid lookalike API false positives
- tighten AM001/AM002 overlap handling so AM001 still reports when nullability is present alongside true type incompatibility
- harden  suppression and AM001 fixer routing/conversion generation (including nullable string-to-int parsing in expression-tree-safe form)
- add regression coverage for non-AutoMapper lookalikes, parenthesized lambda explicit mappings, nullable+incompatible type reporting, and nullable string parse code fix

## Validation
- /Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Infrastructure/CodeFixVerifier.cs(60,43): warning CS8604: Possible null reference argument for parameter 'collection' in 'void List<DiagnosticResult>.AddRange(IEnumerable<DiagnosticResult> collection)'. [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Infrastructure/CodeFixVerifier.cs(92,43): warning CS8604: Possible null reference argument for parameter 'collection' in 'void List<DiagnosticResult>.AddRange(IEnumerable<DiagnosticResult> collection)'. [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Helpers/DiagnosticAssertions.cs(166,9): warning RS2008: Enable analyzer release tracking for the analyzer project containing rule 'AM010' (https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Helpers/DiagnosticAssertions.cs(178,9): warning RS2008: Enable analyzer release tracking for the analyzer project containing rule 'AM011' (https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Framework/DiagnosticTestFrameworkTests.cs(182,2): warning RS1038: This compiler extension should not be implemented in an assembly containing a reference to Microsoft.CodeAnalysis.Workspaces. The Microsoft.CodeAnalysis.Workspaces assembly is not provided during command line compilation scenarios, so references to it could cause the compiler extension to behave unpredictably. (https://github.com/dotnet/roslyn/blob/main/docs/roslyn-analyzers/rules/RS1038.md) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Framework/DiagnosticTestFrameworkTests.cs(182,2): warning RS1041: This compiler extension should not be implemented in an assembly with target framework '.NET 10.0'. References to other target frameworks will cause the compiler to behave unpredictably. (https://github.com/dotnet/roslyn/blob/main/docs/roslyn-analyzers/rules/RS1041.md) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Infrastructure/TestInfrastructureTests.cs(128,2): warning RS1038: This compiler extension should not be implemented in an assembly containing a reference to Microsoft.CodeAnalysis.Workspaces. The Microsoft.CodeAnalysis.Workspaces assembly is not provided during command line compilation scenarios, so references to it could cause the compiler extension to behave unpredictably. (https://github.com/dotnet/roslyn/blob/main/docs/roslyn-analyzers/rules/RS1038.md) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Infrastructure/TestInfrastructureTests.cs(128,2): warning RS1041: This compiler extension should not be implemented in an assembly with target framework '.NET 10.0'. References to other target frameworks will cause the compiler to behave unpredictably. (https://github.com/dotnet/roslyn/blob/main/docs/roslyn-analyzers/rules/RS1041.md) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Framework/DiagnosticTestFramework.cs(219,2): warning RS1038: This compiler extension should not be implemented in an assembly containing a reference to Microsoft.CodeAnalysis.Workspaces. The Microsoft.CodeAnalysis.Workspaces assembly is not provided during command line compilation scenarios, so references to it could cause the compiler extension to behave unpredictably. (https://github.com/dotnet/roslyn/blob/main/docs/roslyn-analyzers/rules/RS1038.md) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Framework/DiagnosticTestFramework.cs(219,2): warning RS1041: This compiler extension should not be implemented in an assembly with target framework '.NET 10.0'. References to other target frameworks will cause the compiler to behave unpredictably. (https://github.com/dotnet/roslyn/blob/main/docs/roslyn-analyzers/rules/RS1041.md) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM030_CustomTypeConverterTests.cs(107,11): warning xUnit1004: Test methods should not be skipped. Remove the Skip property to start running the test again. (https://xunit.net/xunit.analyzers/rules/xUnit1004) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM030_CustomTypeConverterTests.cs(204,11): warning xUnit1004: Test methods should not be skipped. Remove the Skip property to start running the test again. (https://xunit.net/xunit.analyzers/rules/xUnit1004) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Helpers/DiagnosticAssertions.cs(130,9): warning RS2008: Enable analyzer release tracking for the analyzer project containing rule 'AM001' (https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Helpers/TestScenarioBuilder.cs(44,9): warning CA1305: The behavior of 'StringBuilder.AppendLine(ref StringBuilder.AppendInterpolatedStringHandler)' could vary based on the current user's locale settings. Replace this call in 'TestScenarioBuilder.AddClass(string, params (string Type, string Name)[])' with a call to 'StringBuilder.AppendLine(IFormatProvider, ref StringBuilder.AppendInterpolatedStringHandler)'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Helpers/TestScenarioBuilder.cs(49,13): warning CA1305: The behavior of 'StringBuilder.AppendLine(ref StringBuilder.AppendInterpolatedStringHandler)' could vary based on the current user's locale settings. Replace this call in 'TestScenarioBuilder.AddClass(string, params (string Type, string Name)[])' with a call to 'StringBuilder.AppendLine(IFormatProvider, ref StringBuilder.AppendInterpolatedStringHandler)'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Helpers/TestScenarioBuilder.cs(65,9): warning CA1305: The behavior of 'StringBuilder.AppendLine(ref StringBuilder.AppendInterpolatedStringHandler)' could vary based on the current user's locale settings. Replace this call in 'TestScenarioBuilder.AddClassWithRequired(string, params (string Type, string Name, bool Required)[])' with a call to 'StringBuilder.AppendLine(IFormatProvider, ref StringBuilder.AppendInterpolatedStringHandler)'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Helpers/TestScenarioBuilder.cs(72,17): warning CA1305: The behavior of 'StringBuilder.AppendLine(ref StringBuilder.AppendInterpolatedStringHandler)' could vary based on the current user's locale settings. Replace this call in 'TestScenarioBuilder.AddClassWithRequired(string, params (string Type, string Name, bool Required)[])' with a call to 'StringBuilder.AppendLine(IFormatProvider, ref StringBuilder.AppendInterpolatedStringHandler)'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Helpers/TestScenarioBuilder.cs(76,17): warning CA1305: The behavior of 'StringBuilder.AppendLine(ref StringBuilder.AppendInterpolatedStringHandler)' could vary based on the current user's locale settings. Replace this call in 'TestScenarioBuilder.AddClassWithRequired(string, params (string Type, string Name, bool Required)[])' with a call to 'StringBuilder.AppendLine(IFormatProvider, ref StringBuilder.AppendInterpolatedStringHandler)'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Helpers/TestScenarioBuilder.cs(92,9): warning CA1305: The behavior of 'StringBuilder.AppendLine(ref StringBuilder.AppendInterpolatedStringHandler)' could vary based on the current user's locale settings. Replace this call in 'TestScenarioBuilder.AddProfile(string, params string[])' with a call to 'StringBuilder.AppendLine(IFormatProvider, ref StringBuilder.AppendInterpolatedStringHandler)'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Helpers/TestScenarioBuilder.cs(94,9): warning CA1305: The behavior of 'StringBuilder.AppendLine(ref StringBuilder.AppendInterpolatedStringHandler)' could vary based on the current user's locale settings. Replace this call in 'TestScenarioBuilder.AddProfile(string, params string[])' with a call to 'StringBuilder.AppendLine(IFormatProvider, ref StringBuilder.AppendInterpolatedStringHandler)'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Helpers/TestScenarioBuilder.cs(99,13): warning CA1305: The behavior of 'StringBuilder.AppendLine(ref StringBuilder.AppendInterpolatedStringHandler)' could vary based on the current user's locale settings. Replace this call in 'TestScenarioBuilder.AddProfile(string, params string[])' with a call to 'StringBuilder.AppendLine(IFormatProvider, ref StringBuilder.AppendInterpolatedStringHandler)'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Performance/AM031_PerformanceWarningTests.cs(8,11): warning xUnit1004: Test methods should not be skipped. Remove the Skip property to start running the test again. (https://xunit.net/xunit.analyzers/rules/xUnit1004) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Helpers/CodeFixSyntaxHelperTests.cs(187,44): warning CA1861: Prefer 'static readonly' fields over constant array arguments if the called method is called repeatedly and is not mutating the passed array (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Performance/AM031_PerformanceWarningTests.cs(414,11): warning xUnit1004: Test methods should not be skipped. Remove the Skip property to start running the test again. (https://xunit.net/xunit.analyzers/rules/xUnit1004) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Helpers/DiagnosticAssertions.cs(142,9): warning RS2008: Enable analyzer release tracking for the analyzer project containing rule 'AM002' (https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM001_CodeFixTests.cs(140,11): warning xUnit1004: Test methods should not be skipped. Remove the Skip property to start running the test again. (https://xunit.net/xunit.analyzers/rules/xUnit1004) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Helpers/CodeFixSyntaxHelperTests.cs(247,51): warning CA1861: Prefer 'static readonly' fields over constant array arguments if the called method is called repeatedly and is not mutating the passed array (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1861) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM001_CodeFixTests.cs(201,11): warning xUnit1004: Test methods should not be skipped. Remove the Skip property to start running the test again. (https://xunit.net/xunit.analyzers/rules/xUnit1004) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Performance/AM031_CodeFixTests.cs(9,11): warning xUnit1004: Test methods should not be skipped. Remove the Skip property to start running the test again. (https://xunit.net/xunit.analyzers/rules/xUnit1004) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Helpers/TestScenarioBuilder.cs(115,9): warning CA1305: The behavior of 'StringBuilder.Append(ref StringBuilder.AppendInterpolatedStringHandler)' could vary based on the current user's locale settings. Replace this call in 'TestScenarioBuilder.AddMapping(string, string, params string[])' with a call to 'StringBuilder.Append(IFormatProvider, ref StringBuilder.AppendInterpolatedStringHandler)'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Helpers/TestScenarioBuilder.cs(119,13): warning CA1305: The behavior of 'StringBuilder.Append(ref StringBuilder.AppendInterpolatedStringHandler)' could vary based on the current user's locale settings. Replace this call in 'TestScenarioBuilder.AddMapping(string, string, params string[])' with a call to 'StringBuilder.Append(IFormatProvider, ref StringBuilder.AppendInterpolatedStringHandler)'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Performance/AM031_CodeFixTests.cs(102,11): warning xUnit1004: Test methods should not be skipped. Remove the Skip property to start running the test again. (https://xunit.net/xunit.analyzers/rules/xUnit1004) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Performance/AM031_CodeFixTests.cs(183,11): warning xUnit1004: Test methods should not be skipped. Remove the Skip property to start running the test again. (https://xunit.net/xunit.analyzers/rules/xUnit1004) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Performance/AM031_CodeFixTests.cs(255,11): warning xUnit1004: Test methods should not be skipped. Remove the Skip property to start running the test again. (https://xunit.net/xunit.analyzers/rules/xUnit1004) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Performance/AM031_CodeFixTests.cs(321,11): warning xUnit1004: Test methods should not be skipped. Remove the Skip property to start running the test again. (https://xunit.net/xunit.analyzers/rules/xUnit1004) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Performance/AM031_CodeFixTests.cs(402,11): warning xUnit1004: Test methods should not be skipped. Remove the Skip property to start running the test again. (https://xunit.net/xunit.analyzers/rules/xUnit1004) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Helpers/TestScenarioBuilder.cs(150,9): warning CA1305: The behavior of 'StringBuilder.AppendLine(ref StringBuilder.AppendInterpolatedStringHandler)' could vary based on the current user's locale settings. Replace this call in 'TestScenarioBuilder.AddMappingMethod(string, string, string, params string[])' with a call to 'StringBuilder.AppendLine(IFormatProvider, ref StringBuilder.AppendInterpolatedStringHandler)'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Helpers/TestScenarioBuilder.cs(157,17): warning CA1305: The behavior of 'StringBuilder.AppendLine(ref StringBuilder.AppendInterpolatedStringHandler)' could vary based on the current user's locale settings. Replace this call in 'TestScenarioBuilder.AddMappingMethod(string, string, string, params string[])' with a call to 'StringBuilder.AppendLine(IFormatProvider, ref StringBuilder.AppendInterpolatedStringHandler)'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Helpers/TestScenarioBuilder.cs(162,13): warning CA1305: The behavior of 'StringBuilder.AppendLine(ref StringBuilder.AppendInterpolatedStringHandler)' could vary based on the current user's locale settings. Replace this call in 'TestScenarioBuilder.AddMappingMethod(string, string, string, params string[])' with a call to 'StringBuilder.AppendLine(IFormatProvider, ref StringBuilder.AppendInterpolatedStringHandler)'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Helpers/TestScenarioBuilder.cs(182,13): warning CA1305: The behavior of 'StringBuilder.AppendLine(ref StringBuilder.AppendInterpolatedStringHandler)' could vary based on the current user's locale settings. Replace this call in 'TestScenarioBuilder.Build()' with a call to 'StringBuilder.AppendLine(IFormatProvider, ref StringBuilder.AppendInterpolatedStringHandler)'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Helpers/TestScenarioBuilder.cs(212,17): warning CA1305: The behavior of 'StringBuilder.AppendLine(ref StringBuilder.AppendInterpolatedStringHandler)' could vary based on the current user's locale settings. Replace this call in 'TestScenarioBuilder.Build()' with a call to 'StringBuilder.AppendLine(IFormatProvider, ref StringBuilder.AppendInterpolatedStringHandler)'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1305) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/Helpers/DiagnosticAssertions.cs(154,9): warning RS2008: Enable analyzer release tracking for the analyzer project containing rule 'AM003' (https://github.com/dotnet/roslyn/blob/main/src/RoslynAnalyzers/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md) [/Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj]
Test run for /Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/bin/Debug/net10.0/AutoMapperAnalyzer.Tests.dll (.NETCoreApp,Version=v10.0)
A total of 1 test files matched the specified pattern.

Passed!  - Failed:     0, Passed:    14, Skipped:     2, Total:    16, Duration: 2 s - AutoMapperAnalyzer.Tests.dll (net10.0)
- Test run for /Users/georgewall/RiderProjects/automapper-analyser/tests/AutoMapperAnalyzer.Tests/bin/Debug/net10.0/AutoMapperAnalyzer.Tests.dll (.NETCoreApp,Version=v10.0)
A total of 1 test files matched the specified pattern.

Passed!  - Failed:     0, Passed:   490, Skipped:    12, Total:   502, Duration: 8 s - AutoMapperAnalyzer.Tests.dll (net10.0)