### PR TITLE
AM004 second pass: tighten analyzer/fixer direction logic

### DIFF
--- a/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM004_MissingDestinationPropertyCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM004_MissingDestinationPropertyCodeFixProvider.cs
@@ -24,6 +24,26 @@ public class AM004_MissingDestinationPropertyCodeFixProvider : AutoMapperCodeFix
     /// </summary>
     public override ImmutableArray<string> FixableDiagnosticIds => ["AM004"];
 
+    private sealed class MappingAnalysisContext
+    {
+        public InvocationExpressionSyntax MappingInvocation { get; }
+        public ITypeSymbol SourceType { get; }
+        public ITypeSymbol DestinationType { get; }
+        public bool StopAtReverseMapBoundary { get; }
+
+        public MappingAnalysisContext(
+            InvocationExpressionSyntax mappingInvocation,
+            ITypeSymbol sourceType,
+            ITypeSymbol destinationType,
+            bool stopAtReverseMapBoundary)
+        {
+            MappingInvocation = mappingInvocation;
+            SourceType = sourceType;
+            DestinationType = destinationType;
+            StopAtReverseMapBoundary = stopAtReverseMapBoundary;
+        }
+    }
+
     /// <summary>
     ///     Registers code fixes for the specified context.
     /// </summary>
@@ -127,55 +147,67 @@ public class AM004_MissingDestinationPropertyCodeFixProvider : AutoMapperCodeFix
     private Task<Document> BulkIgnoreAsync(Document document, SyntaxNode root, InvocationExpressionSyntax invocation,
         SemanticModel semanticModel)
     {
-        (ITypeSymbol? sourceType, ITypeSymbol? destType) =
-            AutoMapperAnalysisHelpers.GetCreateMapTypeArguments(invocation, semanticModel);
-        if (sourceType == null || destType == null)
+        if (!TryResolveMappingContext(invocation, semanticModel, out MappingAnalysisContext? mappingContext))
         {
             return Task.FromResult(document);
         }
 
-        if (HasCustomConstructionOrConversion(invocation))
+        if (HasCustomConstructionOrConversion(
+                mappingContext.MappingInvocation,
+                semanticModel,
+                mappingContext.StopAtReverseMapBoundary))
         {
             return Task.FromResult(document);
         }
 
         List<IPropertySymbol> propertiesToIgnore =
-            GetUnmappedSourceProperties(invocation, sourceType, destType);
+            GetUnmappedSourceProperties(
+                mappingContext.MappingInvocation,
+                mappingContext.SourceType,
+                mappingContext.DestinationType,
+                semanticModel,
+                mappingContext.StopAtReverseMapBoundary);
 
         if (!propertiesToIgnore.Any())
         {
             return Task.FromResult(document);
         }
 
-        InvocationExpressionSyntax currentInvocation = invocation;
+        InvocationExpressionSyntax currentInvocation = mappingContext.MappingInvocation;
         foreach (var prop in propertiesToIgnore)
         {
             currentInvocation = CodeFixSyntaxHelper.CreateForSourceMemberWithDoNotValidate(currentInvocation, prop.Name);
         }
 
-        SyntaxNode newRoot = root.ReplaceNode(invocation, currentInvocation);
+        SyntaxNode newRoot = root.ReplaceNode(mappingContext.MappingInvocation, currentInvocation);
         return Task.FromResult(document.WithSyntaxRoot(newRoot));
     }
 
-    private static bool IsPropertyConfiguredWithForSourceMember(InvocationExpressionSyntax invocation, string propertyName)
+    private static bool IsSourcePropertyExplicitlyIgnored(
+        InvocationExpressionSyntax mappingInvocation,
+        string sourcePropertyName,
+        SemanticModel semanticModel,
+        bool stopAtReverseMapBoundary)
     {
-        SyntaxNode? parent = invocation.Parent;
-        while (parent is MemberAccessExpressionSyntax memberAccess &&
-               memberAccess.Parent is InvocationExpressionSyntax chainedInvocation)
+        foreach (InvocationExpressionSyntax chainedInvocation in GetScopedChainInvocations(mappingInvocation, stopAtReverseMapBoundary))
         {
-            if (memberAccess.Name.Identifier.Text == "ForSourceMember" &&
-                IsForSourceMemberOfProperty(chainedInvocation, propertyName))
+            if (!IsAutoMapperMethodInvocation(chainedInvocation, semanticModel, "ForSourceMember"))
+            {
+                continue;
+            }
+
+            if (IsForSourceMemberOfProperty(chainedInvocation, sourcePropertyName) &&
+                HasDoNotValidateCall(chainedInvocation))
             {
                 return true;
             }
-
-            parent = chainedInvocation.Parent;
         }
 
         return false;
     }
 
-    private static bool IsForSourceMemberOfProperty(InvocationExpressionSyntax forSourceMemberInvocation,
+    private static bool IsForSourceMemberOfProperty(
+        InvocationExpressionSyntax forSourceMemberInvocation,
         string propertyName)
     {
         if (forSourceMemberInvocation.ArgumentList.Arguments.Count == 0)
@@ -187,18 +219,19 @@ public class AM004_MissingDestinationPropertyCodeFixProvider : AutoMapperCodeFix
         return string.Equals(selectedMember, propertyName, StringComparison.Ordinal);
     }
 
-    private static string? GetSelectedMemberName(ExpressionSyntax expression)
+    private static bool HasDoNotValidateCall(InvocationExpressionSyntax forSourceMemberInvocation)
     {
-        return expression switch
+        if (forSourceMemberInvocation.ArgumentList.Arguments.Count <= 1)
         {
-            SimpleLambdaExpressionSyntax simpleLambda when simpleLambda.Body is MemberAccessExpressionSyntax memberAccess =>
-                memberAccess.Name.Identifier.ValueText,
-            ParenthesizedLambdaExpressionSyntax parenthesizedLambda
-                when parenthesizedLambda.Body is MemberAccessExpressionSyntax memberAccess =>
-                memberAccess.Name.Identifier.ValueText,
-            MemberAccessExpressionSyntax memberAccess => memberAccess.Name.Identifier.ValueText,
-            _ => null
-        };
+            return false;
+        }
+
+        ExpressionSyntax secondArg = forSourceMemberInvocation.ArgumentList.Arguments[1].Expression;
+        return secondArg.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Any(invocation =>
+                invocation.Expression is MemberAccessExpressionSyntax memberAccess &&
+                memberAccess.Name.Identifier.ValueText == "DoNotValidate");
     }
 
     private async Task<Solution> CreateDestinationPropertyAsync(
@@ -211,10 +244,12 @@ public class AM004_MissingDestinationPropertyCodeFixProvider : AutoMapperCodeFix
         var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
         if (semanticModel == null) return document.Project.Solution;
 
-        var (sourceType, destType) = AutoMapperAnalysisHelpers.GetCreateMapTypeArguments(invocation, semanticModel);
-        if (destType == null) return document.Project.Solution;
+        if (!TryResolveMappingContext(invocation, semanticModel, out MappingAnalysisContext? mappingContext))
+        {
+            return document.Project.Solution;
+        }
 
-        return await AddPropertiesToDestinationAsync(document, destType, new[] { (propertyName, propertyType) });
+        return await AddPropertiesToDestinationAsync(document, mappingContext.DestinationType, new[] { (propertyName, propertyType) });
     }
 
     private async Task<Solution> BulkCreatePropertiesAsync(
@@ -222,27 +257,39 @@ public class AM004_MissingDestinationPropertyCodeFixProvider : AutoMapperCodeFix
         InvocationExpressionSyntax invocation,
         SemanticModel semanticModel)
     {
-        var (sourceType, destType) = AutoMapperAnalysisHelpers.GetCreateMapTypeArguments(invocation, semanticModel);
-        if (sourceType == null || destType == null) return document.Project.Solution;
-
-        if (HasCustomConstructionOrConversion(invocation))
+        if (!TryResolveMappingContext(invocation, semanticModel, out MappingAnalysisContext? mappingContext))
         {
             return document.Project.Solution;
         }
 
-        List<(string Name, string Type)> propertiesToAdd = GetUnmappedSourceProperties(invocation, sourceType, destType)
+        if (HasCustomConstructionOrConversion(
+                mappingContext.MappingInvocation,
+                semanticModel,
+                mappingContext.StopAtReverseMapBoundary))
+        {
+            return document.Project.Solution;
+        }
+
+        List<(string Name, string Type)> propertiesToAdd = GetUnmappedSourceProperties(
+                mappingContext.MappingInvocation,
+                mappingContext.SourceType,
+                mappingContext.DestinationType,
+                semanticModel,
+                mappingContext.StopAtReverseMapBoundary)
             .Select(sourceProp => (sourceProp.Name, sourceProp.Type.ToDisplayString()))
             .ToList();
 
         if (!propertiesToAdd.Any()) return document.Project.Solution;
 
-        return await AddPropertiesToDestinationAsync(document, destType, propertiesToAdd);
+        return await AddPropertiesToDestinationAsync(document, mappingContext.DestinationType, propertiesToAdd);
     }
 
     private static List<IPropertySymbol> GetUnmappedSourceProperties(
-        InvocationExpressionSyntax createMapInvocation,
+        InvocationExpressionSyntax mappingInvocation,
         ITypeSymbol sourceType,
-        ITypeSymbol destinationType)
+        ITypeSymbol destinationType,
+        SemanticModel semanticModel,
+        bool stopAtReverseMapBoundary)
     {
         IEnumerable<IPropertySymbol> sourceProperties =
             AutoMapperAnalysisHelpers.GetMappableProperties(sourceType, requireSetter: false);
@@ -258,27 +305,34 @@ public class AM004_MissingDestinationPropertyCodeFixProvider : AutoMapperCodeFix
                 continue;
             }
 
-            if (!AutoMapperAnalysisHelpers.IsBuiltInType(sourceProp.Type))
-            {
-                bool matchesFlattening = destinationProperties
-                    .Any(p => p.Name.StartsWith(sourceProp.Name, StringComparison.OrdinalIgnoreCase));
-                if (matchesFlattening)
-                {
-                    continue;
-                }
-            }
-
-            if (IsSourcePropertyHandledByCustomMapping(createMapInvocation, sourceProp.Name))
+            if (IsFlatteningMatch(sourceProp, destinationProperties))
             {
                 continue;
             }
 
-            if (IsSourcePropertyHandledByCtorParamMapping(createMapInvocation, sourceProp.Name))
+            if (IsSourcePropertyHandledByCustomMapping(
+                    mappingInvocation,
+                    sourceProp.Name,
+                    semanticModel,
+                    stopAtReverseMapBoundary))
             {
                 continue;
             }
 
-            if (IsPropertyConfiguredWithForSourceMember(createMapInvocation, sourceProp.Name))
+            if (IsSourcePropertyHandledByCtorParamMapping(
+                    mappingInvocation,
+                    sourceProp.Name,
+                    semanticModel,
+                    stopAtReverseMapBoundary))
+            {
+                continue;
+            }
+
+            if (IsSourcePropertyExplicitlyIgnored(
+                    mappingInvocation,
+                    sourceProp.Name,
+                    semanticModel,
+                    stopAtReverseMapBoundary))
             {
                 continue;
             }
@@ -290,15 +344,19 @@ public class AM004_MissingDestinationPropertyCodeFixProvider : AutoMapperCodeFix
     }
 
     private static bool IsSourcePropertyHandledByCustomMapping(
-        InvocationExpressionSyntax createMapInvocation,
-        string sourcePropertyName)
+        InvocationExpressionSyntax mappingInvocation,
+        string sourcePropertyName,
+        SemanticModel semanticModel,
+        bool stopAtReverseMapBoundary)
     {
-        IEnumerable<InvocationExpressionSyntax> forMemberCalls =
-            AutoMapperAnalysisHelpers.GetForMemberCalls(createMapInvocation);
-
-        foreach (InvocationExpressionSyntax forMember in forMemberCalls)
+        foreach (InvocationExpressionSyntax chainedInvocation in GetScopedChainInvocations(mappingInvocation, stopAtReverseMapBoundary))
         {
-            if (ForMemberReferencesSourceProperty(forMember, sourcePropertyName))
+            if (!IsAutoMapperMethodInvocation(chainedInvocation, semanticModel, "ForMember"))
+            {
+                continue;
+            }
+
+            if (ForMemberReferencesSourceProperty(chainedInvocation, sourcePropertyName))
             {
                 return true;
             }
@@ -310,12 +368,10 @@ public class AM004_MissingDestinationPropertyCodeFixProvider : AutoMapperCodeFix
     private static bool ForMemberReferencesSourceProperty(InvocationExpressionSyntax forMemberInvocation,
         string sourcePropertyName)
     {
-        foreach (ArgumentSyntax arg in forMemberInvocation.ArgumentList.Arguments)
+        // ForMember's second argument contains the mapping lambda where source usage appears.
+        if (forMemberInvocation.ArgumentList.Arguments.Count > 1)
         {
-            if (ContainsPropertyReference(arg.Expression, sourcePropertyName))
-            {
-                return true;
-            }
+            return ContainsPropertyReference(forMemberInvocation.ArgumentList.Arguments[1].Expression, sourcePropertyName);
         }
 
         return false;
@@ -334,46 +390,245 @@ public class AM004_MissingDestinationPropertyCodeFixProvider : AutoMapperCodeFix
     }
 
     private static bool IsSourcePropertyHandledByCtorParamMapping(
-        InvocationExpressionSyntax createMapInvocation,
-        string sourcePropertyName)
+        InvocationExpressionSyntax mappingInvocation,
+        string sourcePropertyName,
+        SemanticModel semanticModel,
+        bool stopAtReverseMapBoundary)
     {
-        SyntaxNode? parent = createMapInvocation.Parent;
-
-        while (parent is MemberAccessExpressionSyntax memberAccess &&
-               memberAccess.Parent is InvocationExpressionSyntax chainedInvocation)
+        foreach (InvocationExpressionSyntax chainedInvocation in GetScopedChainInvocations(mappingInvocation, stopAtReverseMapBoundary))
         {
-            if (memberAccess.Name.Identifier.ValueText == "ForCtorParam" &&
-                chainedInvocation.ArgumentList.Arguments.Count > 1)
+            if (!IsAutoMapperMethodInvocation(chainedInvocation, semanticModel, "ForCtorParam") ||
+                chainedInvocation.ArgumentList.Arguments.Count <= 1)
             {
-                ExpressionSyntax ctorMappingArg = chainedInvocation.ArgumentList.Arguments[1].Expression;
-                if (ContainsPropertyReference(ctorMappingArg, sourcePropertyName))
-                {
-                    return true;
-                }
+                continue;
             }
 
-            parent = chainedInvocation.Parent;
+            ExpressionSyntax ctorMappingArg = chainedInvocation.ArgumentList.Arguments[1].Expression;
+            if (ContainsPropertyReference(ctorMappingArg, sourcePropertyName))
+            {
+                return true;
+            }
         }
 
         return false;
     }
 
-    private static bool HasCustomConstructionOrConversion(InvocationExpressionSyntax createMapInvocation)
+    private static bool HasCustomConstructionOrConversion(
+        InvocationExpressionSyntax mappingInvocation,
+        SemanticModel semanticModel,
+        bool stopAtReverseMapBoundary)
     {
-        SyntaxNode? parent = createMapInvocation.Parent;
-
-        while (parent is MemberAccessExpressionSyntax memberAccess &&
-               memberAccess.Parent is InvocationExpressionSyntax chainedInvocation)
+        foreach (InvocationExpressionSyntax chainedInvocation in GetScopedChainInvocations(mappingInvocation, stopAtReverseMapBoundary))
         {
-            if (memberAccess.Name.Identifier.ValueText is "ConstructUsing" or "ConvertUsing")
+            if (IsAutoMapperMethodInvocation(chainedInvocation, semanticModel, "ConstructUsing") ||
+                IsAutoMapperMethodInvocation(chainedInvocation, semanticModel, "ConvertUsing"))
             {
                 return true;
             }
-
-            parent = chainedInvocation.Parent;
         }
 
         return false;
+    }
+
+    private static bool IsFlatteningMatch(
+        IPropertySymbol sourceProperty,
+        IEnumerable<IPropertySymbol> destinationProperties)
+    {
+        if (AutoMapperAnalysisHelpers.IsBuiltInType(sourceProperty.Type))
+        {
+            return false;
+        }
+
+        IEnumerable<IPropertySymbol> nestedProperties =
+            AutoMapperAnalysisHelpers.GetMappableProperties(sourceProperty.Type, requireSetter: false);
+
+        foreach (IPropertySymbol destinationProperty in destinationProperties)
+        {
+            if (!destinationProperty.Name.StartsWith(sourceProperty.Name, StringComparison.OrdinalIgnoreCase) ||
+                destinationProperty.Name.Length <= sourceProperty.Name.Length)
+            {
+                continue;
+            }
+
+            string flattenedMemberName = destinationProperty.Name.Substring(sourceProperty.Name.Length);
+            if (nestedProperties.Any(p => string.Equals(p.Name, flattenedMemberName, StringComparison.OrdinalIgnoreCase)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryResolveMappingContext(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        out MappingAnalysisContext? mappingContext)
+    {
+        mappingContext = null;
+
+        // Reverse-map diagnostic location
+        if (IsAutoMapperMethodInvocation(invocation, semanticModel, "ReverseMap"))
+        {
+            InvocationExpressionSyntax? createMapInvocation = FindCreateMapInvocation(invocation, semanticModel);
+            if (createMapInvocation == null)
+            {
+                return false;
+            }
+
+            (ITypeSymbol? sourceType, ITypeSymbol? destinationType) forwardTypes =
+                GetCreateMapTypeArguments(createMapInvocation, semanticModel);
+            if (forwardTypes.sourceType == null || forwardTypes.destinationType == null)
+            {
+                return false;
+            }
+
+            mappingContext = new MappingAnalysisContext(
+                invocation,
+                forwardTypes.destinationType,
+                forwardTypes.sourceType,
+                false);
+            return true;
+        }
+
+        // Forward-map diagnostic location
+        if (IsAutoMapperMethodInvocation(invocation, semanticModel, "CreateMap"))
+        {
+            (ITypeSymbol? sourceType, ITypeSymbol? destinationType) forwardTypes =
+                GetCreateMapTypeArguments(invocation, semanticModel);
+            if (forwardTypes.sourceType == null || forwardTypes.destinationType == null)
+            {
+                return false;
+            }
+
+            mappingContext = new MappingAnalysisContext(
+                invocation,
+                forwardTypes.sourceType,
+                forwardTypes.destinationType,
+                true);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static InvocationExpressionSyntax? FindCreateMapInvocation(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel)
+    {
+        return invocation
+            .DescendantNodesAndSelf()
+            .OfType<InvocationExpressionSyntax>()
+            .FirstOrDefault(node => IsAutoMapperMethodInvocation(node, semanticModel, "CreateMap"));
+    }
+
+    private static string? GetSelectedMemberName(ExpressionSyntax expression)
+    {
+        return expression switch
+        {
+            SimpleLambdaExpressionSyntax simpleLambda when simpleLambda.Body is MemberAccessExpressionSyntax memberAccess =>
+                memberAccess.Name.Identifier.ValueText,
+            ParenthesizedLambdaExpressionSyntax parenthesizedLambda
+                when parenthesizedLambda.Body is MemberAccessExpressionSyntax memberAccess =>
+                memberAccess.Name.Identifier.ValueText,
+            MemberAccessExpressionSyntax memberAccess => memberAccess.Name.Identifier.ValueText,
+            _ => null
+        };
+    }
+
+    private static IEnumerable<InvocationExpressionSyntax> GetScopedChainInvocations(
+        InvocationExpressionSyntax mappingInvocation,
+        bool stopAtReverseMapBoundary)
+    {
+        SyntaxNode? currentNode = mappingInvocation.Parent;
+
+        while (currentNode is MemberAccessExpressionSyntax memberAccess &&
+               memberAccess.Parent is InvocationExpressionSyntax chainedInvocation)
+        {
+            if (stopAtReverseMapBoundary && memberAccess.Name.Identifier.ValueText == "ReverseMap")
+            {
+                break;
+            }
+
+            yield return chainedInvocation;
+            currentNode = chainedInvocation.Parent;
+        }
+    }
+
+    private static bool IsAutoMapperMethodInvocation(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        string methodName)
+    {
+        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(invocation);
+        if (IsAutoMapperMethod(symbolInfo.Symbol as IMethodSymbol, methodName))
+        {
+            return true;
+        }
+
+        foreach (ISymbol candidateSymbol in symbolInfo.CandidateSymbols)
+        {
+            if (IsAutoMapperMethod(candidateSymbol as IMethodSymbol, methodName))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsAutoMapperMethod(IMethodSymbol? methodSymbol, string methodName)
+    {
+        if (methodSymbol == null || methodSymbol.Name != methodName)
+        {
+            return false;
+        }
+
+        string? namespaceName = methodSymbol.ContainingNamespace?.ToDisplayString();
+        return namespaceName == "AutoMapper" ||
+               (namespaceName?.StartsWith("AutoMapper.", StringComparison.Ordinal) ?? false);
+    }
+
+    private static (ITypeSymbol? sourceType, ITypeSymbol? destinationType) GetCreateMapTypeArguments(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel)
+    {
+        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(invocation);
+
+        if (TryGetCreateMapTypeArgumentsFromMethod(symbolInfo.Symbol as IMethodSymbol, out ITypeSymbol? sourceType,
+                out ITypeSymbol? destinationType))
+        {
+            return (sourceType, destinationType);
+        }
+
+        foreach (ISymbol candidateSymbol in symbolInfo.CandidateSymbols)
+        {
+            if (TryGetCreateMapTypeArgumentsFromMethod(candidateSymbol as IMethodSymbol, out sourceType,
+                    out destinationType))
+            {
+                return (sourceType, destinationType);
+            }
+        }
+
+        return AutoMapperAnalysisHelpers.GetCreateMapTypeArguments(invocation, semanticModel);
+    }
+
+    private static bool TryGetCreateMapTypeArgumentsFromMethod(
+        IMethodSymbol? methodSymbol,
+        out ITypeSymbol? sourceType,
+        out ITypeSymbol? destinationType)
+    {
+        sourceType = null;
+        destinationType = null;
+
+        if (methodSymbol?.TypeArguments.Length != 2)
+        {
+            return false;
+        }
+
+        sourceType = methodSymbol.TypeArguments[0];
+        destinationType = methodSymbol.TypeArguments[1];
+        return true;
     }
 
     private async Task<Solution> AddPropertiesToDestinationAsync(

--- a/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM004_MissingDestinationPropertyCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM004_MissingDestinationPropertyCodeFixProvider.cs
@@ -189,7 +189,10 @@ public class AM004_MissingDestinationPropertyCodeFixProvider : AutoMapperCodeFix
         SemanticModel semanticModel,
         bool stopAtReverseMapBoundary)
     {
-        foreach (InvocationExpressionSyntax chainedInvocation in GetScopedChainInvocations(mappingInvocation, stopAtReverseMapBoundary))
+        foreach (InvocationExpressionSyntax chainedInvocation in GetScopedChainInvocations(
+                     mappingInvocation,
+                     semanticModel,
+                     stopAtReverseMapBoundary))
         {
             if (!IsAutoMapperMethodInvocation(chainedInvocation, semanticModel, "ForSourceMember"))
             {
@@ -349,7 +352,10 @@ public class AM004_MissingDestinationPropertyCodeFixProvider : AutoMapperCodeFix
         SemanticModel semanticModel,
         bool stopAtReverseMapBoundary)
     {
-        foreach (InvocationExpressionSyntax chainedInvocation in GetScopedChainInvocations(mappingInvocation, stopAtReverseMapBoundary))
+        foreach (InvocationExpressionSyntax chainedInvocation in GetScopedChainInvocations(
+                     mappingInvocation,
+                     semanticModel,
+                     stopAtReverseMapBoundary))
         {
             if (!IsAutoMapperMethodInvocation(chainedInvocation, semanticModel, "ForMember"))
             {
@@ -395,7 +401,10 @@ public class AM004_MissingDestinationPropertyCodeFixProvider : AutoMapperCodeFix
         SemanticModel semanticModel,
         bool stopAtReverseMapBoundary)
     {
-        foreach (InvocationExpressionSyntax chainedInvocation in GetScopedChainInvocations(mappingInvocation, stopAtReverseMapBoundary))
+        foreach (InvocationExpressionSyntax chainedInvocation in GetScopedChainInvocations(
+                     mappingInvocation,
+                     semanticModel,
+                     stopAtReverseMapBoundary))
         {
             if (!IsAutoMapperMethodInvocation(chainedInvocation, semanticModel, "ForCtorParam") ||
                 chainedInvocation.ArgumentList.Arguments.Count <= 1)
@@ -418,7 +427,10 @@ public class AM004_MissingDestinationPropertyCodeFixProvider : AutoMapperCodeFix
         SemanticModel semanticModel,
         bool stopAtReverseMapBoundary)
     {
-        foreach (InvocationExpressionSyntax chainedInvocation in GetScopedChainInvocations(mappingInvocation, stopAtReverseMapBoundary))
+        foreach (InvocationExpressionSyntax chainedInvocation in GetScopedChainInvocations(
+                     mappingInvocation,
+                     semanticModel,
+                     stopAtReverseMapBoundary))
         {
             if (IsAutoMapperMethodInvocation(chainedInvocation, semanticModel, "ConstructUsing") ||
                 IsAutoMapperMethodInvocation(chainedInvocation, semanticModel, "ConvertUsing"))
@@ -538,6 +550,7 @@ public class AM004_MissingDestinationPropertyCodeFixProvider : AutoMapperCodeFix
 
     private static IEnumerable<InvocationExpressionSyntax> GetScopedChainInvocations(
         InvocationExpressionSyntax mappingInvocation,
+        SemanticModel semanticModel,
         bool stopAtReverseMapBoundary)
     {
         SyntaxNode? currentNode = mappingInvocation.Parent;
@@ -545,7 +558,8 @@ public class AM004_MissingDestinationPropertyCodeFixProvider : AutoMapperCodeFix
         while (currentNode is MemberAccessExpressionSyntax memberAccess &&
                memberAccess.Parent is InvocationExpressionSyntax chainedInvocation)
         {
-            if (stopAtReverseMapBoundary && memberAccess.Name.Identifier.ValueText == "ReverseMap")
+            if (stopAtReverseMapBoundary &&
+                IsAutoMapperMethodInvocation(chainedInvocation, semanticModel, "ReverseMap"))
             {
                 break;
             }

--- a/tests/AutoMapperAnalyzer.Tests/DataIntegrity/AM004_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/DataIntegrity/AM004_CodeFixTests.cs
@@ -673,4 +673,156 @@ public class AM004_CodeFixTests
                 null,
                 1);
     }
+
+    [Fact]
+    public async Task AM004_BulkIgnore_ShouldHandleReverseMapMissingSourceProperty()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public string Name { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public string Name { get; set; }
+                                        public string Description { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>().ReverseMap();
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string expectedFixedCode = """
+                                         using AutoMapper;
+
+                                         namespace TestNamespace
+                                         {
+                                             public class Source
+                                             {
+                                                 public string Name { get; set; }
+                                             }
+
+                                             public class Destination
+                                             {
+                                                 public string Name { get; set; }
+                                                 public string Description { get; set; }
+                                             }
+
+                                             public class TestProfile : Profile
+                                             {
+                                                 public TestProfile()
+                                                 {
+                                                     CreateMap<Source, Destination>().ReverseMap().ForSourceMember(src => src.Description, opt => opt.DoNotValidate());
+                                                 }
+                                             }
+                                         }
+                                         """;
+
+        await CodeFixVerifier<AM004_MissingDestinationPropertyAnalyzer, AM004_MissingDestinationPropertyCodeFixProvider>
+            .VerifyFixAsync(
+                testCode,
+                new[]
+                {
+                    new DiagnosticResult(AM004_MissingDestinationPropertyAnalyzer.MissingDestinationPropertyRule)
+                        .WithLocation(20, 13)
+                        .WithArguments("Description")
+                },
+                expectedFixedCode,
+                0, // Index 0 = "Ignore all unmapped source properties"
+                null,
+                1);
+    }
+
+    [Fact]
+    public async Task AM004_BulkIgnore_ShouldNotIgnoreForCtorParamMappedSourceProperty()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public string RawName { get; set; }
+                                        public string ExtraData { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public string Name { get; }
+
+                                        public Destination(string name)
+                                        {
+                                            Name = name;
+                                        }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>()
+                                                .ForCtorParam("name", opt => opt.MapFrom(src => src.RawName));
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string expectedFixedCode = """
+                                         using AutoMapper;
+
+                                         namespace TestNamespace
+                                         {
+                                             public class Source
+                                             {
+                                                 public string RawName { get; set; }
+                                                 public string ExtraData { get; set; }
+                                             }
+
+                                             public class Destination
+                                             {
+                                                 public string Name { get; }
+
+                                                 public Destination(string name)
+                                                 {
+                                                     Name = name;
+                                                 }
+                                             }
+
+                                             public class TestProfile : Profile
+                                             {
+                                                 public TestProfile()
+                                                 {
+                                                     CreateMap<Source, Destination>()
+                                         .ForSourceMember(src => src.ExtraData, opt => opt.DoNotValidate()).ForCtorParam("name", opt => opt.MapFrom(src => src.RawName));
+                                                 }
+                                             }
+                                         }
+                                         """;
+
+        await CodeFixVerifier<AM004_MissingDestinationPropertyAnalyzer, AM004_MissingDestinationPropertyCodeFixProvider>
+            .VerifyFixAsync(
+                testCode,
+                new[]
+                {
+                    new DiagnosticResult(AM004_MissingDestinationPropertyAnalyzer.MissingDestinationPropertyRule)
+                        .WithLocation(25, 13)
+                        .WithArguments("ExtraData")
+                },
+                expectedFixedCode,
+                0, // Index 0 = "Ignore all unmapped source properties"
+                null,
+                1);
+    }
 }

--- a/tests/AutoMapperAnalyzer.Tests/DataIntegrity/AM004_MissingDestinationPropertyTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/DataIntegrity/AM004_MissingDestinationPropertyTests.cs
@@ -726,6 +726,49 @@ public class AM004_MissingDestinationPropertyTests
     }
 
     [Fact]
+    public async Task AM004_ShouldNotTreatNonAutoMapperReverseMapAsBoundary()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public static class MappingExtensions
+                                    {
+                                        public static IMappingExpression<TSource, TDestination> ReverseMap<TSource, TDestination>(
+                                            this IMappingExpression<TSource, TDestination> expression,
+                                            int marker) => expression;
+                                    }
+
+                                    public class Source
+                                    {
+                                        public string FirstName { get; set; }
+                                        public string LastName { get; set; }
+                                        public string MiddleName { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public string FullName { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>()
+                                                .ReverseMap(1)
+                                                .ForMember(dest => dest.FullName, opt => opt.MapFrom(src =>
+                                                    src.FirstName + " " + src.LastName + " " + src.MiddleName));
+                                        }
+                                    }
+                                }
+                                """;
+
+        await AnalyzerVerifier<AM004_MissingDestinationPropertyAnalyzer>.VerifyAnalyzerAsync(testCode);
+    }
+
+    [Fact]
     public async Task AM004_ShouldReportDiagnostic_WhenFlatteningPrefixMatchesButNestedMemberDoesNotExist()
     {
         const string testCode = """


### PR DESCRIPTION
## Summary
- tighten AM004 detection to AutoMapper `CreateMap`/mapping APIs only (including candidate symbol fallback)
- make analyzer direction-aware around `ReverseMap()` so forward/reverse checks only inspect relevant chain segments
- reduce false positives by only considering source usage in mapping lambdas and validating flattening against real nested source members
- make AM004 bulk/per-property fixes reverse-map aware and avoid ignoring ctor-param mapped source properties
- add targeted AM004 analyzer and code-fix regression tests for these scenarios

## Validation
- dotnet test --nologo -v q --filter "FullyQualifiedName~AM004_"
- dotnet test --nologo -v q
