### PR TITLE
AM003: reduce false positives and harden fixer metadata flow

### DIFF
--- a/docs/ANALYZER_REVIEW_TRACKER.md
+++ b/docs/ANALYZER_REVIEW_TRACKER.md
@@ -18,9 +18,10 @@ Tracks analyzer-by-analyzer improvement passes focused on false positives, contr
 | AM030 | Complex Mappings | [#54](https://github.com/georgepwall1991/automapper-analyser/pull/54) | [v2.15.0](https://github.com/georgepwall1991/automapper-analyser/releases/tag/v2.15.0) | Exact `ForMember` property matching (including case-insensitive suppression), `Ignore`/`ConstructUsing` suppression support, stronger converter signature/null-check analysis, and safer code-fix routing for missing-converter diagnostics. |
 | AM031 | Performance | [#55](https://github.com/georgepwall1991/automapper-analyser/pull/55) | [v2.16.0](https://github.com/georgepwall1991/automapper-analyser/releases/tag/v2.16.0) | Stricter AutoMapper semantic checks, reduced heuristic false positives (`Random`/reflection/database), richer diagnostic metadata for fixer routing, and broader performance regression coverage (`Task.Wait`, parenthesized lambdas, `DateTime.UtcNow`). |
 | AM001 | Type Safety | [#56](https://github.com/georgepwall1991/automapper-analyser/pull/56) | [v2.17.0](https://github.com/georgepwall1991/automapper-analyser/releases/tag/v2.17.0) | Added semantic AutoMapper invocation guards, fixed AM001/AM002 overlap for nullable + incompatible types, improved fixer conversion safety/routing, and expanded AM001 regression coverage. |
+| AM002 | Type Safety | [#57](https://github.com/georgepwall1991/automapper-analyser/pull/57) | [v2.18.0](https://github.com/georgepwall1991/automapper-analyser/releases/tag/v2.18.0) | Added strict AutoMapper symbol checks, parenthesized-lambda `ForMember` suppression, metadata-backed fixer extraction, and regression coverage for lookalike APIs and nullable+incompatible scenarios. |
 
 ## In Progress
 
 | Analyzer | Area | Branch | Goal |
 |---|---|---|---|
-| AM002 | Type Safety | `codex/am002-next-pass` | Next analyzer pass for false positives/fixer reliability improvements. |
+| AM003 | Type Safety | `codex/am003-next-pass` | Next analyzer pass for false positives/fixer reliability improvements. |

--- a/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM003_CollectionTypeIncompatibilityAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM003_CollectionTypeIncompatibilityAnalyzer.cs
@@ -13,6 +13,12 @@ namespace AutoMapperAnalyzer.Analyzers.TypeSafety;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class AM003_CollectionTypeIncompatibilityAnalyzer : DiagnosticAnalyzer
 {
+    internal const string PropertyNamePropertyName = "PropertyName";
+    internal const string SourcePropertyTypePropertyName = "SourcePropertyType";
+    internal const string DestinationPropertyTypePropertyName = "DestinationPropertyType";
+    internal const string SourceElementTypePropertyName = "SourceElementType";
+    internal const string DestinationElementTypePropertyName = "DestinationElementType";
+
     /// <summary>
     ///     AM003: Collection type incompatibility without proper conversion
     /// </summary>
@@ -56,8 +62,8 @@ public class AM003_CollectionTypeIncompatibilityAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // Check if this is a CreateMap<TSource, TDestination>() call
-        if (!AutoMapperAnalysisHelpers.IsCreateMapInvocation(invocationExpr, context.SemanticModel))
+        // Ensure this invocation resolves to AutoMapper CreateMap to avoid lookalike false positives.
+        if (!IsAutoMapperCreateMapInvocation(invocationExpr, context.SemanticModel))
         {
             return;
         }
@@ -87,8 +93,10 @@ public class AM003_CollectionTypeIncompatibilityAnalyzer : DiagnosticAnalyzer
 
         foreach (IPropertySymbol sourceProperty in sourceProperties)
         {
-            IPropertySymbol? destinationProperty = destinationProperties
-                .FirstOrDefault(p => p.Name == sourceProperty.Name);
+            IPropertySymbol? destinationProperty =
+                destinationProperties.FirstOrDefault(p => p.Name == sourceProperty.Name) ??
+                destinationProperties.FirstOrDefault(p =>
+                    string.Equals(p.Name, sourceProperty.Name, StringComparison.OrdinalIgnoreCase));
 
             if (destinationProperty == null)
             {
@@ -96,8 +104,7 @@ public class AM003_CollectionTypeIncompatibilityAnalyzer : DiagnosticAnalyzer
             }
 
             // Check for explicit property mapping that might handle collection conversion
-            if (AutoMapperAnalysisHelpers.IsPropertyConfiguredWithForMember(invocation, sourceProperty.Name,
-                    context.SemanticModel))
+            if (IsPropertyConfiguredWithForMember(invocation, sourceProperty.Name, context.SemanticModel))
             {
                 continue;
             }
@@ -137,13 +144,14 @@ public class AM003_CollectionTypeIncompatibilityAnalyzer : DiagnosticAnalyzer
         {
             ImmutableDictionary<string, string?>.Builder properties =
                 ImmutableDictionary.CreateBuilder<string, string?>();
-            properties.Add("PropertyName", sourceProperty.Name);
+            properties.Add(PropertyNamePropertyName, sourceProperty.Name);
+            properties.Add(SourcePropertyTypePropertyName, sourceTypeName);
+            properties.Add(DestinationPropertyTypePropertyName, destTypeName);
+            properties.Add(SourceElementTypePropertyName, sourceElementType.ToDisplayString());
+            properties.Add(DestinationElementTypePropertyName, destElementType.ToDisplayString());
+            // Backward-compatible aliases for existing fixers/consumers.
             properties.Add("SourceType", sourceTypeName);
             properties.Add("DestType", destTypeName);
-            properties.Add("SourceTypeName", GetTypeName(sourceType));
-            properties.Add("DestTypeName", GetTypeName(destinationType));
-            properties.Add("SourceElementType", sourceElementType.ToDisplayString());
-            properties.Add("DestElementType", destElementType.ToDisplayString());
 
             var diagnostic = Diagnostic.Create(
                 CollectionTypeIncompatibilityRule,
@@ -162,22 +170,23 @@ public class AM003_CollectionTypeIncompatibilityAnalyzer : DiagnosticAnalyzer
         {
             ImmutableDictionary<string, string?>.Builder properties =
                 ImmutableDictionary.CreateBuilder<string, string?>();
-            properties.Add("PropertyName", sourceProperty.Name);
+            properties.Add(PropertyNamePropertyName, sourceProperty.Name);
+            properties.Add(SourcePropertyTypePropertyName, sourceTypeName);
+            properties.Add(DestinationPropertyTypePropertyName, destTypeName);
+            properties.Add(SourceElementTypePropertyName, sourceElementType.ToDisplayString());
+            properties.Add(DestinationElementTypePropertyName, destElementType.ToDisplayString());
+            // Backward-compatible aliases for existing fixers/consumers.
             properties.Add("SourceType", sourceTypeName);
             properties.Add("DestType", destTypeName);
-            properties.Add("SourceTypeName", GetTypeName(sourceType));
-            properties.Add("DestTypeName", GetTypeName(destinationType));
-            properties.Add("SourceElementType", sourceElementType.ToDisplayString());
-            properties.Add("DestElementType", destElementType.ToDisplayString());
 
             var diagnostic = Diagnostic.Create(
                 CollectionElementIncompatibilityRule,
                 invocation.GetLocation(),
                 properties.ToImmutable(),
                 sourceProperty.Name,
-                sourceType.Name,
+                GetTypeName(sourceType),
                 sourceElementType.ToDisplayString(),
-                destinationType.Name,
+                GetTypeName(destinationType),
                 destElementType.ToDisplayString());
 
             context.ReportDiagnostic(diagnostic);
@@ -197,16 +206,12 @@ public class AM003_CollectionTypeIncompatibilityAnalyzer : DiagnosticAnalyzer
         }
 
         // Check for specific incompatible combinations
-        string sourceTypeName = sourceType.ToDisplayString();
-        string destTypeName = destType.ToDisplayString();
-
-        // Detect specific collection types
-        bool sourceIsHashSet = sourceTypeName.Contains("HashSet");
-        bool destIsHashSet = destTypeName.Contains("HashSet");
-        bool sourceIsQueue = sourceTypeName.Contains("Queue");
-        bool destIsQueue = destTypeName.Contains("Queue");
-        bool sourceIsStack = sourceTypeName.Contains("Stack");
-        bool destIsStack = destTypeName.Contains("Stack");
+        bool sourceIsHashSet = IsConstructedFromType(sourceType, "System.Collections.Generic.HashSet<T>");
+        bool destIsHashSet = IsConstructedFromType(destType, "System.Collections.Generic.HashSet<T>");
+        bool sourceIsQueue = IsConstructedFromType(sourceType, "System.Collections.Generic.Queue<T>");
+        bool destIsQueue = IsConstructedFromType(destType, "System.Collections.Generic.Queue<T>");
+        bool sourceIsStack = IsConstructedFromType(sourceType, "System.Collections.Generic.Stack<T>");
+        bool destIsStack = IsConstructedFromType(destType, "System.Collections.Generic.Stack<T>");
 
         // HashSet ↔ List/Array/IEnumerable bidirectional incompatibility
         if (sourceIsHashSet && !destIsHashSet)
@@ -256,6 +261,12 @@ public class AM003_CollectionTypeIncompatibilityAnalyzer : DiagnosticAnalyzer
                namedType.TypeArguments.Length > 0;
     }
 
+    private static bool IsConstructedFromType(ITypeSymbol type, string genericDefinitionName)
+    {
+        return type is INamedTypeSymbol namedType &&
+               namedType.OriginalDefinition.ToDisplayString() == genericDefinitionName;
+    }
+
 
     /// <summary>
     ///     Gets the type name from an ITypeSymbol.
@@ -265,5 +276,93 @@ public class AM003_CollectionTypeIncompatibilityAnalyzer : DiagnosticAnalyzer
     private static string GetTypeName(ITypeSymbol type)
     {
         return type.Name;
+    }
+
+    private static bool IsPropertyConfiguredWithForMember(
+        InvocationExpressionSyntax createMapInvocation,
+        string propertyName,
+        SemanticModel semanticModel)
+    {
+        IEnumerable<InvocationExpressionSyntax> forMemberCalls =
+            AutoMapperAnalysisHelpers.GetForMemberCalls(createMapInvocation);
+
+        foreach (InvocationExpressionSyntax forMemberCall in forMemberCalls)
+        {
+            if (!IsAutoMapperMethodInvocation(forMemberCall, semanticModel, "ForMember"))
+            {
+                continue;
+            }
+
+            if (forMemberCall.ArgumentList.Arguments.Count == 0)
+            {
+                continue;
+            }
+
+            ArgumentSyntax destinationArgument = forMemberCall.ArgumentList.Arguments[0];
+            CSharpSyntaxNode? lambdaBody = GetLambdaBody(destinationArgument.Expression);
+            if (lambdaBody is not MemberAccessExpressionSyntax memberAccess)
+            {
+                continue;
+            }
+
+            if (string.Equals(memberAccess.Name.Identifier.Text, propertyName, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static CSharpSyntaxNode? GetLambdaBody(ExpressionSyntax expression)
+    {
+        return expression switch
+        {
+            SimpleLambdaExpressionSyntax simpleLambda => simpleLambda.Body,
+            ParenthesizedLambdaExpressionSyntax parenthesizedLambda => parenthesizedLambda.Body,
+            _ => null
+        };
+    }
+
+    private static bool IsAutoMapperCreateMapInvocation(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel)
+    {
+        return IsAutoMapperMethodInvocation(invocation, semanticModel, "CreateMap");
+    }
+
+    private static bool IsAutoMapperMethodInvocation(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        string methodName)
+    {
+        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(invocation);
+
+        if (IsAutoMapperMethod(symbolInfo.Symbol as IMethodSymbol, methodName))
+        {
+            return true;
+        }
+
+        foreach (ISymbol candidateSymbol in symbolInfo.CandidateSymbols)
+        {
+            if (IsAutoMapperMethod(candidateSymbol as IMethodSymbol, methodName))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsAutoMapperMethod(IMethodSymbol? methodSymbol, string methodName)
+    {
+        if (methodSymbol == null || methodSymbol.Name != methodName)
+        {
+            return false;
+        }
+
+        string? namespaceName = methodSymbol.ContainingNamespace?.ToDisplayString();
+        return namespaceName == "AutoMapper" ||
+               (namespaceName?.StartsWith("AutoMapper.", StringComparison.Ordinal) ?? false);
     }
 }

--- a/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM003_CollectionTypeIncompatibilityAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM003_CollectionTypeIncompatibilityAnalyzer.cs
@@ -152,6 +152,8 @@ public class AM003_CollectionTypeIncompatibilityAnalyzer : DiagnosticAnalyzer
             // Backward-compatible aliases for existing fixers/consumers.
             properties.Add("SourceType", sourceTypeName);
             properties.Add("DestType", destTypeName);
+            properties.Add("SourceTypeName", GetTypeName(sourceType));
+            properties.Add("DestTypeName", GetTypeName(destinationType));
 
             var diagnostic = Diagnostic.Create(
                 CollectionTypeIncompatibilityRule,
@@ -178,6 +180,8 @@ public class AM003_CollectionTypeIncompatibilityAnalyzer : DiagnosticAnalyzer
             // Backward-compatible aliases for existing fixers/consumers.
             properties.Add("SourceType", sourceTypeName);
             properties.Add("DestType", destTypeName);
+            properties.Add("SourceTypeName", GetTypeName(sourceType));
+            properties.Add("DestTypeName", GetTypeName(destinationType));
 
             var diagnostic = Diagnostic.Create(
                 CollectionElementIncompatibilityRule,


### PR DESCRIPTION
## Summary
- tighten AM003 to only analyze semantic AutoMapper `CreateMap`/`ForMember` invocations (no lookalike API false positives)
- improve explicit mapping suppression to handle parenthesized lambdas and case-insensitive destination property matching
- replace string-name collection kind detection (`Contains("Stack"/"Queue"/"HashSet")`) with exact generic type checks to avoid false positives on custom collection type names
- add canonical AM003 diagnostic metadata keys and keep legacy aliases for compatibility; harden code-fix diagnostic filtering to current context/span/tree
- add regression tests for non-AutoMapper lookalikes, parenthesized-lambda explicit mappings, and custom collection names containing `Stack`

## Validation
- dotnet test --nologo -v q --filter "FullyQualifiedName~AM003_"
- dotnet test --nologo -v q
