### PR TITLE
AM002: reduce false positives and improve fixer metadata

### DIFF
--- a/docs/ANALYZER_REVIEW_TRACKER.md
+++ b/docs/ANALYZER_REVIEW_TRACKER.md
@@ -17,9 +17,10 @@ Tracks analyzer-by-analyzer improvement passes focused on false positives, contr
 | AM022 | Complex Mappings | [#53](https://github.com/georgepwall1991/automapper-analyser/pull/53) | [v2.14.0](https://github.com/georgepwall1991/automapper-analyser/releases/tag/v2.14.0) | Direction-aware reverse-map suppression, stricter ignore-all handling for recursion risks, and collection-aware recursion fixer behavior. |
 | AM030 | Complex Mappings | [#54](https://github.com/georgepwall1991/automapper-analyser/pull/54) | [v2.15.0](https://github.com/georgepwall1991/automapper-analyser/releases/tag/v2.15.0) | Exact `ForMember` property matching (including case-insensitive suppression), `Ignore`/`ConstructUsing` suppression support, stronger converter signature/null-check analysis, and safer code-fix routing for missing-converter diagnostics. |
 | AM031 | Performance | [#55](https://github.com/georgepwall1991/automapper-analyser/pull/55) | [v2.16.0](https://github.com/georgepwall1991/automapper-analyser/releases/tag/v2.16.0) | Stricter AutoMapper semantic checks, reduced heuristic false positives (`Random`/reflection/database), richer diagnostic metadata for fixer routing, and broader performance regression coverage (`Task.Wait`, parenthesized lambdas, `DateTime.UtcNow`). |
+| AM001 | Type Safety | [#56](https://github.com/georgepwall1991/automapper-analyser/pull/56) | [v2.17.0](https://github.com/georgepwall1991/automapper-analyser/releases/tag/v2.17.0) | Added semantic AutoMapper invocation guards, fixed AM001/AM002 overlap for nullable + incompatible types, improved fixer conversion safety/routing, and expanded AM001 regression coverage. |
 
 ## In Progress
 
 | Analyzer | Area | Branch | Goal |
 |---|---|---|---|
-| AM001 | Type Safety | `codex/am001-next-pass` | Next analyzer pass for false positives/fixer reliability improvements. |
+| AM002 | Type Safety | `codex/am002-next-pass` | Next analyzer pass for false positives/fixer reliability improvements. |

--- a/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM002_NullableCompatibilityAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM002_NullableCompatibilityAnalyzer.cs
@@ -97,8 +97,10 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
 
         foreach (IPropertySymbol sourceProperty in sourceProperties)
         {
-            IPropertySymbol? destinationProperty = destinationProperties
-                .FirstOrDefault(p => string.Equals(p.Name, sourceProperty.Name, StringComparison.OrdinalIgnoreCase));
+            IPropertySymbol? destinationProperty = destinationProperties.FirstOrDefault(p => p.Name == sourceProperty.Name) ??
+                                                   destinationProperties.FirstOrDefault(p =>
+                                                       string.Equals(p.Name, sourceProperty.Name,
+                                                           StringComparison.OrdinalIgnoreCase));
 
             if (destinationProperty != null)
             {

--- a/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM002_NullableCompatibilityAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM002_NullableCompatibilityAnalyzer.cs
@@ -13,6 +13,10 @@ namespace AutoMapperAnalyzer.Analyzers.TypeSafety;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
 {
+    internal const string PropertyNamePropertyName = "PropertyName";
+    internal const string SourcePropertyTypePropertyName = "SourcePropertyType";
+    internal const string DestinationPropertyTypePropertyName = "DestinationPropertyType";
+
     /// <summary>
     ///     AM002: Nullable to non-nullable assignment without proper handling.
     /// </summary>
@@ -58,8 +62,8 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
     {
         var invocationExpr = (InvocationExpressionSyntax)context.Node;
 
-        // Check if this is a CreateMap<TSource, TDestination>() call
-        if (!AutoMapperAnalysisHelpers.IsCreateMapInvocation(invocationExpr, context.SemanticModel))
+        // Ensure this resolves to AutoMapper CreateMap to avoid lookalike API false positives.
+        if (!IsAutoMapperCreateMapInvocation(invocationExpr, context.SemanticModel))
         {
             return;
         }
@@ -94,13 +98,12 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
         foreach (IPropertySymbol sourceProperty in sourceProperties)
         {
             IPropertySymbol? destinationProperty = destinationProperties
-                .FirstOrDefault(p => p.Name == sourceProperty.Name);
+                .FirstOrDefault(p => string.Equals(p.Name, sourceProperty.Name, StringComparison.OrdinalIgnoreCase));
 
             if (destinationProperty != null)
             {
                 // Check for explicit property mapping that might handle nullability
-                if (AutoMapperAnalysisHelpers.IsPropertyConfiguredWithForMember(invocation, sourceProperty.Name,
-                        context.SemanticModel))
+                if (IsPropertyConfiguredWithForMember(invocation, sourceProperty.Name, context.SemanticModel))
                 {
                     continue;
                 }
@@ -137,9 +140,15 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
 
             if (AreUnderlyingTypesCompatible(sourceUnderlyingType, destUnderlyingType))
             {
+                var properties = ImmutableDictionary.CreateBuilder<string, string?>();
+                properties.Add(PropertyNamePropertyName, sourceProperty.Name);
+                properties.Add(SourcePropertyTypePropertyName, sourceTypeName);
+                properties.Add(DestinationPropertyTypePropertyName, destTypeName);
+
                 var diagnostic = Diagnostic.Create(
                     NullableToNonNullableRule,
                     invocation.GetLocation(),
+                    properties.ToImmutable(),
                     sourceProperty.Name,
                     GetTypeName(sourceType),
                     sourceTypeName,
@@ -157,9 +166,15 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
 
             if (AreUnderlyingTypesCompatible(sourceUnderlyingType, destUnderlyingType))
             {
+                var properties = ImmutableDictionary.CreateBuilder<string, string?>();
+                properties.Add(PropertyNamePropertyName, sourceProperty.Name);
+                properties.Add(SourcePropertyTypePropertyName, sourceTypeName);
+                properties.Add(DestinationPropertyTypePropertyName, destTypeName);
+
                 var diagnostic = Diagnostic.Create(
                     NonNullableToNullableRule,
                     invocation.GetLocation(),
+                    properties.ToImmutable(),
                     sourceProperty.Name,
                     GetTypeName(sourceType),
                     sourceTypeName,
@@ -217,5 +232,92 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
         }
 
         return type.Name;
+    }
+
+    private static bool IsPropertyConfiguredWithForMember(
+        InvocationExpressionSyntax createMapInvocation,
+        string propertyName,
+        SemanticModel semanticModel)
+    {
+        IEnumerable<InvocationExpressionSyntax> forMemberCalls = AutoMapperAnalysisHelpers.GetForMemberCalls(createMapInvocation);
+
+        foreach (InvocationExpressionSyntax forMemberCall in forMemberCalls)
+        {
+            if (!IsAutoMapperMethodInvocation(forMemberCall, semanticModel, "ForMember"))
+            {
+                continue;
+            }
+
+            if (forMemberCall.ArgumentList.Arguments.Count == 0)
+            {
+                continue;
+            }
+
+            ArgumentSyntax destinationArgument = forMemberCall.ArgumentList.Arguments[0];
+            CSharpSyntaxNode? lambdaBody = GetLambdaBody(destinationArgument.Expression);
+            if (lambdaBody is not MemberAccessExpressionSyntax memberAccess)
+            {
+                continue;
+            }
+
+            if (string.Equals(memberAccess.Name.Identifier.Text, propertyName, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static CSharpSyntaxNode? GetLambdaBody(ExpressionSyntax expression)
+    {
+        return expression switch
+        {
+            SimpleLambdaExpressionSyntax simpleLambda => simpleLambda.Body,
+            ParenthesizedLambdaExpressionSyntax parenthesizedLambda => parenthesizedLambda.Body,
+            _ => null
+        };
+    }
+
+    private static bool IsAutoMapperCreateMapInvocation(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel)
+    {
+        return IsAutoMapperMethodInvocation(invocation, semanticModel, "CreateMap");
+    }
+
+    private static bool IsAutoMapperMethodInvocation(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        string methodName)
+    {
+        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(invocation);
+
+        if (IsAutoMapperMethod(symbolInfo.Symbol as IMethodSymbol, methodName))
+        {
+            return true;
+        }
+
+        foreach (ISymbol candidateSymbol in symbolInfo.CandidateSymbols)
+        {
+            if (IsAutoMapperMethod(candidateSymbol as IMethodSymbol, methodName))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsAutoMapperMethod(IMethodSymbol? methodSymbol, string methodName)
+    {
+        if (methodSymbol == null || methodSymbol.Name != methodName)
+        {
+            return false;
+        }
+
+        string? namespaceName = methodSymbol.ContainingNamespace?.ToDisplayString();
+        return namespaceName == "AutoMapper" ||
+               (namespaceName?.StartsWith("AutoMapper.", StringComparison.Ordinal) ?? false);
     }
 }


### PR DESCRIPTION
## Summary
- harden AM002 to only analyze semantic AutoMapper `CreateMap`/`ForMember` invocations
- avoid false positives from lookalike non-AutoMapper APIs and parenthesized lambda explicit mappings
- attach AM002 diagnostic metadata (`PropertyName`, source/destination property types) to improve fixer extraction reliability
- keep AM002 focused on nullability-only compatibility by skipping nullable+incompatible type mismatches

## Validation
- dotnet test --nologo -v q --filter "FullyQualifiedName~AM002_"
- dotnet test --nologo -v q
