### PR TITLE
Enforce analyzer ownership boundaries and harden fixer UX

### DIFF
--- a/automapper-analyser.sln
+++ b/automapper-analyser.sln
@@ -30,9 +30,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AnalyzerVerifier", "tools\AnalyzerVerifier\AnalyzerVerifier.csproj", "{2B78D0B8-AB15-465E-BF5B-70C036FB7CC2}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{0A62895F-7BE4-4745-BA85-B73511F6BFD7}"
-	ProjectSection(SolutionItems) = preProject
-		samples\AutoMapperAnalyzer.Samples\AutoMapperAnalyzer.Samples.csproj = samples\AutoMapperAnalyzer.Samples\AutoMapperAnalyzer.Samples.csproj
-	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AutoMapperAnalyzer.Samples", "samples\AutoMapperAnalyzer.Samples\AutoMapperAnalyzer.Samples.csproj", "{34FC1BBF-D072-43CB-AE3E-765D600FCCD1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -92,6 +91,18 @@ Global
 		{2B78D0B8-AB15-465E-BF5B-70C036FB7CC2}.Release|x64.Build.0 = Release|Any CPU
 		{2B78D0B8-AB15-465E-BF5B-70C036FB7CC2}.Release|x86.ActiveCfg = Release|Any CPU
 		{2B78D0B8-AB15-465E-BF5B-70C036FB7CC2}.Release|x86.Build.0 = Release|Any CPU
+		{34FC1BBF-D072-43CB-AE3E-765D600FCCD1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{34FC1BBF-D072-43CB-AE3E-765D600FCCD1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{34FC1BBF-D072-43CB-AE3E-765D600FCCD1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{34FC1BBF-D072-43CB-AE3E-765D600FCCD1}.Debug|x64.Build.0 = Debug|Any CPU
+		{34FC1BBF-D072-43CB-AE3E-765D600FCCD1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{34FC1BBF-D072-43CB-AE3E-765D600FCCD1}.Debug|x86.Build.0 = Debug|Any CPU
+		{34FC1BBF-D072-43CB-AE3E-765D600FCCD1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{34FC1BBF-D072-43CB-AE3E-765D600FCCD1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{34FC1BBF-D072-43CB-AE3E-765D600FCCD1}.Release|x64.ActiveCfg = Release|Any CPU
+		{34FC1BBF-D072-43CB-AE3E-765D600FCCD1}.Release|x64.Build.0 = Release|Any CPU
+		{34FC1BBF-D072-43CB-AE3E-765D600FCCD1}.Release|x86.ActiveCfg = Release|Any CPU
+		{34FC1BBF-D072-43CB-AE3E-765D600FCCD1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -101,5 +112,6 @@ Global
 		{FA5DDEE5-6041-4B1C-933A-CA3CB640C4C8} = {072E37BE-1DC8-4DD8-B2D6-E162AB4EE8CF}
 		{F42216BD-C15C-41F4-B0F0-F477121A1C1E} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{2B78D0B8-AB15-465E-BF5B-70C036FB7CC2} = {AFB1397A-2266-402D-A069-0A261F73CEB3}
+		{34FC1BBF-D072-43CB-AE3E-765D600FCCD1} = {0A62895F-7BE4-4745-BA85-B73511F6BFD7}
 	EndGlobalSection
 EndGlobal

--- a/docs/ANALYZER_REVIEW_TRACKER.md
+++ b/docs/ANALYZER_REVIEW_TRACKER.md
@@ -25,6 +25,7 @@ Tracks analyzer-by-analyzer improvement passes focused on false positives, contr
 | AM004 (2nd pass) | Data Integrity | [#61](https://github.com/georgepwall1991/automapper-analyser/pull/61) | [v2.22.0](https://github.com/georgepwall1991/automapper-analyser/releases/tag/v2.22.0) | Tightened AutoMapper symbol gating, direction-scoped forward/reverse analysis, stricter flattening/member-source detection, reverse-map aware bulk fixer context, and semantic `ReverseMap` boundary handling with new regression coverage. |
 | Project Audit | All | main | v2.23.0 | Consolidated ~42 duplicate helper methods into shared helpers (-538 LOC), added AM006 code fix provider with 6 tests, synced version/docs across project. |
 | Bug Fixes + Coverage | AM004, AM006, AM011 | main | v2.24.0 | Fixed AM011 chunked bulk fix placeholder bug, fixed AM004 FindCreateMapInvocation tree traversal for ReverseMap, added 32 new tests (FuzzyMatchHelper, AutoMapperAnalysisHelpers, ReverseMap code fix regression). |
+| Ownership + Fixer Hardening | AM003, AM005, AM011, AM020, AM021, AM022, AM030, AM031 | main | TBD | Enforced single-owner overlap policy (AM003 vs AM021, removed property-level AM030 overlap), added strict symbol-only AutoMapper gating, implemented AM030 unused-converter reporting, and hardened fixers to executable-first actions (AM005 rename/explicit map, AM011 placeholder removal + legacy parser fallback, AM031 safe fixes only). |
 
 ## In Progress
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -70,6 +70,21 @@ Diagnostic Results (warnings/errors)
 Code Fix Providers (optional fixes)
 ```
 
+### Semantic Gating and Ownership
+
+Recent analyzer passes enforce two architectural rules across mapping analyzers:
+
+1. **Strict semantic AutoMapper gating**
+   - CreateMap/ForMember/ConvertUsing checks are symbol-based (`MappingChainAnalysisHelper.IsAutoMapperMethodInvocation`).
+   - Name/text heuristics (`mapper`, `cfg`, `config`) are intentionally not used.
+   - This reduces false positives from lookalike APIs.
+
+2. **Single-owner diagnostics for overlap-prone patterns**
+   - `AM003` owns collection container mismatches.
+   - `AM021` owns collection element mismatches (when containers are otherwise compatible).
+   - `AM030` owns converter-quality diagnostics only (invalid implementation, null handling, unused converter).
+   - Property-level conversion absence is intentionally handled by `AM001`/`AM020`/`AM021`, not `AM030`.
+
 ### Diagnostic Lifecycle
 
 1. **Registration**: Analyzers register callbacks for specific syntax kinds

--- a/docs/TEST_LIMITATIONS.md
+++ b/docs/TEST_LIMITATIONS.md
@@ -1,0 +1,15 @@
+# Test Limitations
+
+This document tracks known test limitations referenced by `[Fact(Skip = ...)]` messages.
+
+1. **Field/dependency type resolution in analyzer tests**
+   Some scenarios that rely on injected service fields (for example `_db`, `_service`) are difficult to model reliably in current analyzer test harness setups and can produce unstable symbol resolution.
+
+2. **Code-fix context span/registration constraints**
+   Some Roslyn testing combinations reject otherwise valid code-fix registrations when diagnostics are reported on larger spans or chain expressions. These scenarios are avoided in current integration tests until harness behavior is standardized.
+
+3. **AM001 advanced expression-tree conversion patterns**
+   Certain string-to-numeric conversion patterns and multi-diagnostic coordination paths are not consistently fixable in a deterministic single-pass code-fix test; those cases remain skipped until analyzer/fixer coordination is refactored.
+
+4. **Invalid-converter and compiler-error co-reporting**
+   Tests that intentionally create invalid converter implementations may emit both analyzer diagnostics and compiler errors, requiring explicit dual-diagnostic expectations and careful harness setup.

--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM020_NestedObjectMappingAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM020_NestedObjectMappingAnalyzer.cs
@@ -41,8 +41,8 @@ public class AM020_NestedObjectMappingAnalyzer : DiagnosticAnalyzer
     {
         var invocationExpr = (InvocationExpressionSyntax)context.Node;
 
-        // Check if this is a CreateMap<TSource, TDestination>() call
-        if (!AutoMapperAnalysisHelpers.IsCreateMapInvocation(invocationExpr, context.SemanticModel))
+        // Ensure strict AutoMapper semantic matching to avoid lookalike false positives.
+        if (!MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(invocationExpr, context.SemanticModel, "CreateMap"))
         {
             return;
         }

--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM022_InfiniteRecursionAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM022_InfiniteRecursionAnalyzer.cs
@@ -58,8 +58,8 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // Check if this is a CreateMap<TSource, TDestination>() call
-        if (!AutoMapperAnalysisHelpers.IsCreateMapInvocation(invocationExpr, context.SemanticModel))
+        // Ensure strict AutoMapper semantic matching to avoid lookalike false positives.
+        if (!MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(invocationExpr, context.SemanticModel, "CreateMap"))
         {
             return;
         }

--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM030_CustomTypeConverterCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM030_CustomTypeConverterCodeFixProvider.cs
@@ -1,27 +1,22 @@
 using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
 using AutoMapperAnalyzer.Analyzers.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 
 namespace AutoMapperAnalyzer.Analyzers.ComplexMappings;
 
 /// <summary>
-///     Code fix provider for AM030 diagnostic - Custom Type Converter issues.
-///     Provides fixes for missing ConvertUsing configurations and invalid converter implementations.
+///     Code fix provider for AM030 diagnostics.
+///     Provides executable fixes for converter-quality diagnostics.
 /// </summary>
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AM030_CustomTypeConverterCodeFixProvider))]
 [Shared]
 public class AM030_CustomTypeConverterCodeFixProvider : AutoMapperCodeFixProviderBase
 {
-    private const string IssueTypePropertyName = "IssueType";
-    private const string MissingConvertUsingIssueType = "MissingConvertUsing";
-
     /// <summary>
     ///     Gets the diagnostic IDs that this code fix provider can fix.
     /// </summary>
@@ -30,8 +25,6 @@ public class AM030_CustomTypeConverterCodeFixProvider : AutoMapperCodeFixProvide
     /// <summary>
     ///     Registers code fixes for the specified context.
     /// </summary>
-    /// <param name="context">The code fix context.</param>
-    /// <returns>A task representing the asynchronous operation.</returns>
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
         var operationContext = await GetOperationContextAsync(context);
@@ -40,241 +33,101 @@ public class AM030_CustomTypeConverterCodeFixProvider : AutoMapperCodeFixProvide
             return;
         }
 
-        foreach (Diagnostic? diagnostic in context.Diagnostics)
+        foreach (Diagnostic diagnostic in context.Diagnostics)
         {
-            if (diagnostic.Id != "AM030")
+            if (diagnostic.Descriptor != AM030_CustomTypeConverterAnalyzer.ConverterNullHandlingIssueRule)
             {
                 continue;
             }
 
-            if (!diagnostic.Properties.TryGetValue(IssueTypePropertyName, out string? issueType) ||
-                issueType != MissingConvertUsingIssueType)
+            SyntaxNode node = operationContext.Root.FindNode(diagnostic.Location.SourceSpan);
+            MethodDeclarationSyntax? convertMethod = node.FirstAncestorOrSelf<MethodDeclarationSyntax>();
+            if (convertMethod == null)
             {
                 continue;
             }
 
-            if (!diagnostic.Properties.TryGetValue("PropertyName", out string? propertyName) ||
-                string.IsNullOrEmpty(propertyName))
+            if (convertMethod.ParameterList.Parameters.Count == 0)
             {
                 continue;
             }
 
-            TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
-            SyntaxNode node = operationContext.Root.FindNode(diagnosticSpan);
-
-            if (node.FirstAncestorOrSelf<InvocationExpressionSyntax>() is not { } invocation)
-            {
-                continue;
-            }
-
-            RegisterMissingConvertUsingFixes(context, operationContext.Root, invocation, propertyName!, diagnostic);
+            string sourceParameterName = convertMethod.ParameterList.Parameters[0].Identifier.ValueText;
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    $"Add null guard for '{sourceParameterName}'",
+                    cancellationToken => AddNullGuardAsync(
+                        context.Document,
+                        operationContext.Root,
+                        convertMethod,
+                        sourceParameterName,
+                        cancellationToken),
+                    $"AM030_AddNullGuard_{sourceParameterName}"),
+                diagnostic);
         }
     }
 
-    private void RegisterMissingConvertUsingFixes(CodeFixContext context, SyntaxNode root,
-        InvocationExpressionSyntax invocation, string propertyName, Diagnostic diagnostic)
-    {
-        // Fix 1: Add ForMember with ConvertUsing for string to primitive conversions
-        if (diagnostic.Properties.TryGetValue("ConverterType", out string? converterType) &&
-            converterType!.Contains("String") && IsStringToPrimitiveConversion(converterType))
-        {
-            var lambdaFix = CodeAction.Create(
-                $"Add ConvertUsing with lambda for '{propertyName}'",
-                cancellationToken =>
-                {
-                    string conversion = GetStringToPrimitiveConversion(converterType!);
-                    InvocationExpressionSyntax newInvocation = CodeFixSyntaxHelper.CreateForMemberWithMapFrom(
-                        invocation,
-                        propertyName,
-                        $"{conversion}(src.{propertyName})");
-                    SyntaxNode newRoot = root.ReplaceNode(invocation, newInvocation);
-                    return Task.FromResult(context.Document.WithSyntaxRoot(newRoot));
-                },
-                $"ConvertUsingLambda_{propertyName}");
-
-            context.RegisterCodeFix(lambdaFix, diagnostic);
-        }
-
-        // Fix 2: Generate and use custom value converter class
-        var generateConverterFix = CodeAction.Create(
-            $"Generate and use ValueConverter for '{propertyName}'",
-            cancellationToken => GenerateValueConverterClassAsync(context.Document, invocation, propertyName, cancellationToken),
-            $"GenerateValueConverter_{propertyName}");
-
-        context.RegisterCodeFix(generateConverterFix, diagnostic);
-
-        // Fix 3: Ignore the property if conversion is too complex
-        var ignoreFix = CodeAction.Create(
-            $"Ignore property '{propertyName}' (conversion too complex)",
-            cancellationToken =>
-            {
-                InvocationExpressionSyntax newInvocation =
-                    CodeFixSyntaxHelper.CreateForMemberWithIgnore(invocation, propertyName);
-                SyntaxNode newRoot = root.ReplaceNode(invocation, newInvocation);
-                return Task.FromResult(context.Document.WithSyntaxRoot(newRoot));
-            },
-            $"Ignore_{propertyName}");
-
-        context.RegisterCodeFix(ignoreFix, diagnostic);
-    }
-
-    private async Task<Solution> GenerateValueConverterClassAsync(
+    private async Task<Document> AddNullGuardAsync(
         Document document,
-        InvocationExpressionSyntax invocation,
-        string propertyName,
+        SyntaxNode root,
+        MethodDeclarationSyntax convertMethod,
+        string sourceParameterName,
         CancellationToken cancellationToken)
     {
-        var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
-        if (semanticModel == null) return document.Project.Solution;
+        StatementSyntax guardStatement = SyntaxFactory.ParseStatement(
+            $"if ({sourceParameterName} == null) throw new ArgumentNullException(nameof({sourceParameterName}));")
+            .WithTrailingTrivia(SyntaxFactory.ElasticLineFeed);
 
-        var (sourceType, destType) = AutoMapperAnalysisHelpers.GetCreateMapTypeArguments(invocation, semanticModel);
-        if (sourceType == null || destType == null) return document.Project.Solution;
+        MethodDeclarationSyntax updatedMethod;
 
-        var sourceProp = AutoMapperAnalysisHelpers.GetMappableProperties(sourceType).FirstOrDefault(p => p.Name == propertyName);
-        var destProp = AutoMapperAnalysisHelpers.GetMappableProperties(destType).FirstOrDefault(p => p.Name == propertyName);
+        if (convertMethod.Body != null)
+        {
+            StatementSyntax formattedGuard = guardStatement;
+            StatementSyntax? firstStatement = convertMethod.Body.Statements.FirstOrDefault();
+            if (firstStatement != null)
+            {
+                formattedGuard = formattedGuard.WithLeadingTrivia(firstStatement.GetLeadingTrivia());
+            }
 
-        // If we can't find properties, fallback to object
-        string sourcePropType = sourceProp?.Type.ToDisplayString() ?? "object";
-        string destPropType = destProp?.Type.ToDisplayString() ?? "object";
-        string converterName = $"{propertyName}Converter";
+            BlockSyntax updatedBody = convertMethod.Body.WithStatements(convertMethod.Body.Statements.Insert(0, formattedGuard));
+            updatedMethod = convertMethod.WithBody(updatedBody);
+        }
+        else if (convertMethod.ExpressionBody != null)
+        {
+            ReturnStatementSyntax returnStatement = SyntaxFactory.ReturnStatement(convertMethod.ExpressionBody.Expression);
+            BlockSyntax newBody = SyntaxFactory.Block(guardStatement, returnStatement);
 
-        // 1. Create the converter class syntax
-        var converterClass = SyntaxFactory.ClassDeclaration(converterName)
-            .WithModifiers(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PrivateKeyword)))
-            .WithBaseList(SyntaxFactory.BaseList(SyntaxFactory.SingletonSeparatedList<BaseTypeSyntax>(
-                SyntaxFactory.SimpleBaseType(SyntaxFactory.ParseTypeName($"IValueConverter<{sourcePropType}, {destPropType}>")))))
-            .WithMembers(SyntaxFactory.SingletonList<MemberDeclarationSyntax>(
-                SyntaxFactory.MethodDeclaration(SyntaxFactory.ParseTypeName(destPropType), "Convert")
-                    .WithModifiers(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PublicKeyword)))
-                    .WithParameterList(SyntaxFactory.ParameterList(SyntaxFactory.SeparatedList(new[] {
-                        SyntaxFactory.Parameter(SyntaxFactory.Identifier("sourceMember")).WithType(SyntaxFactory.ParseTypeName(sourcePropType)),
-                        SyntaxFactory.Parameter(SyntaxFactory.Identifier("context")).WithType(SyntaxFactory.ParseTypeName("ResolutionContext"))
-                    })))
-                    .WithBody(SyntaxFactory.Block(
-                        SyntaxFactory.ThrowStatement(
-                            SyntaxFactory.ObjectCreationExpression(SyntaxFactory.ParseTypeName("NotImplementedException"))
-                                .WithArgumentList(SyntaxFactory.ArgumentList()))))
-            ));
+            updatedMethod = convertMethod
+                .WithBody(newBody)
+                .WithExpressionBody(null)
+                .WithSemicolonToken(default);
+        }
+        else
+        {
+            return document;
+        }
 
-        // 2. Add class to the Profile class
-        var root = await document.GetSyntaxRootAsync(cancellationToken);
-        var profileClass = invocation.Ancestors().OfType<ClassDeclarationSyntax>().FirstOrDefault();
-        if (profileClass == null || root == null) return document.Project.Solution;
+        SyntaxNode newRoot = root.ReplaceNode(convertMethod, updatedMethod);
+        if (newRoot is CompilationUnitSyntax compilationUnit)
+        {
+            newRoot = AddUsingIfMissing(compilationUnit, "System");
+        }
 
-        var newProfileClass = profileClass.AddMembers(converterClass);
-        var newRoot = root.ReplaceNode(profileClass, newProfileClass);
-
-        // 3. Update the mapping to use the new converter
-        // We need to update the invocation in the NEW root
-        // invocation might have been replaced if we updated profileClass? No, ReplaceNode returns new root.
-        // But invocation is a node in the OLD root. We need to find it in the new root.
-        // Or we can do both changes at once? No, easier to chain.
-        
-        // Actually, updating the invocation is easier first, then adding member?
-        // No, `ReplaceNode` creates a new tree.
-        
-        // Let's do it in one go by tracking nodes? Or just replace invocation in the newRoot.
-        // Since we replaced `profileClass`, `invocation` is gone in `newRoot`.
-        // We can find the equivalent node in `newRoot` via `profileClass` location?
-        // Or use `TrackNodes`.
-        
-        root = root.TrackNodes(invocation, profileClass);
-        newProfileClass = root.GetCurrentNode(profileClass)!.AddMembers(converterClass);
-        newRoot = root.ReplaceNode(root.GetCurrentNode(profileClass)!, newProfileClass);
-        
-        var currentInvocation = newRoot.GetCurrentNode(invocation);
-        
-        // Create .ForMember(d => d.Prop, opt => opt.ConvertUsing(new Converter(), src => src.Prop))
-        var newInvocation = SyntaxFactory.InvocationExpression(
-                SyntaxFactory.MemberAccessExpression(
-                    SyntaxKind.SimpleMemberAccessExpression,
-                    currentInvocation!,
-                    SyntaxFactory.IdentifierName("ForMember")))
-            .WithArgumentList(
-                SyntaxFactory.ArgumentList(
-                    SyntaxFactory.SeparatedList(new[]
-                    {
-                        // dest => dest.PropertyName
-                        SyntaxFactory.Argument(
-                            SyntaxFactory.SimpleLambdaExpression(
-                                SyntaxFactory.Parameter(SyntaxFactory.Identifier("dest")),
-                                SyntaxFactory.MemberAccessExpression(
-                                    SyntaxKind.SimpleMemberAccessExpression,
-                                    SyntaxFactory.IdentifierName("dest"),
-                                    SyntaxFactory.IdentifierName(propertyName)))),
-                        // opt => opt.ConvertUsing(new Converter(), src => src.PropertyName)
-                        SyntaxFactory.Argument(
-                            SyntaxFactory.SimpleLambdaExpression(
-                                SyntaxFactory.Parameter(SyntaxFactory.Identifier("opt")),
-                                SyntaxFactory.InvocationExpression(
-                                    SyntaxFactory.MemberAccessExpression(
-                                        SyntaxKind.SimpleMemberAccessExpression,
-                                        SyntaxFactory.IdentifierName("opt"),
-                                        SyntaxFactory.IdentifierName("ConvertUsing")))
-                                    .WithArgumentList(
-                                        SyntaxFactory.ArgumentList(
-                                            SyntaxFactory.SeparatedList(new[] {
-                                                SyntaxFactory.Argument(
-                                                    SyntaxFactory.ObjectCreationExpression(SyntaxFactory.IdentifierName(converterName))
-                                                        .WithArgumentList(SyntaxFactory.ArgumentList())),
-                                                SyntaxFactory.Argument(
-                                                    SyntaxFactory.SimpleLambdaExpression(
-                                                        SyntaxFactory.Parameter(SyntaxFactory.Identifier("src")),
-                                                        SyntaxFactory.MemberAccessExpression(
-                                                            SyntaxKind.SimpleMemberAccessExpression,
-                                                            SyntaxFactory.IdentifierName("src"),
-                                                            SyntaxFactory.IdentifierName(propertyName))))
-                                            })))
-                            ))
-                    })));
-
-        newRoot = newRoot.ReplaceNode(currentInvocation!, newInvocation);
-        
-        return document.Project.Solution.WithDocumentSyntaxRoot(document.Id, newRoot);
+        return document.WithSyntaxRoot(newRoot);
     }
 
-    private bool IsStringToPrimitiveConversion(string converterType)
+    private static CompilationUnitSyntax AddUsingIfMissing(CompilationUnitSyntax root, string namespaceName)
     {
-        return converterType.Contains("Int") ||
-               converterType.Contains("Double") ||
-               converterType.Contains("Decimal") ||
-               converterType.Contains("Boolean") ||
-               converterType.Contains("DateTime") ||
-               converterType.Contains("Guid");
-    }
-
-    private string GetStringToPrimitiveConversion(string converterType)
-    {
-        if (converterType.Contains("Int"))
+        if (root.Usings.Any(u =>
+                u.Name != null &&
+                string.Equals(u.Name.ToString(), namespaceName, StringComparison.Ordinal)))
         {
-            return "Convert.ToInt32";
+            return root;
         }
 
-        if (converterType.Contains("Double"))
-        {
-            return "Convert.ToDouble";
-        }
+        UsingDirectiveSyntax usingDirective = SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(namespaceName))
+            .WithTrailingTrivia(SyntaxFactory.ElasticLineFeed);
 
-        if (converterType.Contains("Decimal"))
-        {
-            return "Convert.ToDecimal";
-        }
-
-        if (converterType.Contains("Boolean"))
-        {
-            return "Convert.ToBoolean";
-        }
-
-        if (converterType.Contains("DateTime"))
-        {
-            return "DateTime.Parse"; // Convert.ToDateTime also exists but Parse is idiomatic
-        }
-
-        if (converterType.Contains("Guid"))
-        {
-            return "Guid.Parse";
-        }
-
-        return "Convert.ChangeType";
+        return root.AddUsings(usingDirective);
     }
 }

--- a/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM005_CaseSensitivityMismatchAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM005_CaseSensitivityMismatchAnalyzer.cs
@@ -43,8 +43,8 @@ public class AM005_CaseSensitivityMismatchAnalyzer : DiagnosticAnalyzer
     {
         var invocationExpr = (InvocationExpressionSyntax)context.Node;
 
-        // Check if this is a CreateMap<TSource, TDestination>() call
-        if (!AutoMapperAnalysisHelpers.IsCreateMapInvocation(invocationExpr, context.SemanticModel))
+        // Ensure strict AutoMapper semantic matching to avoid lookalike false positives.
+        if (!MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(invocationExpr, context.SemanticModel, "CreateMap"))
         {
             return;
         }

--- a/src/AutoMapperAnalyzer.Analyzers/Helpers/BulkFixConfigurationParser.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Helpers/BulkFixConfigurationParser.cs
@@ -227,9 +227,10 @@ public class BulkFixConfigurationParser
             "DEFAULT" => BulkFixAction.Default,
             "IGNORE" => BulkFixAction.Ignore,
             "FUZZY-MATCH" or "FUZZY" => BulkFixAction.FuzzyMatch,
-            "TODO" => BulkFixAction.Todo,
-            "CUSTOM" => BulkFixAction.Custom,
-            "NULLABLE" => BulkFixAction.Nullable,
+            // Legacy compatibility: map retired placeholder actions to executable default behavior.
+            "TODO" => BulkFixAction.Default,
+            "CUSTOM" => BulkFixAction.Default,
+            "NULLABLE" => BulkFixAction.Default,
             _ => null
         };
     }
@@ -287,9 +288,6 @@ public class BulkFixConfigurationParser
         lines.Add(" * DEFAULT       - Map to default value (0, \"\", false, null, etc.)");
         lines.Add(" * FUZZY         - Map to similar source property (specify in Parameter)");
         lines.Add(" * IGNORE        - Add .Ignore() - property not needed");
-        lines.Add(" * TODO          - Add .Ignore() with TODO comment");
-        lines.Add(" * CUSTOM        - Add .MapFrom with TODO for custom logic");
-        lines.Add(" * NULLABLE      - Make destination property nullable (modifies dest class)");
         lines.Add(" *");
         lines.Add(" * === CHUNKING ===");
         lines.Add(" * CHUNKING: [YES/NO]: NO");
@@ -308,9 +306,9 @@ public class BulkFixConfigurationParser
             BulkFixAction.Default => "DEFAULT",
             BulkFixAction.Ignore => "IGNORE",
             BulkFixAction.FuzzyMatch => "FUZZY-MATCH",
-            BulkFixAction.Todo => "TODO",
-            BulkFixAction.Custom => "CUSTOM",
-            BulkFixAction.Nullable => "NULLABLE",
+            BulkFixAction.Todo => "DEFAULT",
+            BulkFixAction.Custom => "DEFAULT",
+            BulkFixAction.Nullable => "DEFAULT",
             _ => "DEFAULT"
         };
     }

--- a/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningAnalyzer.cs
@@ -126,8 +126,8 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
     {
         var invocationExpr = (InvocationExpressionSyntax)context.Node;
 
-        // Check if this is a CreateMap<TSource, TDestination>() call
-        if (!AutoMapperAnalysisHelpers.IsCreateMapInvocation(invocationExpr, context.SemanticModel))
+        // Ensure strict AutoMapper semantic matching to avoid lookalike false positives.
+        if (!MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(invocationExpr, context.SemanticModel, "CreateMap"))
         {
             return;
         }

--- a/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningCodeFixProvider.cs
@@ -47,6 +47,7 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
 
         SyntaxTree documentTree = operationContext.Root.SyntaxTree;
         Diagnostic? diagnostic = context.Diagnostics.FirstOrDefault(diag =>
+            diag.Id == "AM031" &&
             diag.Location.IsInSource &&
             diag.Location.SourceTree == documentTree &&
             diag.Location.SourceSpan.IntersectsWith(context.Span));

--- a/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM003_CollectionTypeIncompatibilityAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM003_CollectionTypeIncompatibilityAnalyzer.cs
@@ -32,7 +32,7 @@ public class AM003_CollectionTypeIncompatibilityAnalyzer : DiagnosticAnalyzer
         "Source and destination properties have incompatible collection types that require explicit conversion configuration.");
 
     /// <summary>
-    ///     AM003: Collection element type incompatibility
+    ///     Legacy descriptor kept for source compatibility; element mismatches are owned by AM021.
     /// </summary>
     public static readonly DiagnosticDescriptor CollectionElementIncompatibilityRule = new(
         "AM003",
@@ -45,7 +45,7 @@ public class AM003_CollectionTypeIncompatibilityAnalyzer : DiagnosticAnalyzer
 
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
-        [CollectionTypeIncompatibilityRule, CollectionElementIncompatibilityRule];
+        [CollectionTypeIncompatibilityRule];
 
     /// <inheritdoc />
     public override void Initialize(AnalysisContext context)
@@ -139,7 +139,7 @@ public class AM003_CollectionTypeIncompatibilityAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // Check if collection types are fundamentally incompatible
+        // AM003 owns collection container incompatibilities.
         if (AreCollectionTypesIncompatible(sourceProperty.Type, destinationProperty.Type))
         {
             ImmutableDictionary<string, string?>.Builder properties =
@@ -164,34 +164,6 @@ public class AM003_CollectionTypeIncompatibilityAnalyzer : DiagnosticAnalyzer
                 sourceTypeName,
                 AutoMapperAnalysisHelpers.GetTypeName(destinationType),
                 destTypeName);
-
-            context.ReportDiagnostic(diagnostic);
-        }
-        // Check if element types are incompatible
-        else if (!AutoMapperAnalysisHelpers.AreTypesCompatible(sourceElementType, destElementType))
-        {
-            ImmutableDictionary<string, string?>.Builder properties =
-                ImmutableDictionary.CreateBuilder<string, string?>();
-            properties.Add(PropertyNamePropertyName, sourceProperty.Name);
-            properties.Add(SourcePropertyTypePropertyName, sourceTypeName);
-            properties.Add(DestinationPropertyTypePropertyName, destTypeName);
-            properties.Add(SourceElementTypePropertyName, sourceElementType.ToDisplayString());
-            properties.Add(DestinationElementTypePropertyName, destElementType.ToDisplayString());
-            // Backward-compatible aliases for existing fixers/consumers.
-            properties.Add("SourceType", sourceTypeName);
-            properties.Add("DestType", destTypeName);
-            properties.Add("SourceTypeName", AutoMapperAnalysisHelpers.GetTypeName(sourceType));
-            properties.Add("DestTypeName", AutoMapperAnalysisHelpers.GetTypeName(destinationType));
-
-            var diagnostic = Diagnostic.Create(
-                CollectionElementIncompatibilityRule,
-                invocation.GetLocation(),
-                properties.ToImmutable(),
-                sourceProperty.Name,
-                AutoMapperAnalysisHelpers.GetTypeName(sourceType),
-                sourceElementType.ToDisplayString(),
-                AutoMapperAnalysisHelpers.GetTypeName(destinationType),
-                destElementType.ToDisplayString());
 
             context.ReportDiagnostic(diagnostic);
         }

--- a/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM021_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM021_CodeFixTests.cs
@@ -245,7 +245,7 @@ public class AM021_CodeFixTests
     }
 
     [Fact]
-    public async Task AM021_ShouldFixArrayToHashSet_WithSelect()
+    public async Task AM021_ShouldFixArrayToArray_WithSelect()
     {
         const string testCode = """
                                 using AutoMapper;
@@ -260,7 +260,7 @@ public class AM021_CodeFixTests
 
                                     public class Destination
                                     {
-                                        public HashSet<int> Tags { get; set; }
+                                        public int[] Tags { get; set; }
                                     }
 
                                     public class TestProfile : Profile
@@ -288,14 +288,14 @@ public class AM021_CodeFixTests
 
                                              public class Destination
                                              {
-                                                 public HashSet<int> Tags { get; set; }
+                                                 public int[] Tags { get; set; }
                                              }
 
                                              public class TestProfile : Profile
                                              {
                                                  public TestProfile()
                                                  {
-                                                     CreateMap<Source, Destination>().ForMember(dest => dest.Tags, opt => opt.MapFrom(src => src.Tags.Select(x => Convert.ToInt32(x)).ToHashSet()));
+                                                     CreateMap<Source, Destination>().ForMember(dest => dest.Tags, opt => opt.MapFrom(src => src.Tags.Select(x => Convert.ToInt32(x)).ToArray()));
                                                  }
                                              }
                                          }

--- a/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM021_CollectionElementMismatchTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM021_CollectionElementMismatchTests.cs
@@ -870,4 +870,121 @@ public class AM021_CollectionElementMismatchTests
                 "Numbers", "Source", "string", "Destination", "int")
             .RunAsync();
     }
+
+    [Fact]
+    public async Task AM021_ShouldNotReportDiagnostic_ForCreateMapLikeApiOutsideAutoMapper()
+    {
+        const string testCode = """
+                                using System.Collections.Generic;
+
+                                namespace TestNamespace
+                                {
+                                    public class MappingConfig
+                                    {
+                                        public void CreateMap<TSource, TDestination>()
+                                        {
+                                        }
+                                    }
+
+                                    public class Source
+                                    {
+                                        public List<string> Values { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public List<int> Values { get; set; }
+                                    }
+
+                                    public class TestProfile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            var cfg = new MappingConfig();
+                                            cfg.CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM021_CollectionElementMismatchAnalyzer>()
+            .WithSource(testCode)
+            .ExpectNoDiagnostics()
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM021_ShouldNotReportDiagnostic_WhenListToQueueContainerMismatch()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Collections.Generic;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public List<string> Items { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public Queue<int> Items { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        // AM003 owns collection container incompatibilities.
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM021_CollectionElementMismatchAnalyzer>()
+            .WithSource(testCode)
+            .ExpectNoDiagnostics()
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM021_ShouldNotReportDiagnostic_WhenListToStackContainerMismatch()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Collections.Generic;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public List<string> Items { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public Stack<int> Items { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        // AM003 owns collection container incompatibilities.
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM021_CollectionElementMismatchAnalyzer>()
+            .WithSource(testCode)
+            .ExpectNoDiagnostics()
+            .RunAsync();
+    }
 }

--- a/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM021_CollectionElementMismatchTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM021_CollectionElementMismatchTests.cs
@@ -92,7 +92,7 @@ public class AM021_CollectionElementMismatchTests
     }
 
     [Fact]
-    public async Task AM021_ShouldReportDiagnostic_WhenArrayToCollectionElementMismatch()
+    public async Task AM021_ShouldNotReportDiagnostic_WhenContainerTypesAreIncompatible()
     {
         const string testCode = """
                                 using AutoMapper;
@@ -120,16 +120,16 @@ public class AM021_CollectionElementMismatchTests
                                 }
                                 """;
 
+        // AM003 owns collection container incompatibilities.
         await DiagnosticTestFramework
             .ForAnalyzer<AM021_CollectionElementMismatchAnalyzer>()
             .WithSource(testCode)
-            .ExpectDiagnostic(AM021_CollectionElementMismatchAnalyzer.CollectionElementIncompatibilityRule, 20, 13,
-                "Tags", "Source", "string", "Destination", "int")
+            .ExpectNoDiagnostics()
             .RunAsync();
     }
 
     [Fact]
-    public async Task AM021_ShouldReportMultipleDiagnostics_WhenMultipleCollectionIssues()
+    public async Task AM021_ShouldReportOnlyElementDiagnostic_WhenContainerAndElementIssuesExist()
     {
         const string testCode = """
                                 using AutoMapper;
@@ -159,15 +159,13 @@ public class AM021_CollectionElementMismatchTests
                                 }
                                 """;
 
-        // NOTE: Analyzer reports both diagnostics, but they point to the same CreateMap invocation line
-        // The location is the CreateMap call, not individual property locations
+        // AM021 reports only the List<string> -> List<int> element mismatch.
+        // HashSet<double> -> List<string> is a container incompatibility owned by AM003.
         await DiagnosticTestFramework
             .ForAnalyzer<AM021_CollectionElementMismatchAnalyzer>()
             .WithSource(testCode)
             .ExpectDiagnostic(AM021_CollectionElementMismatchAnalyzer.CollectionElementIncompatibilityRule, 22, 13,
                 "StringNumbers", "Source", "string", "Destination", "int")
-            .ExpectDiagnostic(AM021_CollectionElementMismatchAnalyzer.CollectionElementIncompatibilityRule, 22, 13,
-                "DecimalValues", "Source", "double", "Destination", "string")
             .RunAsync();
     }
 
@@ -424,7 +422,7 @@ public class AM021_CollectionElementMismatchTests
     }
 
     [Fact]
-    public async Task AM021_ShouldReportDiagnostic_WhenIEnumerableToHashSetWithElementMismatch()
+    public async Task AM021_ShouldNotReportDiagnostic_WhenIEnumerableToHashSetWithElementMismatch()
     {
         const string testCode = """
                                 using AutoMapper;
@@ -452,16 +450,16 @@ public class AM021_CollectionElementMismatchTests
                                 }
                                 """;
 
+        // AM003 owns collection container incompatibilities.
         await DiagnosticTestFramework
             .ForAnalyzer<AM021_CollectionElementMismatchAnalyzer>()
             .WithSource(testCode)
-            .ExpectDiagnostic(AM021_CollectionElementMismatchAnalyzer.CollectionElementIncompatibilityRule, 20, 13,
-                "Values", "Source", "string", "Destination", "int")
+            .ExpectNoDiagnostics()
             .RunAsync();
     }
 
     [Fact]
-    public async Task AM021_ShouldReportDiagnostic_WhenQueueToStackWithElementMismatch()
+    public async Task AM021_ShouldNotReportDiagnostic_WhenQueueToStackWithElementMismatch()
     {
         const string testCode = """
                                 using AutoMapper;
@@ -489,11 +487,11 @@ public class AM021_CollectionElementMismatchTests
                                 }
                                 """;
 
+        // AM003 owns collection container incompatibilities.
         await DiagnosticTestFramework
             .ForAnalyzer<AM021_CollectionElementMismatchAnalyzer>()
             .WithSource(testCode)
-            .ExpectDiagnostic(AM021_CollectionElementMismatchAnalyzer.CollectionElementIncompatibilityRule, 20, 13,
-                "Measurements", "Source", "double", "Destination", "int")
+            .ExpectNoDiagnostics()
             .RunAsync();
     }
 

--- a/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM030_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM030_CodeFixTests.cs
@@ -7,29 +7,26 @@ namespace AutoMapperAnalyzer.Tests.ComplexMappings;
 public class AM030_CodeFixTests
 {
     [Fact]
-    public async Task AM030_ShouldFixMissingConvertUsingWithLambda()
+    public async Task AM030_ShouldAddNullGuard_ForBlockBodiedConvertMethod()
     {
         const string testCode = """
                                 using AutoMapper;
-                                using System;
 
                                 namespace TestNamespace
                                 {
-                                    public class Source
+                                    public class NullUnsafeConverter : ITypeConverter<string?, int>
                                     {
-                                        public string CreatedDate { get; set; } = "2023-01-01";
-                                    }
-
-                                    public class Destination
-                                    {
-                                        public DateTime CreatedDate { get; set; }
+                                        public int Convert(string? source, int destination, ResolutionContext context)
+                                        {
+                                            return int.Parse(source);
+                                        }
                                     }
 
                                     public class TestProfile : Profile
                                     {
                                         public TestProfile()
                                         {
-                                            CreateMap<Source, Destination>();
+                                            CreateMap<string?, int>().ConvertUsing<NullUnsafeConverter>();
                                         }
                                     }
                                 }
@@ -41,21 +38,20 @@ public class AM030_CodeFixTests
 
                                          namespace TestNamespace
                                          {
-                                             public class Source
+                                             public class NullUnsafeConverter : ITypeConverter<string?, int>
                                              {
-                                                 public string CreatedDate { get; set; } = "2023-01-01";
-                                             }
-
-                                             public class Destination
-                                             {
-                                                 public DateTime CreatedDate { get; set; }
+                                                 public int Convert(string? source, int destination, ResolutionContext context)
+                                                 {
+                                                     if (source == null) throw new ArgumentNullException(nameof(source));
+                                                     return int.Parse(source);
+                                                 }
                                              }
 
                                              public class TestProfile : Profile
                                              {
                                                  public TestProfile()
                                                  {
-                                                     CreateMap<Source, Destination>().ForMember(dest => dest.CreatedDate, opt => opt.MapFrom(src => DateTime.Parse(src.CreatedDate)));
+                                                     CreateMap<string?, int>().ConvertUsing<NullUnsafeConverter>();
                                                  }
                                              }
                                          }
@@ -64,36 +60,30 @@ public class AM030_CodeFixTests
         await CodeFixVerifier<AM030_CustomTypeConverterAnalyzer, AM030_CustomTypeConverterCodeFixProvider>
             .VerifyFixAsync(
                 testCode,
-                new DiagnosticResult(AM030_CustomTypeConverterAnalyzer.MissingConvertUsingConfigurationRule)
-                    .WithLocation(20, 13)
-                    .WithArguments("CreatedDate", "ITypeConverter<String, DateTime>"),
+                new DiagnosticResult(AM030_CustomTypeConverterAnalyzer.ConverterNullHandlingIssueRule)
+                    .WithLocation(7, 20)
+                    .WithArguments("NullUnsafeConverter", "String"),
                 expectedFixedCode);
     }
 
     [Fact]
-    public async Task AM030_ShouldFixMissingConvertUsingWithConverter()
+    public async Task AM030_ShouldAddNullGuard_ForExpressionBodiedConvertMethod()
     {
         const string testCode = """
                                 using AutoMapper;
-                                using System;
 
                                 namespace TestNamespace
                                 {
-                                    public class Source
+                                    public class NullUnsafeConverter : ITypeConverter<string?, int>
                                     {
-                                        public string Price { get; set; } = "19.99";
-                                    }
-
-                                    public class Destination
-                                    {
-                                        public decimal Price { get; set; }
+                                        public int Convert(string? source, int destination, ResolutionContext context) => int.Parse(source);
                                     }
 
                                     public class TestProfile : Profile
                                     {
                                         public TestProfile()
                                         {
-                                            CreateMap<Source, Destination>();
+                                            CreateMap<string?, int>().ConvertUsing<NullUnsafeConverter>();
                                         }
                                     }
                                 }
@@ -105,21 +95,20 @@ public class AM030_CodeFixTests
 
                                          namespace TestNamespace
                                          {
-                                             public class Source
+                                             public class NullUnsafeConverter : ITypeConverter<string?, int>
                                              {
-                                                 public string Price { get; set; } = "19.99";
-                                             }
-
-                                             public class Destination
-                                             {
-                                                 public decimal Price { get; set; }
+                                                 public int Convert(string? source, int destination, ResolutionContext context)
+                                                 {
+                                                     if (source == null) throw new ArgumentNullException(nameof(source));
+                                                     return int.Parse(source);
+                                                 }
                                              }
 
                                              public class TestProfile : Profile
                                              {
                                                  public TestProfile()
                                                  {
-                                                     CreateMap<Source, Destination>().ForMember(dest => dest.Price, opt => opt.MapFrom(src => Convert.ToDecimal(src.Price)));
+                                                     CreateMap<string?, int>().ConvertUsing<NullUnsafeConverter>();
                                                  }
                                              }
                                          }
@@ -128,73 +117,9 @@ public class AM030_CodeFixTests
         await CodeFixVerifier<AM030_CustomTypeConverterAnalyzer, AM030_CustomTypeConverterCodeFixProvider>
             .VerifyFixAsync(
                 testCode,
-                new DiagnosticResult(AM030_CustomTypeConverterAnalyzer.MissingConvertUsingConfigurationRule)
-                    .WithLocation(20, 13)
-                    .WithArguments("Price", "ITypeConverter<String, Decimal>"),
-                expectedFixedCode);
-    }
-
-    [Fact]
-    public async Task AM030_ShouldFixMissingConvertUsingWithForMember()
-    {
-        const string testCode = """
-                                using AutoMapper;
-                                using System;
-
-                                namespace TestNamespace
-                                {
-                                    public class Source
-                                    {
-                                        public string UpdatedDate { get; set; } = "2023-01-02";
-                                    }
-
-                                    public class Destination
-                                    {
-                                        public DateTime UpdatedDate { get; set; }
-                                    }
-
-                                    public class TestProfile : Profile
-                                    {
-                                        public TestProfile()
-                                        {
-                                            CreateMap<Source, Destination>();
-                                        }
-                                    }
-                                }
-                                """;
-
-        const string expectedFixedCode = """
-                                         using AutoMapper;
-                                         using System;
-
-                                         namespace TestNamespace
-                                         {
-                                             public class Source
-                                             {
-                                                 public string UpdatedDate { get; set; } = "2023-01-02";
-                                             }
-
-                                             public class Destination
-                                             {
-                                                 public DateTime UpdatedDate { get; set; }
-                                             }
-
-                                             public class TestProfile : Profile
-                                             {
-                                                 public TestProfile()
-                                                 {
-                                                     CreateMap<Source, Destination>().ForMember(dest => dest.UpdatedDate, opt => opt.MapFrom(src => DateTime.Parse(src.UpdatedDate)));
-                                                 }
-                                             }
-                                         }
-                                         """;
-
-        await CodeFixVerifier<AM030_CustomTypeConverterAnalyzer, AM030_CustomTypeConverterCodeFixProvider>
-            .VerifyFixAsync(
-                testCode,
-                new DiagnosticResult(AM030_CustomTypeConverterAnalyzer.MissingConvertUsingConfigurationRule)
-                    .WithLocation(20, 13)
-                    .WithArguments("UpdatedDate", "ITypeConverter<String, DateTime>"),
+                new DiagnosticResult(AM030_CustomTypeConverterAnalyzer.ConverterNullHandlingIssueRule)
+                    .WithLocation(7, 20)
+                    .WithArguments("NullUnsafeConverter", "String"),
                 expectedFixedCode);
     }
 }

--- a/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM030_CustomTypeConverterTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM030_CustomTypeConverterTests.cs
@@ -1,157 +1,12 @@
 using AutoMapperAnalyzer.Analyzers.ComplexMappings;
 using AutoMapperAnalyzer.Tests.Framework;
+using AutoMapperAnalyzer.Tests.Infrastructure;
+using Microsoft.CodeAnalysis.Testing;
 
 namespace AutoMapperAnalyzer.Tests.ComplexMappings;
 
 public class AM030_CustomTypeConverterTests
 {
-    [Fact]
-    public async Task AM030_ShouldReportDiagnostic_WhenMissingConvertUsingForIncompatibleTypes()
-    {
-        const string testCode = """
-                                using AutoMapper;
-                                using System;
-
-                                namespace TestNamespace
-                                {
-                                    public class Source
-                                    {
-                                        public string CreatedDate { get; set; } = "2023-01-01";
-                                    }
-
-                                    public class Destination
-                                    {
-                                        public DateTime CreatedDate { get; set; }
-                                    }
-
-                                    public class TestProfile : Profile
-                                    {
-                                        public TestProfile()
-                                        {
-                                            CreateMap<Source, Destination>();
-                                        }
-                                    }
-                                }
-                                """;
-
-        await DiagnosticTestFramework
-            .ForAnalyzer<AM030_CustomTypeConverterAnalyzer>()
-            .WithSource(testCode)
-            .ExpectDiagnostic(AM030_CustomTypeConverterAnalyzer.MissingConvertUsingConfigurationRule, 20, 13,
-                "CreatedDate", "ITypeConverter<String, DateTime>")
-            .RunAsync();
-    }
-
-    [Fact]
-    public async Task AM030_ShouldNotReportDiagnostic_WhenNestedMappingExists()
-    {
-        const string mainProfile = """
-                                   using AutoMapper;
-
-                                   namespace TestNamespace
-                                   {
-                                       public class Address
-                                       {
-                                           public string Street { get; set; }
-                                       }
-
-                                       public class AddressDto
-                                       {
-                                           public string Street { get; set; }
-                                       }
-
-                                       public class Source
-                                       {
-                                           public Address HomeAddress { get; set; }
-                                       }
-
-                                       public class Destination
-                                       {
-                                           public AddressDto HomeAddress { get; set; }
-                                       }
-
-                                       public class PrimaryProfile : Profile
-                                       {
-                                           public PrimaryProfile()
-                                           {
-                                               CreateMap<Source, Destination>();
-                                           }
-                                       }
-                                   }
-                                   """;
-
-        const string addressProfile = """
-                                      using AutoMapper;
-
-                                      namespace TestNamespace.Inner
-                                      {
-                                          using TestNamespace;
-
-                                          public class AddressProfile : Profile
-                                          {
-                                              public AddressProfile()
-                                              {
-                                                  CreateMap<Address, AddressDto>();
-                                              }
-                                          }
-                                      }
-                                      """;
-
-        await DiagnosticTestFramework
-            .ForAnalyzer<AM030_CustomTypeConverterAnalyzer>()
-            .WithSource(mainProfile, "PrimaryProfile.cs")
-            .WithSource(addressProfile, "AddressProfile.cs")
-            .RunWithNoDiagnosticsAsync();
-    }
-
-    [Fact(Skip = "Future feature: invalid converter detection - see docs/TEST_LIMITATIONS.md #4")]
-    public async Task AM030_ShouldReportDiagnostic_WhenInvalidTypeConverterImplementation()
-    {
-        const string testCode = """
-                                using AutoMapper;
-                                using System;
-
-                                namespace TestNamespace
-                                {
-                                    public class InvalidConverter : ITypeConverter<string, DateTime>
-                                    {
-                                        // Missing Convert method - should trigger diagnostic
-                                        // Note: This will also cause compiler error CS0535 which is expected
-                                    }
-
-                                    public class Source
-                                    {
-                                        public string CreatedDate { get; set; } = "2023-01-01";
-                                    }
-
-                                    public class Destination
-                                    {
-                                        public DateTime CreatedDate { get; set; }
-                                    }
-
-                                    public class TestProfile : Profile
-                                    {
-                                        public TestProfile()
-                                        {
-                                            CreateMap<Source, Destination>();
-                                        }
-                                    }
-                                }
-                                """;
-
-        // This test expects both AM030 diagnostics plus a compiler error
-        // Since our test framework doesn't have ExpectCompilerError, we'll allow the extra diagnostic
-        await DiagnosticTestFramework
-            .ForAnalyzer<AM030_CustomTypeConverterAnalyzer>()
-            .WithSource(testCode)
-            .ExpectDiagnostic(AM030_CustomTypeConverterAnalyzer.InvalidConverterImplementationRule, 6, 18,
-                "InvalidConverter", "TSource", "TDestination")
-            .ExpectDiagnostic(AM030_CustomTypeConverterAnalyzer.MissingConvertUsingConfigurationRule, 26, 13,
-                "CreatedDate", "ITypeConverter<String, DateTime>")
-            // Note: This will also produce CS0535 compiler error which we can't easily test for
-            .RunAsync();
-    }
-
     [Fact]
     public async Task AM030_ShouldReportDiagnostic_WhenConverterDoesNotHandleNullValues()
     {
@@ -165,27 +20,15 @@ public class AM030_CustomTypeConverterTests
                                     {
                                         public DateTime Convert(string? source, DateTime destination, ResolutionContext context)
                                         {
-                                            // No null check - should trigger diagnostic
                                             return DateTime.Parse(source);
                                         }
-                                    }
-
-                                    public class Source
-                                    {
-                                        public string? CreatedDate { get; set; }
-                                    }
-
-                                    public class Destination
-                                    {
-                                        public DateTime CreatedDate { get; set; }
                                     }
 
                                     public class TestProfile : Profile
                                     {
                                         public TestProfile()
                                         {
-                                            CreateMap<Source, Destination>();
-                                            // Note: We're just testing that the analyzer detects the null handling issue in the converter class
+                                            CreateMap<string?, DateTime>().ConvertUsing<NullUnsafeConverter>();
                                         }
                                     }
                                 }
@@ -196,103 +39,6 @@ public class AM030_CustomTypeConverterTests
             .WithSource(testCode)
             .ExpectDiagnostic(AM030_CustomTypeConverterAnalyzer.ConverterNullHandlingIssueRule, 8, 25,
                 "NullUnsafeConverter", "String")
-            .ExpectDiagnostic(AM030_CustomTypeConverterAnalyzer.MissingConvertUsingConfigurationRule, 29, 13,
-                "CreatedDate", "ITypeConverter<String, DateTime>")
-            .RunAsync();
-    }
-
-    [Fact(Skip = "Future feature: unused converter detection - see docs/TEST_LIMITATIONS.md #4")]
-    public async Task AM030_ShouldReportDiagnostic_WhenTypeConverterIsUnused()
-    {
-        const string testCode = """
-                                using AutoMapper;
-                                using System;
-
-                                namespace TestNamespace
-                                {
-                                    public class UnusedConverter : ITypeConverter<string, DateTime>
-                                    {
-                                        public DateTime Convert(string source, DateTime destination, ResolutionContext context)
-                                        {
-                                            return DateTime.Parse(source ?? "2000-01-01");
-                                        }
-                                    }
-
-                                    public class Source
-                                    {
-                                        public string Name { get; set; } = "";
-                                    }
-
-                                    public class Destination
-                                    {
-                                        public string Name { get; set; } = "";
-                                    }
-
-                                    public class TestProfile : Profile
-                                    {
-                                        public TestProfile()
-                                        {
-                                            CreateMap<Source, Destination>();
-                                            // UnusedConverter is never referenced
-                                        }
-                                    }
-                                }
-                                """;
-
-        await DiagnosticTestFramework
-            .ForAnalyzer<AM030_CustomTypeConverterAnalyzer>()
-            .WithSource(testCode)
-            .ExpectDiagnostic(AM030_CustomTypeConverterAnalyzer.UnusedTypeConverterRule, 6, 35,
-                "UnusedConverter")
-            .RunAsync();
-    }
-
-    [Fact]
-    public async Task AM030_ShouldNotReportDiagnostic_WhenConvertUsingIsProperlyConfigured()
-    {
-        const string testCode = """
-                                using AutoMapper;
-                                using System;
-
-                                namespace TestNamespace
-                                {
-                                    public class ValidConverter : ITypeConverter<string, DateTime>
-                                    {
-                                        public DateTime Convert(string source, DateTime destination, ResolutionContext context)
-                                        {
-                                            if (string.IsNullOrEmpty(source))
-                                                return DateTime.MinValue;
-                                            
-                                            return DateTime.Parse(source);
-                                        }
-                                    }
-
-                                    public class Source
-                                    {
-                                        public string CreatedDate { get; set; } = "2023-01-01";
-                                    }
-
-                                    public class Destination
-                                    {
-                                        public DateTime CreatedDate { get; set; }
-                                    }
-
-                                    public class TestProfile : Profile
-                                    {
-                                        public TestProfile()
-                                        {
-                                            CreateMap<Source, Destination>()
-                                                .ForMember(dest => dest.CreatedDate, 
-                                                    opt => opt.MapFrom(src => new ValidConverter().Convert(src.CreatedDate, default, null!)));
-                                        }
-                                    }
-                                }
-                                """;
-
-        await DiagnosticTestFramework
-            .ForAnalyzer<AM030_CustomTypeConverterAnalyzer>()
-            .WithSource(testCode)
-            .ExpectNoDiagnostics()
             .RunAsync();
     }
 
@@ -309,30 +55,20 @@ public class AM030_CustomTypeConverterTests
                                     {
                                         public DateTime Convert(string? source, DateTime destination, ResolutionContext context)
                                         {
-                                            if (source == null)
+                                            if (string.IsNullOrWhiteSpace(source))
+                                            {
                                                 return DateTime.MinValue;
-                                            
-                                            return DateTime.TryParse(source, out var result) ? result : DateTime.MinValue;
+                                            }
+
+                                            return DateTime.Parse(source);
                                         }
-                                    }
-
-                                    public class Source
-                                    {
-                                        public string? CreatedDate { get; set; }
-                                    }
-
-                                    public class Destination
-                                    {
-                                        public DateTime CreatedDate { get; set; }
                                     }
 
                                     public class TestProfile : Profile
                                     {
                                         public TestProfile()
                                         {
-                                            CreateMap<Source, Destination>()
-                                                .ForMember(dest => dest.CreatedDate, 
-                                                    opt => opt.MapFrom(src => new NullSafeConverter().Convert(src.CreatedDate, default, null!)));
+                                            CreateMap<string?, DateTime>().ConvertUsing<NullSafeConverter>();
                                         }
                                     }
                                 }
@@ -346,7 +82,7 @@ public class AM030_CustomTypeConverterTests
     }
 
     [Fact]
-    public async Task AM030_ShouldHandleInlineConvertUsingWithLambda()
+    public async Task AM030_ShouldReportDiagnostic_WhenInvalidTypeConverterImplementation()
     {
         const string testCode = """
                                 using AutoMapper;
@@ -354,37 +90,26 @@ public class AM030_CustomTypeConverterTests
 
                                 namespace TestNamespace
                                 {
-                                    public class Source
+                                    public class InvalidConverter : ITypeConverter<string, DateTime>
                                     {
-                                        public string CreatedDate { get; set; } = "2023-01-01";
-                                    }
-
-                                    public class Destination
-                                    {
-                                        public DateTime CreatedDate { get; set; }
-                                    }
-
-                                    public class TestProfile : Profile
-                                    {
-                                        public TestProfile()
-                                        {
-                                            CreateMap<Source, Destination>()
-                                                .ForMember(dest => dest.CreatedDate, 
-                                                    opt => opt.MapFrom(src => DateTime.Parse(src.CreatedDate)));
-                                        }
                                     }
                                 }
                                 """;
 
-        await DiagnosticTestFramework
-            .ForAnalyzer<AM030_CustomTypeConverterAnalyzer>()
-            .WithSource(testCode)
-            .ExpectNoDiagnostics()
-            .RunAsync();
+        await AnalyzerVerifier<AM030_CustomTypeConverterAnalyzer>.VerifyAnalyzerAsync(
+            testCode,
+            new DiagnosticResult(AM030_CustomTypeConverterAnalyzer.InvalidConverterImplementationRule)
+                .WithLocation(6, 18)
+                .WithArguments("InvalidConverter", "String", "DateTime"),
+            new DiagnosticResult(AM030_CustomTypeConverterAnalyzer.UnusedTypeConverterRule)
+                .WithLocation(6, 18)
+                .WithArguments("InvalidConverter"),
+            DiagnosticResult.CompilerError("CS0535")
+                .WithLocation(6, 37));
     }
 
     [Fact]
-    public async Task AM030_ShouldNotReportDiagnostic_WhenForMemberIgnoreIsConfigured()
+    public async Task AM030_ShouldReportDiagnostic_WhenTypeConverterIsUnused()
     {
         const string testCode = """
                                 using AutoMapper;
@@ -392,406 +117,22 @@ public class AM030_CustomTypeConverterTests
 
                                 namespace TestNamespace
                                 {
-                                    public class Source
+                                    public class UnusedConverter : ITypeConverter<string, DateTime>
                                     {
-                                        public string CreatedDate { get; set; } = "2023-01-01";
-                                    }
-
-                                    public class Destination
-                                    {
-                                        public DateTime CreatedDate { get; set; }
-                                    }
-
-                                    public class TestProfile : Profile
-                                    {
-                                        public TestProfile()
+                                        public DateTime Convert(string source, DateTime destination, ResolutionContext context)
                                         {
-                                            CreateMap<Source, Destination>()
-                                                .ForMember(dest => dest.CreatedDate, opt => opt.Ignore());
-                                        }
-                                    }
-                                }
-                                """;
-
-        await DiagnosticTestFramework
-            .ForAnalyzer<AM030_CustomTypeConverterAnalyzer>()
-            .WithSource(testCode)
-            .RunWithNoDiagnosticsAsync();
-    }
-
-    [Fact]
-    public async Task AM030_ShouldOnlyMatchExactForMemberProperty()
-    {
-        const string testCode = """
-                                using AutoMapper;
-                                using System;
-
-                                namespace TestNamespace
-                                {
-                                    public class Source
-                                    {
-                                        public string Id { get; set; } = "";
-                                        public string OrderId { get; set; } = "";
-                                    }
-
-                                    public class Destination
-                                    {
-                                        public Guid Id { get; set; }
-                                        public Guid OrderId { get; set; }
-                                    }
-
-                                    public class TestProfile : Profile
-                                    {
-                                        public TestProfile()
-                                        {
-                                            CreateMap<Source, Destination>()
-                                                .ForMember(dest => dest.OrderId, opt => opt.MapFrom(src => Guid.Parse(src.OrderId)));
-                                        }
-                                    }
-                                }
-                                """;
-
-        await DiagnosticTestFramework
-            .ForAnalyzer<AM030_CustomTypeConverterAnalyzer>()
-            .WithSource(testCode)
-            .ExpectDiagnostic(AM030_CustomTypeConverterAnalyzer.MissingConvertUsingConfigurationRule, 22, 13,
-                "Id", "ITypeConverter<String, Guid>")
-            .RunAsync();
-    }
-
-    [Fact]
-    public async Task AM030_ShouldTreatForMemberPropertyMatchingAsCaseInsensitive()
-    {
-        const string testCode = """
-                                using AutoMapper;
-                                using System;
-
-                                namespace TestNamespace
-                                {
-                                    public class Source
-                                    {
-                                        public string name { get; set; } = "2023-01-01";
-                                    }
-
-                                    public class Destination
-                                    {
-                                        public DateTime Name { get; set; }
-                                    }
-
-                                    public class TestProfile : Profile
-                                    {
-                                        public TestProfile()
-                                        {
-                                            CreateMap<Source, Destination>()
-                                                .ForMember(dest => dest.Name, opt => opt.MapFrom(src => DateTime.Parse(src.name)));
-                                        }
-                                    }
-                                }
-                                """;
-
-        await DiagnosticTestFramework
-            .ForAnalyzer<AM030_CustomTypeConverterAnalyzer>()
-            .WithSource(testCode)
-            .RunWithNoDiagnosticsAsync();
-    }
-
-    [Fact]
-    public async Task AM030_ShouldNotReportDiagnostic_WhenConstructUsingIsConfigured()
-    {
-        const string testCode = """
-                                using AutoMapper;
-                                using System;
-
-                                namespace TestNamespace
-                                {
-                                    public class Source
-                                    {
-                                        public string CreatedDate { get; set; } = "2023-01-01";
-                                    }
-
-                                    public class Destination
-                                    {
-                                        public DateTime CreatedDate { get; set; }
-                                    }
-
-                                    public class TestProfile : Profile
-                                    {
-                                        public TestProfile()
-                                        {
-                                            CreateMap<Source, Destination>()
-                                                .ConstructUsing(src => new Destination { CreatedDate = DateTime.Parse(src.CreatedDate) });
-                                        }
-                                    }
-                                }
-                                """;
-
-        await DiagnosticTestFramework
-            .ForAnalyzer<AM030_CustomTypeConverterAnalyzer>()
-            .WithSource(testCode)
-            .RunWithNoDiagnosticsAsync();
-    }
-
-    [Fact]
-    public async Task AM030_ShouldHandleMultipleIncompatibleProperties()
-    {
-        const string testCode = """
-                                using AutoMapper;
-                                using System;
-
-                                namespace TestNamespace
-                                {
-                                    public class Source
-                                    {
-                                        public string CreatedDate { get; set; } = "2023-01-01";
-                                        public string UpdatedDate { get; set; } = "2023-01-02";
-                                        public string Price { get; set; } = "19.99";
-                                    }
-
-                                    public class Destination
-                                    {
-                                        public DateTime CreatedDate { get; set; }
-                                        public DateTime UpdatedDate { get; set; }
-                                        public decimal Price { get; set; }
-                                    }
-
-                                    public class TestProfile : Profile
-                                    {
-                                        public TestProfile()
-                                        {
-                                            CreateMap<Source, Destination>();
-                                        }
-                                    }
-                                }
-                                """;
-
-        await DiagnosticTestFramework
-            .ForAnalyzer<AM030_CustomTypeConverterAnalyzer>()
-            .WithSource(testCode)
-            .ExpectDiagnostic(AM030_CustomTypeConverterAnalyzer.MissingConvertUsingConfigurationRule, 24, 13,
-                "CreatedDate", "ITypeConverter<String, DateTime>")
-            .ExpectDiagnostic(AM030_CustomTypeConverterAnalyzer.MissingConvertUsingConfigurationRule, 24, 13,
-                "UpdatedDate", "ITypeConverter<String, DateTime>")
-            .ExpectDiagnostic(AM030_CustomTypeConverterAnalyzer.MissingConvertUsingConfigurationRule, 24, 13,
-                "Price", "ITypeConverter<String, Decimal>")
-            .RunAsync();
-    }
-
-    [Fact]
-    public async Task AM030_ShouldIgnoreCompatibleTypes()
-    {
-        const string testCode = """
-                                using AutoMapper;
-                                using System;
-
-                                namespace TestNamespace
-                                {
-                                    public class Source
-                                    {
-                                        public string Name { get; set; } = "";
-                                        public int Age { get; set; }
-                                        public bool IsActive { get; set; }
-                                    }
-
-                                    public class Destination
-                                    {
-                                        public string Name { get; set; } = "";
-                                        public int Age { get; set; }
-                                        public bool IsActive { get; set; }
-                                    }
-
-                                    public class TestProfile : Profile
-                                    {
-                                        public TestProfile()
-                                        {
-                                            CreateMap<Source, Destination>();
-                                        }
-                                    }
-                                }
-                                """;
-
-        await DiagnosticTestFramework
-            .ForAnalyzer<AM030_CustomTypeConverterAnalyzer>()
-            .WithSource(testCode)
-            .ExpectNoDiagnostics()
-            .RunAsync();
-    }
-
-    [Fact]
-    public async Task AM030_ShouldReportDiagnostic_WhenConvertingBoolToString()
-    {
-        const string testCode = """
-                                using AutoMapper;
-
-                                namespace TestNamespace
-                                {
-                                    public class Source
-                                    {
-                                        public bool IsActive { get; set; }
-                                    }
-
-                                    public class Destination
-                                    {
-                                        public string IsActive { get; set; } = "";
-                                    }
-
-                                    public class TestProfile : Profile
-                                    {
-                                        public TestProfile()
-                                        {
-                                            CreateMap<Source, Destination>();
-                                        }
-                                    }
-                                }
-                                """;
-
-        await DiagnosticTestFramework
-            .ForAnalyzer<AM030_CustomTypeConverterAnalyzer>()
-            .WithSource(testCode)
-            .ExpectDiagnostic(AM030_CustomTypeConverterAnalyzer.MissingConvertUsingConfigurationRule, 19, 13,
-                "IsActive", "ITypeConverter<Boolean, String>")
-            .RunAsync();
-    }
-
-    [Fact]
-    public async Task AM030_ShouldReportDiagnostic_WhenConvertingGuidToString()
-    {
-        const string testCode = """
-                                using AutoMapper;
-                                using System;
-
-                                namespace TestNamespace
-                                {
-                                    public class Source
-                                    {
-                                        public Guid Id { get; set; }
-                                    }
-
-                                    public class Destination
-                                    {
-                                        public string Id { get; set; } = "";
-                                    }
-
-                                    public class TestProfile : Profile
-                                    {
-                                        public TestProfile()
-                                        {
-                                            CreateMap<Source, Destination>();
-                                        }
-                                    }
-                                }
-                                """;
-
-        await DiagnosticTestFramework
-            .ForAnalyzer<AM030_CustomTypeConverterAnalyzer>()
-            .WithSource(testCode)
-            .ExpectDiagnostic(AM030_CustomTypeConverterAnalyzer.MissingConvertUsingConfigurationRule, 20, 13,
-                "Id", "ITypeConverter<Guid, String>")
-            .RunAsync();
-    }
-
-    [Fact]
-    public async Task AM030_ShouldNotReportDiagnostic_WhenSameTypesUsed()
-    {
-        const string testCode = """
-                                using AutoMapper;
-
-                                namespace TestNamespace
-                                {
-                                    public class Source
-                                    {
-                                        public string Name { get; set; }
-                                        public int Age { get; set; }
-                                    }
-
-                                    public class Destination
-                                    {
-                                        public string Name { get; set; }
-                                        public int Age { get; set; }
-                                    }
-
-                                    public class TestProfile : Profile
-                                    {
-                                        public TestProfile()
-                                        {
-                                            CreateMap<Source, Destination>();
-                                        }
-                                    }
-                                }
-                                """;
-
-        // Same types don't require type converters
-        await DiagnosticTestFramework
-            .ForAnalyzer<AM030_CustomTypeConverterAnalyzer>()
-            .WithSource(testCode)
-            .ExpectNoDiagnostics()
-            .RunAsync();
-    }
-
-    [Fact]
-    public async Task AM030_ShouldNotReportNullHandlingDiagnostic_WhenConverterUsesIsNullOrEmpty()
-    {
-        const string testCode = """
-                                using AutoMapper;
-                                using System;
-
-                                namespace TestNamespace
-                                {
-                                    public class SafeConverter : ITypeConverter<string?, DateTime>
-                                    {
-                                        public DateTime Convert(string? source, DateTime destination, ResolutionContext context)
-                                        {
-                                            if (string.IsNullOrEmpty(source))
-                                                return DateTime.MinValue;
-
                                             return DateTime.Parse(source);
                                         }
                                     }
 
                                     public class Source
                                     {
-                                        public string? Date { get; set; }
+                                        public string Name { get; set; } = string.Empty;
                                     }
 
                                     public class Destination
                                     {
-                                        public DateTime Date { get; set; }
-                                    }
-
-                                    public class TestProfile : Profile
-                                    {
-                                        public TestProfile()
-                                        {
-                                            CreateMap<Source, Destination>()
-                                                .ForMember(dest => dest.Date,
-                                                    opt => opt.MapFrom(src => new SafeConverter().Convert(src.Date, default, null!)));
-                                        }
-                                    }
-                                }
-                                """;
-
-        // IsNullOrEmpty counts as null-handling and explicit MapFrom covers conversion.
-        await DiagnosticTestFramework
-            .ForAnalyzer<AM030_CustomTypeConverterAnalyzer>()
-            .WithSource(testCode)
-            .RunWithNoDiagnosticsAsync();
-    }
-
-    [Fact]
-    public async Task AM030_ShouldHandleIntToStringConversion()
-    {
-        const string testCode = """
-                                using AutoMapper;
-
-                                namespace TestNamespace
-                                {
-                                    public class Source
-                                    {
-                                        public int Count { get; set; }
-                                    }
-
-                                    public class Destination
-                                    {
-                                        public string Count { get; set; } = "";
+                                        public string Name { get; set; } = string.Empty;
                                     }
 
                                     public class TestProfile : Profile
@@ -804,261 +145,58 @@ public class AM030_CustomTypeConverterTests
                                 }
                                 """;
 
-        // Int to string requires converter
         await DiagnosticTestFramework
             .ForAnalyzer<AM030_CustomTypeConverterAnalyzer>()
             .WithSource(testCode)
-            .ExpectDiagnostic(AM030_CustomTypeConverterAnalyzer.MissingConvertUsingConfigurationRule, 19, 13,
-                "Count", "ITypeConverter<Int32, String>")
+            .ExpectDiagnostic(AM030_CustomTypeConverterAnalyzer.UnusedTypeConverterRule, 6, 18,
+                "UnusedConverter")
             .RunAsync();
     }
 
     [Fact]
-    public async Task AM030_ShouldHandleDoubleToStringConversion()
+    public async Task AM030_ShouldNotReportDiagnostic_WhenTypeConverterIsUsedInConvertUsing()
     {
         const string testCode = """
                                 using AutoMapper;
+                                using System;
 
                                 namespace TestNamespace
                                 {
                                     public class Source
                                     {
-                                        public double Price { get; set; }
+                                        public string CreatedDate { get; set; } = "2024-01-01";
                                     }
 
                                     public class Destination
                                     {
-                                        public string Price { get; set; } = "";
+                                        public DateTime CreatedDate { get; set; }
                                     }
 
-                                    public class TestProfile : Profile
-                                    {
-                                        public TestProfile()
-                                        {
-                                            CreateMap<Source, Destination>();
-                                        }
-                                    }
-                                }
-                                """;
-
-        // Double to string requires converter
-        await DiagnosticTestFramework
-            .ForAnalyzer<AM030_CustomTypeConverterAnalyzer>()
-            .WithSource(testCode)
-            .ExpectDiagnostic(AM030_CustomTypeConverterAnalyzer.MissingConvertUsingConfigurationRule, 19, 13,
-                "Price", "ITypeConverter<Double, String>")
-            .RunAsync();
-    }
-
-    [Fact]
-    public async Task AM030_ShouldReportDiagnostic_WhenStringToDecimalConversion()
-    {
-        const string testCode = """
-                                using AutoMapper;
-
-                                namespace TestNamespace
-                                {
-                                    public class Source
-                                    {
-                                        public string Price { get; set; } = "";
-                                    }
-
-                                    public class Destination
-                                    {
-                                        public decimal Price { get; set; }
-                                    }
-
-                                    public class TestProfile : Profile
-                                    {
-                                        public TestProfile()
-                                        {
-                                            CreateMap<Source, Destination>();
-                                        }
-                                    }
-                                }
-                                """;
-
-        // String to decimal requires converter
-        await DiagnosticTestFramework
-            .ForAnalyzer<AM030_CustomTypeConverterAnalyzer>()
-            .WithSource(testCode)
-            .ExpectDiagnostic(AM030_CustomTypeConverterAnalyzer.MissingConvertUsingConfigurationRule, 19, 13,
-                "Price", "ITypeConverter<String, Decimal>")
-            .RunAsync();
-    }
-
-    [Fact]
-    public async Task AM030_ShouldHandleComplexClassConversions()
-    {
-        const string testCode = """
-                                using AutoMapper;
-
-                                namespace TestNamespace
-                                {
-                                    public class SourceAddress
-                                    {
-                                        public string Street { get; set; }
-                                        public string City { get; set; }
-                                    }
-
-                                    public class DestinationLocation
-                                    {
-                                        public string FullAddress { get; set; }
-                                    }
-
-                                    public class Source
-                                    {
-                                        public SourceAddress Address { get; set; }
-                                    }
-
-                                    public class Destination
-                                    {
-                                        public DestinationLocation Address { get; set; }
-                                    }
-
-                                    public class TestProfile : Profile
-                                    {
-                                        public TestProfile()
-                                        {
-                                            CreateMap<Source, Destination>();
-                                        }
-                                    }
-                                }
-                                """;
-
-        // Complex object conversions detected by AM030 when types don't match
-        await DiagnosticTestFramework
-            .ForAnalyzer<AM030_CustomTypeConverterAnalyzer>()
-            .WithSource(testCode)
-            .ExpectDiagnostic(AM030_CustomTypeConverterAnalyzer.MissingConvertUsingConfigurationRule, 30, 13,
-                "Address", "ITypeConverter<SourceAddress, DestinationLocation>")
-            .RunAsync();
-    }
-
-    [Fact]
-    public async Task AM030_ShouldNotReportDiagnostic_WhenSourcePropertyTypeIsAssignableToDestinationType()
-    {
-        const string testCode = """
-                                using AutoMapper;
-
-                                namespace TestNamespace
-                                {
-                                    public class Animal {}
-                                    public class Dog : Animal {}
-
-                                    public class Source
-                                    {
-                                        public Dog Pet { get; set; } = new();
-                                    }
-
-                                    public class Destination
-                                    {
-                                        public Animal Pet { get; set; } = new Animal();
-                                    }
-
-                                    public class TestProfile : Profile
-                                    {
-                                        public TestProfile()
-                                        {
-                                            CreateMap<Source, Destination>();
-                                        }
-                                    }
-                                }
-                                """;
-
-        await DiagnosticTestFramework
-            .ForAnalyzer<AM030_CustomTypeConverterAnalyzer>()
-            .WithSource(testCode)
-            .RunWithNoDiagnosticsAsync();
-    }
-
-    [Fact]
-    public async Task AM030_ShouldHandleConverterWithMultipleSourceDestinationTypes()
-    {
-        const string testCode = """
-                                using AutoMapper;
-
-                                namespace TestNamespace
-                                {
-                                    public class CustomConverter : ITypeConverter<Source, Destination>
+                                    public class UsedConverter : ITypeConverter<Source, Destination>
                                     {
                                         public Destination Convert(Source source, Destination destination, ResolutionContext context)
                                         {
                                             return new Destination
                                             {
-                                                Value1 = int.TryParse(source.Value1, out var v1) ? v1 : 0,
-                                                Value2 = int.TryParse(source.Value2, out var v2) ? v2 : 0
+                                                CreatedDate = DateTime.Parse(source.CreatedDate)
                                             };
                                         }
                                     }
 
-                                    public class Source
-                                    {
-                                        public string Value1 { get; set; }
-                                        public string Value2 { get; set; }
-                                    }
-
-                                    public class Destination
-                                    {
-                                        public int Value1 { get; set; }
-                                        public int Value2 { get; set; }
-                                    }
-
                                     public class TestProfile : Profile
                                     {
                                         public TestProfile()
                                         {
-                                            CreateMap<Source, Destination>()
-                                                .ConvertUsing<CustomConverter>();
+                                            CreateMap<Source, Destination>().ConvertUsing<UsedConverter>();
                                         }
                                     }
                                 }
                                 """;
 
-        // Global ConvertUsing with custom converter should suppress diagnostics for all properties
         await DiagnosticTestFramework
             .ForAnalyzer<AM030_CustomTypeConverterAnalyzer>()
             .WithSource(testCode)
-            .RunWithNoDiagnosticsAsync();
-    }
-
-    [Fact]
-    public async Task AM030_ShouldReportDiagnostic_ForObjectToCustomClassConversion()
-    {
-        const string testCode = """
-                                using AutoMapper;
-
-                                namespace TestNamespace
-                                {
-                                    public class CustomData
-                                    {
-                                        public string Value { get; set; }
-                                    }
-
-                                    public class Source
-                                    {
-                                        public object Data { get; set; }
-                                    }
-
-                                    public class Destination
-                                    {
-                                        public CustomData Data { get; set; }
-                                    }
-
-                                    public class TestProfile : Profile
-                                    {
-                                        public TestProfile()
-                                        {
-                                            CreateMap<Source, Destination>();
-                                        }
-                                    }
-                                }
-                                """;
-
-        // Object to custom class might need explicit mapping - handled by AM020 for nested objects
-        await DiagnosticTestFramework
-            .ForAnalyzer<AM030_CustomTypeConverterAnalyzer>()
-            .WithSource(testCode)
-            .RunWithNoDiagnosticsAsync();
+            .ExpectNoDiagnostics()
+            .RunAsync();
     }
 }

--- a/tests/AutoMapperAnalyzer.Tests/Conflicts/AnalyzerOwnershipConflictTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Conflicts/AnalyzerOwnershipConflictTests.cs
@@ -1,0 +1,208 @@
+using AutoMapperAnalyzer.Analyzers.ComplexMappings;
+using AutoMapperAnalyzer.Analyzers.TypeSafety;
+using AutoMapperAnalyzer.Tests.Framework;
+
+namespace AutoMapperAnalyzer.Tests.Conflicts;
+
+public class AnalyzerOwnershipConflictTests
+{
+    [Fact]
+    public async Task StringToIntMismatch_ReportsOnlyAM001()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public string Age { get; set; } = string.Empty;
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public int Age { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzers(
+                new AM001_PropertyTypeMismatchAnalyzer(),
+                new AM030_CustomTypeConverterAnalyzer())
+            .WithSource(testCode)
+            .ExpectDiagnostic(
+                AM001_PropertyTypeMismatchAnalyzer.PropertyTypeMismatchRule,
+                19,
+                13,
+                "Age",
+                "Source",
+                "string",
+                "Destination",
+                "int")
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task NestedObjectMismatch_ReportsOnlyAM020()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class SourceAddress
+                                    {
+                                        public string Street { get; set; } = string.Empty;
+                                    }
+
+                                    public class DestinationAddress
+                                    {
+                                        public string Street { get; set; } = string.Empty;
+                                    }
+
+                                    public class Source
+                                    {
+                                        public SourceAddress Address { get; set; } = new();
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public DestinationAddress Address { get; set; } = new();
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzers(
+                new AM020_NestedObjectMappingAnalyzer(),
+                new AM030_CustomTypeConverterAnalyzer())
+            .WithSource(testCode)
+            .ExpectDiagnostic(
+                AM020_NestedObjectMappingAnalyzer.NestedObjectMappingMissingRule,
+                29,
+                13,
+                "Address",
+                "SourceAddress",
+                "DestinationAddress")
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task CollectionElementMismatch_ReportsOnlyAM021()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Collections.Generic;
+
+                                namespace TestNamespace
+                                {
+                                    public class SourceItem
+                                    {
+                                        public string Name { get; set; } = string.Empty;
+                                    }
+
+                                    public class DestinationItem
+                                    {
+                                        public string Title { get; set; } = string.Empty;
+                                    }
+
+                                    public class Source
+                                    {
+                                        public List<SourceItem> Items { get; set; } = new();
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public List<DestinationItem> Items { get; set; } = new();
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzers(
+                new AM003_CollectionTypeIncompatibilityAnalyzer(),
+                new AM021_CollectionElementMismatchAnalyzer())
+            .WithSource(testCode)
+            .ExpectDiagnostic(
+                AM021_CollectionElementMismatchAnalyzer.CollectionElementIncompatibilityRule,
+                30,
+                13,
+                "Items",
+                "Source",
+                "TestNamespace.SourceItem",
+                "Destination",
+                "TestNamespace.DestinationItem")
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task CollectionContainerMismatch_ReportsOnlyAM003()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Collections.Generic;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public HashSet<string> Tags { get; set; } = new();
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public List<string> Tags { get; set; } = new();
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzers(
+                new AM003_CollectionTypeIncompatibilityAnalyzer(),
+                new AM021_CollectionElementMismatchAnalyzer())
+            .WithSource(testCode)
+            .ExpectDiagnostic(
+                AM003_CollectionTypeIncompatibilityAnalyzer.CollectionTypeIncompatibilityRule,
+                20,
+                13,
+                "Tags",
+                "Source",
+                "System.Collections.Generic.HashSet<string>",
+                "Destination",
+                "System.Collections.Generic.List<string>")
+            .RunAsync();
+    }
+}

--- a/tests/AutoMapperAnalyzer.Tests/DataIntegrity/AM005_CodeFixIntegrationTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/DataIntegrity/AM005_CodeFixIntegrationTests.cs
@@ -135,4 +135,67 @@ public class AM005_CodeFixIntegrationTests
                 expectedFixedCode,
                 0);
     }
+
+    [Fact]
+    public async Task AM005_ShouldApplyRenameCodeFix_WhenSourcePropertyIsEditable()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public string emailAddress { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public string EmailAddress { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string expectedFixedCode = """
+                                         using AutoMapper;
+
+                                         namespace TestNamespace
+                                         {
+                                             public class Source
+                                             {
+                                                 public string EmailAddress { get; set; }
+                                             }
+
+                                             public class Destination
+                                             {
+                                                 public string EmailAddress { get; set; }
+                                             }
+
+                                             public class TestProfile : Profile
+                                             {
+                                                 public TestProfile()
+                                                 {
+                                                     CreateMap<Source, Destination>();
+                                                 }
+                                             }
+                                         }
+                                         """;
+
+        await CodeFixVerifier<AM005_CaseSensitivityMismatchAnalyzer, AM005_CaseSensitivityMismatchCodeFixProvider>
+            .VerifyFixAsync(
+                testCode,
+                new DiagnosticResult(AM005_CaseSensitivityMismatchAnalyzer.CaseSensitivityMismatchRule)
+                    .WithLocation(19, 13)
+                    .WithArguments("emailAddress", "EmailAddress"),
+                expectedFixedCode,
+                1);
+    }
 }

--- a/tests/AutoMapperAnalyzer.Tests/DataIntegrity/AM005_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/DataIntegrity/AM005_CodeFixTests.cs
@@ -75,7 +75,7 @@ public class AM005_CodeFixTests
     }
 
     [Fact]
-    public async Task AM005_ShouldAddCaseInsensitiveConfigComment()
+    public async Task AM005_ShouldOfferExecutableFix_ForSimpleCaseMismatch()
     {
         const string testCode = """
 
@@ -123,10 +123,8 @@ public class AM005_CodeFixTests
                                              {
                                                  public TestProfile()
                                                  {
-                                                     // TODO: Consider configuring case-insensitive property matching in MapperConfiguration
-                                                     // Alternative: cfg.DestinationMemberNamingConvention = LowerUnderscoreNamingConvention.Instance;
-                                                     // or cfg.SourceMemberNamingConvention = PascalCaseNamingConvention.Instance;
-                                                     CreateMap<Source, Destination>();
+                                                     CreateMap<Source, Destination>()
+                                                         .ForMember(dest => dest.UserName, opt => opt.MapFrom(src => src.userName));
                                                  }
                                              }
                                          }
@@ -142,7 +140,7 @@ public class AM005_CodeFixTests
     }
 
     [Fact]
-    public async Task AM005_ShouldAddCasingCorrectionComment()
+    public async Task AM005_ShouldOfferExecutableFix_ForLowerCamelSourceProperty()
     {
         const string testCode = """
 
@@ -190,9 +188,8 @@ public class AM005_CodeFixTests
                                              {
                                                  public TestProfile()
                                                  {
-                                                     // TODO: Standardize property casing - consider renaming 'emailAddress' to 'EmailAddress' in source class
-                                                     // This will eliminate case sensitivity issues and improve code consistency
-                                                     CreateMap<Source, Destination>();
+                                                     CreateMap<Source, Destination>()
+                                                         .ForMember(dest => dest.EmailAddress, opt => opt.MapFrom(src => src.emailAddress));
                                                  }
                                              }
                                          }

--- a/tests/AutoMapperAnalyzer.Tests/Framework/DiagnosticTestFrameworkTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Framework/DiagnosticTestFrameworkTests.cs
@@ -165,14 +165,14 @@ public class DiagnosticTestFrameworkTests
     }
 
     [Fact]
-    public async Task MultiAnalyzerTestRunner_ThrowsNotImplemented()
+    public async Task MultiAnalyzerTestRunner_CanRun()
     {
         // Arrange
         MultiAnalyzerTestRunner runner = DiagnosticTestFramework.ForAnalyzers(new TestAnalyzer())
             .WithSource("public class Test { }");
 
-        // Act & Assert
-        await Assert.ThrowsAsync<NotImplementedException>(() => runner.RunAsync());
+        // Act & Assert (should not throw)
+        await runner.RunAsync();
     }
 }
 

--- a/tests/AutoMapperAnalyzer.Tests/Helpers/AutoMapperAnalysisHelpersTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Helpers/AutoMapperAnalysisHelpersTests.cs
@@ -148,6 +148,32 @@ public class AutoMapperAnalysisHelpersTests
     }
 
     [Fact]
+    public void IsCreateMapInvocation_ShouldReturnTrue_WhenAutoMapperMethodIsCandidateSymbol()
+    {
+        const string code = @"
+            using AutoMapper;
+            public class TestProfile : Profile
+            {
+                public TestProfile()
+                {
+                    CreateMap<string, int>(42);
+                }
+            }";
+
+        CSharpCompilation compilation = CreateCompilation(code);
+        SyntaxTree tree = compilation.SyntaxTrees.First();
+        SemanticModel semanticModel = compilation.GetSemanticModel(tree);
+        InvocationExpressionSyntax invocation = tree.GetRoot()
+            .DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .First(inv => inv.Expression.ToString().Contains("CreateMap"));
+
+        bool result = AutoMapperAnalysisHelpers.IsCreateMapInvocation(invocation, semanticModel);
+
+        Assert.True(result);
+    }
+
+    [Fact]
     public void IsCreateMapInvocation_ShouldReturnFalse_WhenNotCreateMapMethod()
     {
         const string code = @"

--- a/tests/AutoMapperAnalyzer.Tests/Helpers/AutoMapperAnalysisHelpersTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Helpers/AutoMapperAnalysisHelpersTests.cs
@@ -870,9 +870,9 @@ public class AutoMapperAnalysisHelpersTests
     }
 
     [Fact]
-    public void IsCreateMapInvocation_ShouldReturnTrue_WithMapperConfigurationContainingType()
+    public void IsCreateMapInvocation_ShouldReturnFalse_WithMapperConfigurationNamedTypeOutsideAutoMapper()
     {
-        // This tests lines 47-48: return true when containing type name contains "MapperConfiguration"
+        // Strict semantic gating should ignore lookalike CreateMap methods.
         const string code = @"
             using AutoMapper;
             public class CustomMapperConfiguration
@@ -892,7 +892,7 @@ public class AutoMapperAnalysisHelpersTests
 
         bool result = AutoMapperAnalysisHelpers.IsCreateMapInvocation(invocation, semanticModel);
 
-        Assert.True(result);
+        Assert.False(result);
     }
 
     [Fact]

--- a/tests/AutoMapperAnalyzer.Tests/Helpers/BulkFixConfigurationParserTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Helpers/BulkFixConfigurationParserTests.cs
@@ -1,0 +1,42 @@
+using AutoMapperAnalyzer.Analyzers.Helpers;
+
+namespace AutoMapperAnalyzer.Tests.Helpers;
+
+public class BulkFixConfigurationParserTests
+{
+    [Fact]
+    public void GenerateConfigurationComment_ShouldNotContainLegacyPlaceholderActions()
+    {
+        string comment = BulkFixConfigurationParser.GenerateConfigurationComment(new[]
+        {
+            ("RequiredName", "string", BulkFixAction.Default, (string?)null)
+        });
+
+        Assert.DoesNotContain("TODO", comment, StringComparison.Ordinal);
+        Assert.DoesNotContain("CUSTOM", comment, StringComparison.Ordinal);
+        Assert.DoesNotContain("NULLABLE", comment, StringComparison.Ordinal);
+        Assert.Contains("DEFAULT", comment, StringComparison.Ordinal);
+        Assert.Contains("FUZZY", comment, StringComparison.Ordinal);
+        Assert.Contains("IGNORE", comment, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Parse_ShouldMapLegacyActionsToDefault_ForBackwardCompatibility()
+    {
+        const string comment = """
+                               /* BULK-FIX-CONFIG:
+                                * Property Name           | Type              | Action        | Parameter
+                                * -------------------------------------------------------------------------------
+                                * RequiredA               | string            | TODO          |
+                                * RequiredB               | int               | CUSTOM        |
+                                * RequiredC               | string            | NULLABLE      |
+                                */
+                               """;
+
+        BulkFixConfiguration? config = BulkFixConfigurationParser.Parse(comment);
+
+        Assert.NotNull(config);
+        Assert.Equal(3, config!.PropertyActions.Count);
+        Assert.All(config.PropertyActions, action => Assert.Equal(BulkFixAction.Default, action.Action));
+    }
+}

--- a/tests/AutoMapperAnalyzer.Tests/Helpers/BulkFixConfigurationParserTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Helpers/BulkFixConfigurationParserTests.cs
@@ -39,4 +39,23 @@ public class BulkFixConfigurationParserTests
         Assert.Equal(3, config!.PropertyActions.Count);
         Assert.All(config.PropertyActions, action => Assert.Equal(BulkFixAction.Default, action.Action));
     }
+
+    [Fact]
+    public void GenerateConfigurationComment_ShouldRenderLegacyEnumValuesAsDefault()
+    {
+        string comment = BulkFixConfigurationParser.GenerateConfigurationComment(new[]
+        {
+            ("LegacyTodo", "string", BulkFixAction.Todo, (string?)null),
+            ("LegacyCustom", "int", BulkFixAction.Custom, (string?)null),
+            ("LegacyNullable", "bool", BulkFixAction.Nullable, (string?)null)
+        });
+
+        Assert.Contains("LegacyTodo", comment, StringComparison.Ordinal);
+        Assert.Contains("LegacyCustom", comment, StringComparison.Ordinal);
+        Assert.Contains("LegacyNullable", comment, StringComparison.Ordinal);
+        Assert.DoesNotContain("| TODO", comment, StringComparison.Ordinal);
+        Assert.DoesNotContain("| CUSTOM", comment, StringComparison.Ordinal);
+        Assert.DoesNotContain("| NULLABLE", comment, StringComparison.Ordinal);
+        Assert.Contains("| DEFAULT", comment, StringComparison.Ordinal);
+    }
 }

--- a/tests/AutoMapperAnalyzer.Tests/Performance/AM031_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Performance/AM031_CodeFixTests.cs
@@ -1,135 +1,308 @@
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using AutoMapper;
 using AutoMapperAnalyzer.Analyzers.Performance;
-using AutoMapperAnalyzer.Tests.Framework;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
 
 namespace AutoMapperAnalyzer.Tests.Performance;
 
 public class AM031_CodeFixTests
 {
     [Fact]
-    public async Task AM031_ShouldRegisterCodeFixes_ForMultipleEnumerationDiagnostics()
+    public async Task AM031_ShouldRegisterAndApplyCachingFix_ForMultipleEnumeration()
     {
-        const string testCode = """
-                                using AutoMapper;
-                                using System.Collections.Generic;
-                                using System.Linq;
+        const string source = """
+                              using AutoMapper;
+                              using System.Collections.Generic;
+                              using System.Linq;
 
-                                namespace TestNamespace
-                                {
-                                    public class Source
-                                    {
-                                        public List<int> Numbers { get; set; } = new();
-                                    }
+                              namespace TestNamespace
+                              {
+                                  public class Source
+                                  {
+                                      public List<int> Numbers { get; set; } = new();
+                                  }
 
-                                    public class Destination
-                                    {
-                                        public int Total { get; set; }
-                                    }
+                                  public class Destination
+                                  {
+                                      public int Total { get; set; }
+                                  }
 
-                                    public class TestProfile : Profile
-                                    {
-                                        public TestProfile()
-                                        {
-                                            CreateMap<Source, Destination>()
-                                                .ForMember(dest => dest.Total, opt => opt.MapFrom(src => src.Numbers.Sum() + src.Numbers.Average()));
-                                        }
-                                    }
-                                }
-                                """;
+                                  public class TestProfile : Profile
+                                  {
+                                      public TestProfile()
+                                      {
+                                          CreateMap<Source, Destination>()
+                                              .ForMember(dest => dest.Total, opt => opt.MapFrom(src => src.Numbers.Sum() + src.Numbers.Average()));
+                                      }
+                                  }
+                              }
+                              """;
 
-        await CodeFixTestFramework
-            .ForAnalyzer<AM031_PerformanceWarningAnalyzer>()
-            .WithCodeFix<AM031_PerformanceWarningCodeFixProvider>()
-            .WithSource(testCode)
-            .ExpectDiagnostic(AM031_PerformanceWarningAnalyzer.MultipleEnumerationRule, 22, 67,
-                "Total", "Numbers")
-            .ExpectFixedCode(testCode)
-            .RunAsync();
+        Document document = CreateDocument(source);
+        var diagnostic = await CreateDiagnosticAtSourceLambdaAsync(
+            document,
+            AM031_PerformanceWarningAnalyzer.MultipleEnumerationRule,
+            "MultipleEnumeration",
+            "Total",
+            "Total",
+            "Numbers");
+
+        List<CodeAction> actions = await RegisterActionsAsync(document, diagnostic);
+
+        CodeAction cacheAction = Assert.Single(
+            actions,
+            action => action.Title.Contains("Cache collection with ToList()", StringComparison.Ordinal));
+
+        string updatedCode = await ApplyActionAsync(cacheAction, document);
+        Assert.Contains("ToList()", updatedCode, StringComparison.Ordinal);
     }
 
     [Fact]
-    public async Task AM031_ShouldRegisterCodeFixes_ForExpensiveOperationDiagnostics()
+    public async Task AM031_ShouldOfferIgnoreOnly_WhenConventionMappingIsNotPossible()
     {
-        const string testCode = """
-                                using AutoMapper;
+        const string source = """
+                              using AutoMapper;
 
-                                namespace TestNamespace
-                                {
-                                    public class ScoreService
-                                    {
-                                        public int Calculate(int id) => id * 2;
-                                    }
+                              namespace TestNamespace
+                              {
+                                  public class ScoreService
+                                  {
+                                      public int Calculate(int id) => id * 2;
+                                  }
 
-                                    public class Source
-                                    {
-                                        public int Id { get; set; }
-                                    }
+                                  public class Source
+                                  {
+                                      public int Id { get; set; }
+                                  }
 
-                                    public class Destination
-                                    {
-                                        public int Score { get; set; }
-                                    }
+                                  public class Destination
+                                  {
+                                      public int Score { get; set; }
+                                  }
 
-                                    public class TestProfile : Profile
-                                    {
-                                        private readonly ScoreService _service;
+                                  public class TestProfile : Profile
+                                  {
+                                      private readonly ScoreService _service;
 
-                                        public TestProfile(ScoreService service)
-                                        {
-                                            _service = service;
-                                            CreateMap<Source, Destination>()
-                                                .ForMember(dest => dest.Score, opt => opt.MapFrom(src => _service.Calculate(src.Id)));
-                                        }
-                                    }
-                                }
-                                """;
+                                      public TestProfile(ScoreService service)
+                                      {
+                                          _service = service;
+                                          CreateMap<Source, Destination>()
+                                              .ForMember(dest => dest.Score, opt => opt.MapFrom(src => _service.Calculate(src.Id)));
+                                      }
+                                  }
+                              }
+                              """;
 
-        await CodeFixTestFramework
-            .ForAnalyzer<AM031_PerformanceWarningAnalyzer>()
-            .WithCodeFix<AM031_PerformanceWarningCodeFixProvider>()
-            .WithSource(testCode)
-            .ExpectDiagnostic(AM031_PerformanceWarningAnalyzer.ExpensiveOperationInMapFromRule, 28, 67,
-                "Score", "method call")
-            .ExpectFixedCode(testCode)
-            .RunAsync();
+        Document document = CreateDocument(source);
+        var diagnostic = await CreateDiagnosticAtSourceLambdaAsync(
+            document,
+            AM031_PerformanceWarningAnalyzer.ExpensiveOperationInMapFromRule,
+            "ExpensiveOperation",
+            "Score",
+            "Score",
+            "method call");
+
+        List<CodeAction> actions = await RegisterActionsAsync(document, diagnostic);
+
+        CodeAction ignoreAction = Assert.Single(
+            actions,
+            action => action.Title.Contains("Ignore mapping for 'Score'", StringComparison.Ordinal));
+        Assert.DoesNotContain(actions, action => action.Title.Contains("Remove redundant ForMember", StringComparison.Ordinal));
+
+        string updatedCode = await ApplyActionAsync(ignoreAction, document);
+        Assert.Contains(".ForMember(dest => dest.Score, opt => opt.Ignore())", updatedCode, StringComparison.Ordinal);
     }
 
     [Fact]
-    public async Task AM031_ShouldRegisterCodeFixes_ForNonDeterministicDiagnostics()
+    public async Task AM031_ShouldRegisterAndApplyRemoveForMemberFix()
     {
-        const string testCode = """
-                                using AutoMapper;
-                                using System;
+        const string source = """
+                              using AutoMapper;
 
-                                namespace TestNamespace
-                                {
-                                    public class Source
-                                    {
-                                        public DateTime Timestamp { get; set; }
-                                    }
+                              namespace TestNamespace
+                              {
+                                  public class Source
+                                  {
+                                      public int Score { get; set; }
+                                  }
 
-                                    public class Destination
-                                    {
-                                        public DateTime Timestamp { get; set; }
-                                    }
+                                  public class Destination
+                                  {
+                                      public int Score { get; set; }
+                                  }
 
-                                    public class TestProfile : Profile
-                                    {
-                                        public TestProfile()
-                                        {
-                                            CreateMap<Source, Destination>()
-                                                .ForMember(dest => dest.Timestamp, opt => opt.MapFrom(src => DateTime.Now));
-                                        }
-                                    }
-                                }
-                                """;
+                                  public class TestProfile : Profile
+                                  {
+                                      public TestProfile()
+                                      {
+                                          CreateMap<Source, Destination>()
+                                              .ForMember(dest => dest.Score, opt => opt.MapFrom(src => src.Score + 1));
+                                      }
+                                  }
+                              }
+                              """;
 
-        await CodeFixTestFramework
-            .ForAnalyzer<AM031_PerformanceWarningAnalyzer>()
-            .WithCodeFix<AM031_PerformanceWarningCodeFixProvider>()
-            .WithSource(testCode)
-            .ExpectDiagnostic(AM031_PerformanceWarningAnalyzer.NonDeterministicOperationRule, 21, 71,
-                "Timestamp", "DateTime.Now")
-            .ExpectFixedCode(testCode)
-            .RunAsync();
+        Document document = CreateDocument(source);
+        var diagnostic = await CreateDiagnosticAtSourceLambdaAsync(
+            document,
+            AM031_PerformanceWarningAnalyzer.ExpensiveOperationInMapFromRule,
+            "ExpensiveOperation",
+            "Score",
+            "Score",
+            "method call");
+        SyntaxNode root = (await document.GetSyntaxRootAsync())!;
+        InvocationExpressionSyntax forMemberInvocation = root.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .First(invocation => invocation.Expression is MemberAccessExpressionSyntax
+            {
+                Name.Identifier.Text: "ForMember"
+            });
+
+        var actions = new List<CodeAction>();
+        var context = new CodeFixContext(
+            document,
+            diagnostic,
+            (action, _) => actions.Add(action),
+            CancellationToken.None);
+
+        MethodInfo registerRemoveFixMethod = typeof(AM031_PerformanceWarningCodeFixProvider).GetMethod(
+            "RegisterRemoveForMemberFix",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var provider = new AM031_PerformanceWarningCodeFixProvider();
+        registerRemoveFixMethod.Invoke(provider, [context, root, forMemberInvocation, "Score", diagnostic]);
+
+        CodeAction removeAction = Assert.Single(actions);
+        Assert.Contains("Remove redundant ForMember for 'Score'", removeAction.Title, StringComparison.Ordinal);
+
+        string updatedCode = await ApplyActionAsync(removeAction, document);
+        Assert.Contains("CreateMap<Source, Destination>();", updatedCode, StringComparison.Ordinal);
+        Assert.DoesNotContain("ForMember(dest => dest.Score", updatedCode, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task AM031_ShouldNotRegisterFixes_ForNonAm031DiagnosticId()
+    {
+        const string source = """
+                              using AutoMapper;
+
+                              namespace TestNamespace
+                              {
+                                  public class Source
+                                  {
+                                      public int Score { get; set; }
+                                  }
+
+                                  public class Destination
+                                  {
+                                      public int Score { get; set; }
+                                  }
+
+                                  public class TestProfile : Profile
+                                  {
+                                      public TestProfile()
+                                      {
+                                          CreateMap<Source, Destination>()
+                                              .ForMember(dest => dest.Score, opt => opt.MapFrom(src => src.Score));
+                                      }
+                                  }
+                              }
+                              """;
+
+        Document document = CreateDocument(source);
+        var nonAm031Descriptor = new DiagnosticDescriptor(
+            "AM999",
+            "Synthetic diagnostic",
+            "Synthetic diagnostic",
+            "Test",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+        var diagnostic = await CreateDiagnosticAtSourceLambdaAsync(
+            document,
+            nonAm031Descriptor,
+            "ExpensiveOperation",
+            "Score");
+
+        List<CodeAction> actions = await RegisterActionsAsync(document, diagnostic);
+        Assert.Empty(actions);
+    }
+
+    private static Document CreateDocument(string source)
+    {
+        var workspace = new AdhocWorkspace();
+        ProjectId projectId = ProjectId.CreateNewId();
+        DocumentId documentId = DocumentId.CreateNewId(projectId);
+
+        Solution solution = workspace.CurrentSolution
+            .AddProject(projectId, "AM031Tests", "AM031Tests", LanguageNames.CSharp)
+            .WithProjectCompilationOptions(projectId, new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+            .WithProjectParseOptions(projectId, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+
+        string trustedPlatformAssemblies = (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") ?? string.Empty;
+        foreach (string assemblyPath in trustedPlatformAssemblies.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(assemblyPath))
+            {
+                solution = solution.AddMetadataReference(projectId, MetadataReference.CreateFromFile(assemblyPath));
+            }
+        }
+
+        solution = solution
+            .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(Profile).Assembly.Location))
+            .AddDocument(documentId, "Test0.cs", SourceText.From(source));
+
+        return solution.GetDocument(documentId)!;
+    }
+
+    private static async Task<Diagnostic> CreateDiagnosticAtSourceLambdaAsync(
+        Document document,
+        DiagnosticDescriptor descriptor,
+        string issueType,
+        string propertyName,
+        params object[] messageArgs)
+    {
+        SyntaxNode root = (await document.GetSyntaxRootAsync())!;
+        LambdaExpressionSyntax sourceLambda = root.DescendantNodes()
+            .OfType<LambdaExpressionSyntax>()
+            .First(lambda => lambda.ToString().Contains("src =>", StringComparison.Ordinal));
+
+        ImmutableDictionary<string, string?> properties = ImmutableDictionary<string, string?>.Empty
+            .Add("IssueType", issueType)
+            .Add("PropertyName", propertyName);
+
+        return Diagnostic.Create(descriptor, sourceLambda.GetLocation(), properties, messageArgs);
+    }
+
+    private static async Task<List<CodeAction>> RegisterActionsAsync(Document document, Diagnostic diagnostic)
+    {
+        var actions = new List<CodeAction>();
+        var provider = new AM031_PerformanceWarningCodeFixProvider();
+
+        var context = new CodeFixContext(
+            document,
+            diagnostic,
+            (action, _) => actions.Add(action),
+            CancellationToken.None);
+
+        await provider.RegisterCodeFixesAsync(context);
+        return actions;
+    }
+
+    private static async Task<string> ApplyActionAsync(CodeAction action, Document originalDocument)
+    {
+        ImmutableArray<CodeActionOperation> operations = await action.GetOperationsAsync(CancellationToken.None);
+        ApplyChangesOperation applyChanges = Assert.IsType<ApplyChangesOperation>(operations.Single());
+
+        Document updatedDocument = applyChanges.ChangedSolution.GetDocument(originalDocument.Id)!;
+        SourceText updatedText = await updatedDocument.GetTextAsync();
+        return updatedText.ToString();
     }
 }

--- a/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM003_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM003_CodeFixTests.cs
@@ -99,7 +99,7 @@ public class AM003_CodeFixTests
     }
 
     [Fact]
-    public async Task AM003_ShouldFixElementTypeIncompatibilityWithSelect()
+    public async Task AM003_ShouldNotReportDiagnostic_WhenElementTypesAreIncompatible()
     {
         const string testCode = """
 
@@ -128,45 +128,8 @@ public class AM003_CodeFixTests
                                 }
                                 """;
 
-        const string expectedFixedCode = """
-
-                                         using AutoMapper;
-                                         using System.Collections.Generic;
-                                         using System.Linq;
-
-                                         namespace TestNamespace
-                                         {
-                                             public class Source
-                                             {
-                                                 public List<string> Items { get; set; }
-                                             }
-
-                                             public class Destination
-                                             {
-                                                 public List<int> Items { get; set; }
-                                             }
-
-                                             public class TestProfile : Profile
-                                             {
-                                                 public TestProfile()
-                                                 {
-                                                     CreateMap<Source, Destination>().ForMember(dest => dest.Items, opt => opt.MapFrom(src => src.Items.Select(x => int.Parse(x))));
-                                                 }
-                                             }
-                                         }
-                                         """;
-
-        await VerifyFixAsync(
-            testCode,
-            AM003_CollectionTypeIncompatibilityAnalyzer.CollectionElementIncompatibilityRule,
-            21,
-            13,
-            expectedFixedCode,
-            "Items",
-            "Source",
-            "string",
-            "Destination",
-            "int");
+        // AM021 owns collection element mismatch diagnostics.
+        await AnalyzerVerifier<AM003_CollectionTypeIncompatibilityAnalyzer>.VerifyAnalyzerAsync(testCode);
     }
 
     [Fact]
@@ -445,7 +408,7 @@ public class AM003_CodeFixTests
     }
 
     [Fact]
-    public async Task AM003_ShouldFixListWithComplexElementTypeConversion()
+    public async Task AM003_ShouldNotReportDiagnostic_WhenComplexElementTypesDiffer()
     {
         const string testCode = """
                                 using AutoMapper;
@@ -473,48 +436,12 @@ public class AM003_CodeFixTests
                                 }
                                 """;
 
-        const string expectedFixedCode = """
-                                         using AutoMapper;
-                                         using System.Collections.Generic;
-                                         using System.Linq;
-
-                                         namespace TestNamespace
-                                         {
-                                             public class Source
-                                             {
-                                                 public List<object> Data { get; set; }
-                                             }
-
-                                             public class Destination
-                                             {
-                                                 public List<string> Data { get; set; }
-                                             }
-
-                                             public class TestProfile : Profile
-                                             {
-                                                 public TestProfile()
-                                                 {
-                                                     CreateMap<Source, Destination>().ForMember(dest => dest.Data, opt => opt.MapFrom(src => src.Data.Select(x => x != null ? x.ToString() : string.Empty)));
-                                                 }
-                                             }
-                                         }
-                                         """;
-
-        await VerifyFixAsync(
-            testCode,
-            AM003_CollectionTypeIncompatibilityAnalyzer.CollectionElementIncompatibilityRule,
-            20,
-            13,
-            expectedFixedCode,
-            "Data",
-            "Source",
-            "object",
-            "Destination",
-            "string");
+        // AM021 owns collection element mismatch diagnostics.
+        await AnalyzerVerifier<AM003_CollectionTypeIncompatibilityAnalyzer>.VerifyAnalyzerAsync(testCode);
     }
 
     [Fact]
-    public async Task AM003_ShouldFixListToBoolConversionWithParse()
+    public async Task AM003_ShouldNotReportDiagnostic_WhenPrimitiveElementTypesDiffer()
     {
         const string testCode = """
                                 using AutoMapper;
@@ -542,44 +469,8 @@ public class AM003_CodeFixTests
                                 }
                                 """;
 
-        const string expectedFixedCode = """
-                                         using AutoMapper;
-                                         using System.Collections.Generic;
-                                         using System.Linq;
-
-                                         namespace TestNamespace
-                                         {
-                                             public class Source
-                                             {
-                                                 public List<string> Flags { get; set; }
-                                             }
-
-                                             public class Destination
-                                             {
-                                                 public List<bool> Flags { get; set; }
-                                             }
-
-                                             public class TestProfile : Profile
-                                             {
-                                                 public TestProfile()
-                                                 {
-                                                     CreateMap<Source, Destination>().ForMember(dest => dest.Flags, opt => opt.MapFrom(src => src.Flags.Select(x => bool.Parse(x))));
-                                                 }
-                                             }
-                                         }
-                                         """;
-
-        await VerifyFixAsync(
-            testCode,
-            AM003_CollectionTypeIncompatibilityAnalyzer.CollectionElementIncompatibilityRule,
-            20,
-            13,
-            expectedFixedCode,
-            "Flags",
-            "Source",
-            "string",
-            "Destination",
-            "bool");
+        // AM021 owns collection element mismatch diagnostics.
+        await AnalyzerVerifier<AM003_CollectionTypeIncompatibilityAnalyzer>.VerifyAnalyzerAsync(testCode);
     }
 
     [Fact]
@@ -719,7 +610,7 @@ public class AM003_CodeFixTests
     }
 
     [Fact]
-    public async Task AM003_ShouldHandleDoubleToIntElementConversion()
+    public async Task AM003_ShouldNotReportDiagnostic_WhenNumericElementTypesDiffer()
     {
         const string testCode = """
                                 using AutoMapper;
@@ -747,44 +638,8 @@ public class AM003_CodeFixTests
                                 }
                                 """;
 
-        const string expectedFixedCode = """
-                                         using AutoMapper;
-                                         using System.Collections.Generic;
-                                         using System.Linq;
-
-                                         namespace TestNamespace
-                                         {
-                                             public class Source
-                                             {
-                                                 public List<double> Measurements { get; set; }
-                                             }
-
-                                             public class Destination
-                                             {
-                                                 public List<int> Measurements { get; set; }
-                                             }
-
-                                             public class TestProfile : Profile
-                                             {
-                                                 public TestProfile()
-                                                 {
-                                                     CreateMap<Source, Destination>().ForMember(dest => dest.Measurements, opt => opt.MapFrom(src => src.Measurements.Select(x => global::System.Convert.ToInt32(x))));
-                                                 }
-                                             }
-                                         }
-                                         """;
-
-        await VerifyFixAsync(
-            testCode,
-            AM003_CollectionTypeIncompatibilityAnalyzer.CollectionElementIncompatibilityRule,
-            20,
-            13,
-            expectedFixedCode,
-            "Measurements",
-            "Source",
-            "double",
-            "Destination",
-            "int");
+        // AM021 owns collection element mismatch diagnostics.
+        await AnalyzerVerifier<AM003_CollectionTypeIncompatibilityAnalyzer>.VerifyAnalyzerAsync(testCode);
     }
 
     [Fact]

--- a/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM003_CollectionTypeIncompatibilityTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM003_CollectionTypeIncompatibilityTests.cs
@@ -51,7 +51,7 @@ public class AM003_CollectionTypeIncompatibilityTests
     }
 
     [Fact]
-    public async Task AM003_ShouldReportDiagnostic_WhenCollectionElementTypesIncompatible()
+    public async Task AM003_ShouldNotReportDiagnostic_WhenCollectionElementTypesIncompatible()
     {
         const string testCode = """
 
@@ -80,10 +80,8 @@ public class AM003_CollectionTypeIncompatibilityTests
                                 }
                                 """;
 
-        await AnalyzerVerifier<AM003_CollectionTypeIncompatibilityAnalyzer>.VerifyAnalyzerAsync(
-            testCode,
-            Diagnostic(AM003_CollectionTypeIncompatibilityAnalyzer.CollectionElementIncompatibilityRule, 21, 13,
-                "Items", "Source", "string", "Destination", "int"));
+        // AM021 owns collection element mismatch diagnostics.
+        await AnalyzerVerifier<AM003_CollectionTypeIncompatibilityAnalyzer>.VerifyAnalyzerAsync(testCode);
     }
 
     [Fact]
@@ -226,7 +224,7 @@ public class AM003_CollectionTypeIncompatibilityTests
     }
 
     [Fact]
-    public async Task AM003_ShouldReportDiagnostic_WhenNumericElementTypesIncompatible()
+    public async Task AM003_ShouldNotReportDiagnostic_WhenNumericElementTypesIncompatible()
     {
         const string testCode = """
 
@@ -255,10 +253,8 @@ public class AM003_CollectionTypeIncompatibilityTests
                                 }
                                 """;
 
-        await AnalyzerVerifier<AM003_CollectionTypeIncompatibilityAnalyzer>.VerifyAnalyzerAsync(
-            testCode,
-            Diagnostic(AM003_CollectionTypeIncompatibilityAnalyzer.CollectionElementIncompatibilityRule, 21, 13,
-                "Numbers", "Source", "int", "Destination", "string"));
+        // AM021 owns collection element mismatch diagnostics.
+        await AnalyzerVerifier<AM003_CollectionTypeIncompatibilityAnalyzer>.VerifyAnalyzerAsync(testCode);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
This PR implements the analyzer/fixer conflict-resolution and UX hardening pass by enforcing single-owner diagnostics for overlap-prone scenarios and prioritizing executable code fixes.

## Key Changes
- Enforced analyzer ownership boundaries:
  - `AM003` now owns collection container mismatch diagnostics only.
  - `AM021` is sole owner of collection element mismatches.
  - `AM030` now focuses on converter-quality diagnostics (`invalid implementation`, `null handling`, `unused converter`) and no longer reports property-level missing-converter diagnostics.
- Standardized strict semantic AutoMapper method gating across targeted analyzers; removed permissive name-based heuristics in helpers.
- Hardened code-fix UX:
  - `AM005`: executable fixes only (explicit map + source rename action).
  - `AM011`: removed placeholder/comment actions; retained resolving actions and added source-property creation paths.
  - `AM031`: removed risky cross-file rewrites; now safe fixes only.
  - `AM030`: removed missing-converter fixes; added null-guard insertion fix.
- Implemented multi-analyzer test runner and added conflict ownership test suite.
- Updated/rewrote analyzer and code-fix tests for AM003/AM021/AM030/AM031/AM005 behavior changes.
- Added parser regression tests for legacy bulk-fix action fallback (`TODO/CUSTOM/NULLABLE -> DEFAULT`).
- Added `docs/TEST_LIMITATIONS.md` and updated rules/architecture/review-tracker docs.

## Validation
- `dotnet test automapper-analyser.sln -nologo -v q`
  - Passed: 577, Skipped: 4, Failed: 0
- `dotnet build samples/AutoMapperAnalyzer.Samples/AutoMapperAnalyzer.Samples.csproj -nologo -v minimal`
  - Build succeeded
- Verified no same-location overlap for target conflict pairs in sample analyzer output:
  - `AM001 + AM030`
  - `AM020 + AM030`
  - `AM003 + AM021`
