### PR TITLE
fix: harden AutoMapper code actions for v2.30.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet Version](https://img.shields.io/nuget/v/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=NuGet)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=Downloads)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/georgepwall1991/automapper-analyser/ci.yml?style=flat-square&logo=github&label=Build)](https://github.com/georgepwall1991/automapper-analyser/actions)
-[![Tests](https://img.shields.io/badge/Tests-627%20passing%2C%209%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
+[![Tests](https://img.shields.io/badge/Tests-633%20passing%2C%208%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
 [![.NET](https://img.shields.io/badge/.NET-4.8+%20%7C%206.0+%20%7C%208.0+%20%7C%209.0+%20%7C%2010.0+-512BD4?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 [![Coverage](https://img.shields.io/codecov/c/github/georgepwall1991/automapper-analyser?style=flat-square&logo=codecov&label=Coverage)](https://codecov.io/gh/georgepwall1991/automapper-analyser)
@@ -14,27 +14,27 @@ prevention*
 
 ---
 
-## 🎉 Latest Release: v2.29.0
+## 🎉 Latest Release: v2.30.0
 
-**Smart Primary Fix — reduced fixer noise to max 2 options per diagnostic**
+**Fixer Hardening — safer actions for collections, fuzzy matches, and multi-diagnostic maps**
 
 ✅ **Highlights**
 
-- Simplified code fixers AM002, AM004, AM006, and AM011 from 5-10 lightbulb options down to max 2 per diagnostic.
-- Each fixer now offers one contextually-chosen best fix plus one fallback (e.g. ignore/suppress).
-- Removed bulk fix infrastructure (`BulkFixConfigurationParser`, grouped actions, nested code action menus).
-- Uses `WellKnownFixAllProviders.BatchFixer` for multi-diagnostic scenarios instead of custom bulk logic.
-- Fuzzy matching selects the single best candidate; falls back to default value or ignore when no good match exists.
-- Deleted ~900 lines of code across fixers and base class while preserving all functional behavior.
+- Fixed AM021 simple collection conversions for `Queue<T>` and `Stack<T>` so the suggested code now matches the destination collection shape.
+- Fixed AM001 so multiple type mismatches on the same `CreateMap` expose stable, per-property actions instead of only handling the first diagnostic.
+- Tightened AM006 and AM011 fuzzy matching to offer a mapping action only when there is a unique best candidate.
+- Removed AM005 rename-based lightbulbs and kept the explicit executable mapping action only.
+- Added targeted regression coverage for action ordering, ambiguous fuzzy matches, and queue/stack conversion fixes.
 
 🧪 **Validation**
 
-- Full solution builds passed in `Debug` and `Release`.
-- Full test suite passed with `627` passing and `9` skipped.
-- Code review fixes applied: removed unused variables (AM004, AM006) and prevented false fuzzy matches (AM011).
+- Full solution builds passed in `Release`.
+- Full test suite passed with `633` passing and `8` skipped.
+- Release validation covered targeted fixer regressions plus full Release build/test passes before tagging.
 
 ### Recent Releases
 
+- **v2.29.0**: Smart primary fix and reduced fixer noise across the main data-integrity fixers.
 - **v2.28.2**: False-positive reduction, fixer UX improvements, and release workflow hardening.
 - **v2.28.1**: Case-aware AM021 suppression and fixer reliability improvements.
 - **v2.28.0**: Analyzer logic fixes and performance improvements.
@@ -169,7 +169,7 @@ Install-Package AutoMapperAnalyzer.Analyzers
 ### Project File (For CI/CD)
 
 ```xml
-<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.29.0">
+<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.0">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 </PackageReference>
@@ -352,7 +352,7 @@ This isn't just another analyzer—it's built for **enterprise-grade reliability
 
 - **🏎️ Performance-First**: Incremental analysis with minimal IDE impact
 - **🔧 Extensible Design**: Clean plugin architecture for new rules
-- **🧪 Battle-Tested**: 636 tests with 627 passing and 9 intentionally skipped scenarios
+- **🧪 Battle-Tested**: release validation includes full suite coverage plus targeted regression tests for high-risk fixers
 - **🌐 Cross-Platform**: Identical behavior on Windows, macOS, Linux
 - **⚡ CI/CD Ready**: Automated GitHub Actions with codecov integration
 - **📊 Code Coverage**: 55%+ coverage with comprehensive testing
@@ -363,6 +363,7 @@ This isn't just another analyzer—it's built for **enterprise-grade reliability
 
 ### Recently Completed ✅
 
+- **v2.30.0**: Fixer hardening for AM001, AM005, AM006, AM011, and AM021 with safer action selection
 - **v2.29.0**: Smart Primary Fix — reduced fixer noise to max 2 lightbulb options per diagnostic
 - **v2.28.2**: False-positive reduction, fixer UX improvements, and release workflow hardening
 - **v2.28.1**: Case-aware AM021 suppression and fixer accuracy improvements

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet Version](https://img.shields.io/nuget/v/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=NuGet)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=Downloads)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/georgepwall1991/automapper-analyser/ci.yml?style=flat-square&logo=github&label=Build)](https://github.com/georgepwall1991/automapper-analyser/actions)
-[![Tests](https://img.shields.io/badge/Tests-633%20passing%2C%208%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
+[![Tests](https://img.shields.io/badge/Tests-635%20passing%2C%208%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
 [![.NET](https://img.shields.io/badge/.NET-4.8+%20%7C%206.0+%20%7C%208.0+%20%7C%209.0+%20%7C%2010.0+-512BD4?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 [![Coverage](https://img.shields.io/codecov/c/github/georgepwall1991/automapper-analyser?style=flat-square&logo=codecov&label=Coverage)](https://codecov.io/gh/georgepwall1991/automapper-analyser)
@@ -29,7 +29,7 @@ prevention*
 🧪 **Validation**
 
 - Full solution builds passed in `Release`.
-- Full test suite passed with `633` passing and `8` skipped.
+- Full test suite passed with `635` passing and `8` skipped.
 - Release validation covered targeted fixer regressions plus full Release build/test passes before tagging.
 
 ### Recent Releases

--- a/docs/ANALYZER_REVIEW_TRACKER.md
+++ b/docs/ANALYZER_REVIEW_TRACKER.md
@@ -27,6 +27,7 @@ Tracks analyzer-by-analyzer improvement passes focused on false positives, contr
 | Bug Fixes + Coverage | AM004, AM006, AM011 | main | v2.24.0 | Fixed AM011 chunked bulk fix placeholder bug, fixed AM004 FindCreateMapInvocation tree traversal for ReverseMap, added 32 new tests (FuzzyMatchHelper, AutoMapperAnalysisHelpers, ReverseMap code fix regression). |
 | Ownership + Fixer Hardening | AM003, AM005, AM011, AM020, AM021, AM022, AM030, AM031 | main | TBD | Enforced single-owner overlap policy (AM003 vs AM021, removed property-level AM030 overlap), added strict symbol-only AutoMapper gating, implemented AM030 unused-converter reporting, and hardened fixers to executable-first actions (AM005 rename/explicit map, AM011 placeholder removal + legacy parser fallback, AM031 safe fixes only). |
 | Case-aware Suppression + Fix Routing | AM006, AM020, AM021 | main | v2.28.1 | Fixed AM021 source/destination property-name routing for case-only matches, added top-level parsing for string-literal member paths in shared suppression helpers, and expanded regression coverage for explicit configuration suppression and conflict ownership. |
+| Fixer Hardening Follow-up | AM001, AM005, AM006, AM011, AM021 | main | v2.30.0 | Fixed AM021 queue/stack conversion codegen, restored stable per-diagnostic AM001 action registration, required unique-best fuzzy matches for AM006/AM011, removed AM005 rename actions, and added targeted regression coverage for action ordering and ambiguous suggestions. |
 
 ## In Progress
 

--- a/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
+++ b/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
@@ -16,8 +16,8 @@
         <!-- Semantic Versioning: Version is set by release workflow via /p:PackageVersion=X.Y.Z -->
         <!-- Fallback for local builds: 2.0.YYYYMMDD-local -->
         <MajorVersion>2</MajorVersion>
-        <MinorVersion>28</MinorVersion>
-        <PatchVersion>2</PatchVersion>
+        <MinorVersion>30</MinorVersion>
+        <PatchVersion>0</PatchVersion>
         <BuildNumber Condition="'$(BuildNumber)' == ''"
         >$([System.DateTime]::Now.ToString('yyyyMMdd'))
         </BuildNumber
@@ -32,19 +32,19 @@
         <RepositoryUrl>https://github.com/georgepwall1991/automapper-analyser</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <PackageReleaseNotes>Version 2.28.2 - False-positive reduction and code-fix UX improvements
+        <PackageReleaseNotes>Version 2.30.0 - Fixer hardening and safer action selection
 
             Fixes:
-            - Reduced false positives when ConstructUsing or ConvertUsing fully handles AM001, AM002, AM003, AM005, AM020, and AM021 scenarios
-            - Improved ForPath and string-literal member handling so explicit nested configuration suppresses the right diagnostics
-            - Hardened AM031 fixes for overlapping diagnostics, multiple-enumeration caching, and convention-removal suggestions
-            - Improved code-fix presentation with clearer AM011, AM020, AM041, and AM050 action titles and stable equivalence keys
+            - Fixed AM021 queue and stack collection-element conversions to generate compilable constructor-based mappings
+            - Fixed AM001 so multi-diagnostic CreateMap sites register stable per-property actions instead of only the first mismatch
+            - Hardened AM006 and AM011 fuzzy matching to require a unique best candidate before offering speculative mapping actions
+            - Removed AM005 source-property rename suggestions and kept the executable explicit-mapping action only
 
             Validation:
-            - Full solution builds in Debug and Release
-            - Full test suite passing in Release configuration with targeted fixer UI regression coverage
+            - Full solution builds in Release
+            - Full analyzer test suite passing in Release with targeted fixer regression coverage
 
-            Previous Release: v2.28.1 - case-aware mapping suppression and AM021 fixer reliability
+            Previous Release: v2.29.0 - smart primary fix and reduced fixer noise
         </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>

--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM021_CollectionElementMismatchCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM021_CollectionElementMismatchCodeFixProvider.cs
@@ -134,9 +134,16 @@ public class AM021_CollectionElementMismatchCodeFixProvider : AutoMapperCodeFixP
         SemanticModel semanticModel)
     {
         string conversionMethod = GetConversionMethod(destElementType);
-        string collectionMethod = GetCollectionMaterializationMethod(invocation, destinationPropertyName, semanticModel);
-
-        string mapFromExpression = $"src.{sourcePropertyName}.Select(x => {conversionMethod}(x)).{collectionMethod}()";
+        string? mapFromExpression = CreateSimpleConversionExpression(
+            invocation,
+            sourcePropertyName,
+            destinationPropertyName,
+            conversionMethod,
+            semanticModel);
+        if (mapFromExpression == null)
+        {
+            return;
+        }
 
         context.RegisterCodeFix(
             CodeAction.Create(
@@ -190,8 +197,9 @@ public class AM021_CollectionElementMismatchCodeFixProvider : AutoMapperCodeFixP
         {
             newRoot = AddUsingIfMissing(compilationUnit, "System.Linq");
 
-            // Add using System if Convert is used
-            if (mapFromExpression.Contains("Convert."))
+            if (mapFromExpression.Contains("Convert.", StringComparison.Ordinal) ||
+                mapFromExpression.Contains("DateTime.", StringComparison.Ordinal) ||
+                mapFromExpression.Contains("Guid.", StringComparison.Ordinal))
             {
                 newRoot = AddUsingIfMissing((CompilationUnitSyntax)newRoot, "System");
             }
@@ -277,49 +285,58 @@ public class AM021_CollectionElementMismatchCodeFixProvider : AutoMapperCodeFixP
         );
     }
 
-    private static string GetCollectionMaterializationMethod(InvocationExpressionSyntax invocation, string propertyName,
+    private static string? CreateSimpleConversionExpression(
+        InvocationExpressionSyntax invocation,
+        string sourcePropertyName,
+        string destinationPropertyName,
+        string conversionMethod,
         SemanticModel semanticModel)
     {
-        // Get the destination property type to determine the appropriate collection method
         (ITypeSymbol? sourceType, ITypeSymbol? destType) createMapTypes =
             AutoMapperAnalysisHelpers.GetCreateMapTypeArguments(invocation, semanticModel);
         if (createMapTypes.Item2 == null)
         {
-            return "ToList"; // Default
+            return null;
         }
 
         IPropertySymbol? destProperty = createMapTypes.Item2.GetMembers()
             .OfType<IPropertySymbol>()
-            .FirstOrDefault(p => string.Equals(p.Name, propertyName, StringComparison.OrdinalIgnoreCase));
+            .FirstOrDefault(p => string.Equals(p.Name, destinationPropertyName, StringComparison.OrdinalIgnoreCase));
 
         if (destProperty == null)
         {
-            return "ToList";
+            return null;
         }
 
-        string destTypeName = destProperty.Type.ToDisplayString();
+        string selectExpression = $"src.{sourcePropertyName}.Select(x => {conversionMethod}(x))";
+        string destinationTypeName = destProperty.Type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
 
-        if (destTypeName.Contains("HashSet"))
+        if (destProperty.Type.TypeKind == TypeKind.Array)
         {
-            return "ToHashSet";
+            return $"{selectExpression}.ToArray()";
         }
 
-        if (destTypeName.Contains("[]"))
+        if (IsConstructedFromType(destProperty.Type, "System.Collections.Generic.List<T>"))
         {
-            return "ToArray";
+            return $"{selectExpression}.ToList()";
         }
 
-        if (destTypeName.Contains("Stack"))
+        if (IsConstructedFromType(destProperty.Type, "System.Collections.Generic.HashSet<T>"))
         {
-            return "ToList"; // Stack doesn't have ToStack, use ToList + new Stack<T>
+            return $"{selectExpression}.ToHashSet()";
         }
 
-        if (destTypeName.Contains("Queue"))
+        if (IsConstructedFromType(destProperty.Type, "System.Collections.Generic.Queue<T>"))
         {
-            return "ToList"; // Queue doesn't have ToQueue, use ToList + new Queue<T>
+            return $"new {destinationTypeName}({selectExpression})";
         }
 
-        return "ToList";
+        if (IsConstructedFromType(destProperty.Type, "System.Collections.Generic.Stack<T>"))
+        {
+            return $"new {destinationTypeName}({selectExpression})";
+        }
+
+        return null;
     }
 
     private static bool IsSimpleTypeConversion(string sourceElementType, string destElementType)
@@ -433,6 +450,12 @@ public class AM021_CollectionElementMismatchCodeFixProvider : AutoMapperCodeFixP
             "Char" => "System.Char",
             _ => normalized
         };
+    }
+
+    private static bool IsConstructedFromType(ITypeSymbol type, string genericDefinitionName)
+    {
+        return type is INamedTypeSymbol namedType &&
+               namedType.OriginalDefinition.ToDisplayString() == genericDefinitionName;
     }
 
     private static string? ExtractPropertyNameFromDiagnostic(Diagnostic diagnostic)

--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM021_CollectionElementMismatchCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM021_CollectionElementMismatchCodeFixProvider.cs
@@ -321,6 +321,15 @@ public class AM021_CollectionElementMismatchCodeFixProvider : AutoMapperCodeFixP
             return $"{selectExpression}.ToList()";
         }
 
+        if (IsConstructedFromType(destProperty.Type, "System.Collections.Generic.IEnumerable<T>") ||
+            IsConstructedFromType(destProperty.Type, "System.Collections.Generic.ICollection<T>") ||
+            IsConstructedFromType(destProperty.Type, "System.Collections.Generic.IList<T>") ||
+            IsConstructedFromType(destProperty.Type, "System.Collections.Generic.IReadOnlyCollection<T>") ||
+            IsConstructedFromType(destProperty.Type, "System.Collections.Generic.IReadOnlyList<T>"))
+        {
+            return $"{selectExpression}.ToList()";
+        }
+
         if (IsConstructedFromType(destProperty.Type, "System.Collections.Generic.HashSet<T>"))
         {
             return $"{selectExpression}.ToHashSet()";

--- a/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM005_CaseSensitivityMismatchCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM005_CaseSensitivityMismatchCodeFixProvider.cs
@@ -5,7 +5,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Rename;
 
 namespace AutoMapperAnalyzer.Analyzers.DataIntegrity;
 
@@ -66,44 +65,6 @@ public class AM005_CaseSensitivityMismatchCodeFixProvider : AutoMapperCodeFixPro
                 $"ExplicitMapping_{sourcePropertyName}_{destinationPropertyName}");
 
             context.RegisterCodeFix(explicitMappingAction, diagnostic);
-
-            // Fix 2: Rename source property when it is editable in source.
-            var sourcePropertySymbol = FindSourcePropertySymbol(
-                invocation,
-                operationContext.SemanticModel,
-                sourcePropertyName);
-            if (sourcePropertySymbol?.Locations.Any(location => location.IsInSource) == true)
-            {
-                var renameAction = CodeAction.Create(
-                    $"Rename source property '{sourcePropertyName}' to '{destinationPropertyName}'",
-                    cancellationToken =>
-                        Renamer.RenameSymbolAsync(
-                            context.Document.Project.Solution,
-                            sourcePropertySymbol,
-                            new SymbolRenameOptions(),
-                            destinationPropertyName,
-                            cancellationToken),
-                    $"Rename_{sourcePropertyName}_{destinationPropertyName}");
-
-                context.RegisterCodeFix(renameAction, diagnostic);
-            }
         }
-    }
-
-    private static IPropertySymbol? FindSourcePropertySymbol(
-        InvocationExpressionSyntax createMapInvocation,
-        SemanticModel semanticModel,
-        string sourcePropertyName)
-    {
-        (ITypeSymbol? sourceType, ITypeSymbol? _) =
-            MappingChainAnalysisHelper.GetCreateMapTypeArguments(createMapInvocation, semanticModel);
-        if (sourceType == null)
-        {
-            return null;
-        }
-
-        return AutoMapperAnalysisHelpers.GetMappableProperties(sourceType, requireSetter: false)
-            .FirstOrDefault(property =>
-                string.Equals(property.Name, sourcePropertyName, StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM006_UnmappedDestinationPropertyCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM006_UnmappedDestinationPropertyCodeFixProvider.cs
@@ -48,8 +48,8 @@ public class AM006_UnmappedDestinationPropertyCodeFixProvider : AutoMapperCodeFi
                         var sourceProperties = AutoMapperAnalysisHelpers
                             .GetMappableProperties(sourceType, requireSetter: false);
 
-                        var bestMatch = FuzzyMatchHelper.FindFuzzyMatches(propertyName, sourceProperties, destPropertySymbol.Type)
-                            .FirstOrDefault();
+                        IPropertySymbol? bestMatch =
+                            FuzzyMatchHelper.FindUniqueBestFuzzyMatch(propertyName, sourceProperties, destPropertySymbol.Type);
 
                         if (bestMatch != null)
                         {

--- a/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM011_UnmappedRequiredPropertyCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM011_UnmappedRequiredPropertyCodeFixProvider.cs
@@ -42,8 +42,8 @@ public class AM011_UnmappedRequiredPropertyCodeFixProvider : AutoMapperCodeFixPr
 
                     if (destinationProperty != null)
                     {
-                        bestFuzzyMatch = FuzzyMatchHelper.FindFuzzyMatches(propertyName, sourceProperties, destinationProperty.Type)
-                            .FirstOrDefault();
+                        bestFuzzyMatch =
+                            FuzzyMatchHelper.FindUniqueBestFuzzyMatch(propertyName, sourceProperties, destinationProperty.Type);
                     }
                 }
 

--- a/src/AutoMapperAnalyzer.Analyzers/Helpers/FuzzyMatchHelper.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Helpers/FuzzyMatchHelper.cs
@@ -101,4 +101,42 @@ public static class FuzzyMatchHelper
     {
         return candidateProperties.Where(p => IsFuzzyMatchCandidate(targetPropertyName, p, targetPropertyType));
     }
+
+    /// <summary>
+    ///     Finds a single best fuzzy match candidate when there is a unique lowest-distance match.
+    ///     Returns null when there are no compatible candidates or when multiple candidates tie for best score.
+    /// </summary>
+    /// <param name="targetPropertyName">The property name to find a fuzzy match for.</param>
+    /// <param name="candidateProperties">The properties to search for matches.</param>
+    /// <param name="targetPropertyType">The type of the target property, used for compatibility checking.</param>
+    /// <returns>The unique best fuzzy match candidate, or null if the best score is ambiguous.</returns>
+    public static IPropertySymbol? FindUniqueBestFuzzyMatch(
+        string targetPropertyName,
+        IEnumerable<IPropertySymbol> candidateProperties,
+        ITypeSymbol targetPropertyType)
+    {
+        var rankedMatches = candidateProperties
+            .Where(candidate => IsFuzzyMatchCandidate(targetPropertyName, candidate, targetPropertyType))
+            .Select(candidate => new
+            {
+                Candidate = candidate,
+                Distance = ComputeLevenshteinDistance(targetPropertyName, candidate.Name)
+            })
+            .OrderBy(match => match.Distance)
+            .ThenBy(match => match.Candidate.Name, StringComparer.Ordinal)
+            .ToList();
+
+        if (rankedMatches.Count == 0)
+        {
+            return null;
+        }
+
+        int bestDistance = rankedMatches[0].Distance;
+        if (rankedMatches.Count(match => match.Distance == bestDistance) != 1)
+        {
+            return null;
+        }
+
+        return rankedMatches[0].Candidate;
+    }
 }

--- a/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM001_PropertyTypeMismatchCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM001_PropertyTypeMismatchCodeFixProvider.cs
@@ -81,13 +81,7 @@ public class AM001_PropertyTypeMismatchCodeFixProvider : AutoMapperCodeFixProvid
                     CodeAction.Create(
                         $"Map '{propertyNameValue}' with conversion",
                         cancellationToken =>
-                        {
-                            InvocationExpressionSyntax newInvocation = CodeFixSyntaxHelper.CreateForMemberWithMapFrom(
-                                invocation,
-                                propertyNameValue,
-                                conversionExpression);
-                            return ReplaceNodeAsync(context.Document, operationContext.Root, invocation, newInvocation);
-                        },
+                            AddMapFromAsync(context.Document, diagnostic, propertyNameValue, conversionExpression, cancellationToken),
                         $"AM001_MapWithConversion_{propertyNameValue}"),
                     diagnostic);
             }
@@ -96,11 +90,7 @@ public class AM001_PropertyTypeMismatchCodeFixProvider : AutoMapperCodeFixProvid
                 CodeAction.Create(
                     $"Ignore property '{propertyNameValue}'",
                     cancellationToken =>
-                    {
-                        InvocationExpressionSyntax newInvocation =
-                            CodeFixSyntaxHelper.CreateForMemberWithIgnore(invocation, propertyNameValue);
-                        return ReplaceNodeAsync(context.Document, operationContext.Root, invocation, newInvocation);
-                    },
+                        AddIgnoreAsync(context.Document, diagnostic, propertyNameValue, cancellationToken),
                     $"AM001_Ignore_{propertyNameValue}"),
                 diagnostic);
         }
@@ -120,6 +110,53 @@ public class AM001_PropertyTypeMismatchCodeFixProvider : AutoMapperCodeFixProvid
                     out string? propertyName)
                 ? propertyName
                 : diag.GetMessage(), StringComparer.Ordinal);
+    }
+
+    private async Task<Document> AddMapFromAsync(
+        Document document,
+        Diagnostic diagnostic,
+        string propertyName,
+        string conversionExpression,
+        CancellationToken cancellationToken)
+    {
+        SyntaxNode? root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root == null)
+        {
+            return document;
+        }
+
+        InvocationExpressionSyntax? invocation = GetCreateMapInvocation(root, diagnostic);
+        if (invocation == null)
+        {
+            return document;
+        }
+
+        InvocationExpressionSyntax newInvocation =
+            CodeFixSyntaxHelper.CreateForMemberWithMapFrom(invocation, propertyName, conversionExpression);
+        return await ReplaceNodeAsync(document, root, invocation, newInvocation);
+    }
+
+    private async Task<Document> AddIgnoreAsync(
+        Document document,
+        Diagnostic diagnostic,
+        string propertyName,
+        CancellationToken cancellationToken)
+    {
+        SyntaxNode? root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root == null)
+        {
+            return document;
+        }
+
+        InvocationExpressionSyntax? invocation = GetCreateMapInvocation(root, diagnostic);
+        if (invocation == null)
+        {
+            return document;
+        }
+
+        InvocationExpressionSyntax newInvocation =
+            CodeFixSyntaxHelper.CreateForMemberWithIgnore(invocation, propertyName);
+        return await ReplaceNodeAsync(document, root, invocation, newInvocation);
     }
 
     private static IPropertySymbol? FindProperty(ITypeSymbol typeSymbol, string name, bool expectSetter)

--- a/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM001_PropertyTypeMismatchCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM001_PropertyTypeMismatchCodeFixProvider.cs
@@ -33,87 +33,93 @@ public class AM001_PropertyTypeMismatchCodeFixProvider : AutoMapperCodeFixProvid
             return;
         }
 
-        Diagnostic? diagnostic = context.Diagnostics.FirstOrDefault(diag =>
-            diag.Id == "AM001" &&
-            diag.Location.IsInSource &&
-            diag.Location.SourceTree == operationContext.Root.SyntaxTree &&
-            diag.Location.SourceSpan.IntersectsWith(context.Span));
-
-        if (diagnostic == null)
+        foreach (Diagnostic diagnostic in GetRelevantDiagnostics(context, operationContext.Root))
         {
-            return;
-        }
+            InvocationExpressionSyntax? invocation = GetCreateMapInvocation(operationContext.Root, diagnostic);
+            if (invocation == null)
+            {
+                continue;
+            }
 
-        // Find the CreateMap invocation that triggered the diagnostic
-        InvocationExpressionSyntax? invocation = GetCreateMapInvocation(operationContext.Root, diagnostic);
-        if (invocation == null)
-        {
-            return;
-        }
+            string? propertyName = ExtractPropertyNameFromDiagnostic(diagnostic);
+            if (string.IsNullOrEmpty(propertyName))
+            {
+                continue;
+            }
 
-        // Extract property name from diagnostic message
-        string? propertyName = ExtractPropertyNameFromDiagnostic(diagnostic);
-        if (string.IsNullOrEmpty(propertyName))
-        {
-            return;
-        }
+            string propertyNameValue = propertyName!;
 
-        SymbolInfo semanticInfo = operationContext.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken);
-        if (semanticInfo.Symbol is not IMethodSymbol methodSymbol || methodSymbol.TypeArguments.Length != 2)
-        {
-            return;
-        }
+            SymbolInfo semanticInfo = operationContext.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken);
+            if (semanticInfo.Symbol is not IMethodSymbol methodSymbol || methodSymbol.TypeArguments.Length != 2)
+            {
+                continue;
+            }
 
-        ITypeSymbol sourceType = methodSymbol.TypeArguments[0];
-        ITypeSymbol destinationType = methodSymbol.TypeArguments[1];
+            ITypeSymbol sourceType = methodSymbol.TypeArguments[0];
+            ITypeSymbol destinationType = methodSymbol.TypeArguments[1];
 
-        IPropertySymbol? sourceProperty = FindProperty(sourceType, propertyName!, false);
-        IPropertySymbol? destinationProperty = FindProperty(destinationType, propertyName!, true);
-        if (sourceProperty == null || destinationProperty == null)
-        {
-            return;
-        }
+            IPropertySymbol? sourceProperty = FindProperty(sourceType, propertyNameValue, false);
+            IPropertySymbol? destinationProperty = FindProperty(destinationType, propertyNameValue, true);
+            if (sourceProperty == null || destinationProperty == null)
+            {
+                continue;
+            }
 
-        ITypeSymbol sourcePropertyType = sourceProperty.Type;
-        ITypeSymbol destinationPropertyType = destinationProperty.Type;
+            ITypeSymbol sourcePropertyType = sourceProperty.Type;
+            ITypeSymbol destinationPropertyType = destinationProperty.Type;
 
-        if (SymbolEqualityComparer.Default.Equals(sourcePropertyType, destinationPropertyType))
-        {
-            return;
-        }
+            if (SymbolEqualityComparer.Default.Equals(sourcePropertyType, destinationPropertyType))
+            {
+                continue;
+            }
 
-        // Prepare map-from expression that either converts or casts.
-        string? conversionExpression =
-            CreateConversionExpression(sourcePropertyType, destinationPropertyType, propertyName!);
-        if (conversionExpression != null)
-        {
+            string? conversionExpression =
+                CreateConversionExpression(sourcePropertyType, destinationPropertyType, propertyNameValue);
+            if (conversionExpression != null)
+            {
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        $"Map '{propertyNameValue}' with conversion",
+                        cancellationToken =>
+                        {
+                            InvocationExpressionSyntax newInvocation = CodeFixSyntaxHelper.CreateForMemberWithMapFrom(
+                                invocation,
+                                propertyNameValue,
+                                conversionExpression);
+                            return ReplaceNodeAsync(context.Document, operationContext.Root, invocation, newInvocation);
+                        },
+                        $"AM001_MapWithConversion_{propertyNameValue}"),
+                    diagnostic);
+            }
+
             context.RegisterCodeFix(
                 CodeAction.Create(
-                    $"Map '{propertyName}' with conversion",
+                    $"Ignore property '{propertyNameValue}'",
                     cancellationToken =>
                     {
-                        InvocationExpressionSyntax newInvocation = CodeFixSyntaxHelper.CreateForMemberWithMapFrom(
-                            invocation,
-                            propertyName!,
-                            conversionExpression);
+                        InvocationExpressionSyntax newInvocation =
+                            CodeFixSyntaxHelper.CreateForMemberWithIgnore(invocation, propertyNameValue);
                         return ReplaceNodeAsync(context.Document, operationContext.Root, invocation, newInvocation);
                     },
-                    $"AM001_MapWithConversion_{propertyName}"),
+                    $"AM001_Ignore_{propertyNameValue}"),
                 diagnostic);
         }
+    }
 
-        // Always provide ignore option as a safe fallback.
-        context.RegisterCodeFix(
-            CodeAction.Create(
-                $"Ignore property '{propertyName}'",
-                cancellationToken =>
-                {
-                    InvocationExpressionSyntax newInvocation =
-                        CodeFixSyntaxHelper.CreateForMemberWithIgnore(invocation, propertyName!);
-                    return ReplaceNodeAsync(context.Document, operationContext.Root, invocation, newInvocation);
-                },
-                $"AM001_Ignore_{propertyName}"),
-            diagnostic);
+    private static IEnumerable<Diagnostic> GetRelevantDiagnostics(CodeFixContext context, SyntaxNode root)
+    {
+        return context.Diagnostics
+            .Where(diag =>
+                diag.Id == "AM001" &&
+                diag.Location.IsInSource &&
+                diag.Location.SourceTree == root.SyntaxTree &&
+                diag.Location.SourceSpan.IntersectsWith(context.Span))
+            .OrderBy(diag => diag.Location.SourceSpan.Start)
+            .ThenBy(diag => diag.Properties.TryGetValue(
+                    AM001_PropertyTypeMismatchAnalyzer.PropertyNamePropertyName,
+                    out string? propertyName)
+                ? propertyName
+                : diag.GetMessage(), StringComparer.Ordinal);
     }
 
     private static IPropertySymbol? FindProperty(ITypeSymbol typeSymbol, string name, bool expectSetter)

--- a/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM021_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM021_CodeFixTests.cs
@@ -443,6 +443,72 @@ public class AM021_CodeFixTests
     }
 
     [Fact]
+    public async Task AM021_ShouldFixIEnumerableToIEnumerable_WithSelectToListFallback()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Collections.Generic;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public IEnumerable<string> Values { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public IEnumerable<int> Values { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string expectedFixedCode = """
+                                         using AutoMapper;
+                                         using System.Collections.Generic;
+                                         using System.Linq;
+                                         using System;
+
+                                         namespace TestNamespace
+                                         {
+                                             public class Source
+                                             {
+                                                 public IEnumerable<string> Values { get; set; }
+                                             }
+
+                                             public class Destination
+                                             {
+                                                 public IEnumerable<int> Values { get; set; }
+                                             }
+
+                                             public class TestProfile : Profile
+                                             {
+                                                 public TestProfile()
+                                                 {
+                                                     CreateMap<Source, Destination>().ForMember(dest => dest.Values, opt => opt.MapFrom(src => src.Values.Select(x => Convert.ToInt32(x)).ToList()));
+                                                 }
+                                             }
+                                         }
+                                         """;
+
+        await CodeFixVerifier<AM021_CollectionElementMismatchAnalyzer, AM021_CollectionElementMismatchCodeFixProvider>
+            .VerifyFixAsync(
+                testCode,
+                new DiagnosticResult(AM021_CollectionElementMismatchAnalyzer.CollectionElementIncompatibilityRule)
+                    .WithLocation(20, 13)
+                    .WithArguments("Values", "Source", "string", "Destination", "Values", "int"),
+                expectedFixedCode);
+    }
+
+    [Fact]
     public async Task AM021_ShouldFixCaseOnlyPropertyMismatch_UsingSourceAndDestinationNamesSeparately()
     {
         const string testCode = """

--- a/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM021_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM021_CodeFixTests.cs
@@ -306,7 +306,139 @@ public class AM021_CodeFixTests
                 testCode,
                 new DiagnosticResult(AM021_CollectionElementMismatchAnalyzer.CollectionElementIncompatibilityRule)
                     .WithLocation(20, 13)
-                    .WithArguments("Tags", "Source", "string", "Destination", "Tags", "int"),
+                .WithArguments("Tags", "Source", "string", "Destination", "Tags", "int"),
+                expectedFixedCode);
+    }
+
+    [Fact]
+    public async Task AM021_ShouldFixQueueToQueue_WithSelectWrappedInQueueConstructor()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Collections.Generic;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public Queue<string> Values { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public Queue<int> Values { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string expectedFixedCode = """
+                                         using AutoMapper;
+                                         using System.Collections.Generic;
+                                         using System.Linq;
+                                         using System;
+
+                                         namespace TestNamespace
+                                         {
+                                             public class Source
+                                             {
+                                                 public Queue<string> Values { get; set; }
+                                             }
+
+                                             public class Destination
+                                             {
+                                                 public Queue<int> Values { get; set; }
+                                             }
+
+                                             public class TestProfile : Profile
+                                             {
+                                                 public TestProfile()
+                                                 {
+                                                     CreateMap<Source, Destination>().ForMember(dest => dest.Values, opt => opt.MapFrom(src => new Queue<int>(src.Values.Select(x => Convert.ToInt32(x)))));
+                                                 }
+                                             }
+                                         }
+                                         """;
+
+        await CodeFixVerifier<AM021_CollectionElementMismatchAnalyzer, AM021_CollectionElementMismatchCodeFixProvider>
+            .VerifyFixAsync(
+                testCode,
+                new DiagnosticResult(AM021_CollectionElementMismatchAnalyzer.CollectionElementIncompatibilityRule)
+                    .WithLocation(20, 13)
+                    .WithArguments("Values", "Source", "string", "Destination", "Values", "int"),
+                expectedFixedCode);
+    }
+
+    [Fact]
+    public async Task AM021_ShouldFixStackToStack_WithSelectWrappedInStackConstructor()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Collections.Generic;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public Stack<string> Values { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public Stack<int> Values { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string expectedFixedCode = """
+                                         using AutoMapper;
+                                         using System.Collections.Generic;
+                                         using System.Linq;
+                                         using System;
+
+                                         namespace TestNamespace
+                                         {
+                                             public class Source
+                                             {
+                                                 public Stack<string> Values { get; set; }
+                                             }
+
+                                             public class Destination
+                                             {
+                                                 public Stack<int> Values { get; set; }
+                                             }
+
+                                             public class TestProfile : Profile
+                                             {
+                                                 public TestProfile()
+                                                 {
+                                                     CreateMap<Source, Destination>().ForMember(dest => dest.Values, opt => opt.MapFrom(src => new Stack<int>(src.Values.Select(x => Convert.ToInt32(x)))));
+                                                 }
+                                             }
+                                         }
+                                         """;
+
+        await CodeFixVerifier<AM021_CollectionElementMismatchAnalyzer, AM021_CollectionElementMismatchCodeFixProvider>
+            .VerifyFixAsync(
+                testCode,
+                new DiagnosticResult(AM021_CollectionElementMismatchAnalyzer.CollectionElementIncompatibilityRule)
+                    .WithLocation(20, 13)
+                    .WithArguments("Values", "Source", "string", "Destination", "Values", "int"),
                 expectedFixedCode);
     }
 

--- a/tests/AutoMapperAnalyzer.Tests/DataIntegrity/AM005_CodeFixIntegrationTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/DataIntegrity/AM005_CodeFixIntegrationTests.cs
@@ -1,5 +1,15 @@
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using AutoMapper;
 using AutoMapperAnalyzer.Analyzers.DataIntegrity;
 using AutoMapperAnalyzer.Tests.Infrastructure;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Testing;
 
 namespace AutoMapperAnalyzer.Tests.DataIntegrity;
@@ -137,7 +147,7 @@ public class AM005_CodeFixIntegrationTests
     }
 
     [Fact]
-    public async Task AM005_ShouldApplyRenameCodeFix_WhenSourcePropertyIsEditable()
+    public async Task AM005_ShouldOfferOnlyExplicitMappingCodeFix_WhenSourcePropertyIsEditable()
     {
         const string testCode = """
                                 using AutoMapper;
@@ -164,38 +174,57 @@ public class AM005_CodeFixIntegrationTests
                                 }
                                 """;
 
-        const string expectedFixedCode = """
-                                         using AutoMapper;
+        Document document = CreateDocument(testCode);
+        Compilation compilation = (await document.Project.GetCompilationAsync())!;
+        Diagnostic diagnostic = (await compilation.WithAnalyzers(
+                ImmutableArray.Create<DiagnosticAnalyzer>(new AM005_CaseSensitivityMismatchAnalyzer()))
+            .GetAnalyzerDiagnosticsAsync())
+            .Single();
 
-                                         namespace TestNamespace
-                                         {
-                                             public class Source
-                                             {
-                                                 public string EmailAddress { get; set; }
-                                             }
+        List<CodeAction> actions = await RegisterActionsAsync(document, diagnostic);
+        CodeAction action = Assert.Single(actions);
+        Assert.Equal("Map 'emailAddress' to 'EmailAddress' explicitly", action.Title);
+    }
 
-                                             public class Destination
-                                             {
-                                                 public string EmailAddress { get; set; }
-                                             }
+    private static Document CreateDocument(string source)
+    {
+        var workspace = new AdhocWorkspace();
+        ProjectId projectId = ProjectId.CreateNewId();
+        DocumentId documentId = DocumentId.CreateNewId(projectId);
 
-                                             public class TestProfile : Profile
-                                             {
-                                                 public TestProfile()
-                                                 {
-                                                     CreateMap<Source, Destination>();
-                                                 }
-                                             }
-                                         }
-                                         """;
+        Solution solution = workspace.CurrentSolution
+            .AddProject(projectId, "AM005Tests", "AM005Tests", LanguageNames.CSharp)
+            .WithProjectCompilationOptions(projectId, new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+            .WithProjectParseOptions(projectId, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
 
-        await CodeFixVerifier<AM005_CaseSensitivityMismatchAnalyzer, AM005_CaseSensitivityMismatchCodeFixProvider>
-            .VerifyFixAsync(
-                testCode,
-                new DiagnosticResult(AM005_CaseSensitivityMismatchAnalyzer.CaseSensitivityMismatchRule)
-                    .WithLocation(19, 13)
-                    .WithArguments("emailAddress", "EmailAddress"),
-                expectedFixedCode,
-                1);
+        string trustedPlatformAssemblies = (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") ?? string.Empty;
+        foreach (string assemblyPath in trustedPlatformAssemblies.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(assemblyPath))
+            {
+                solution = solution.AddMetadataReference(projectId, MetadataReference.CreateFromFile(assemblyPath));
+            }
+        }
+
+        solution = solution
+            .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(Profile).Assembly.Location))
+            .AddDocument(documentId, "Test0.cs", SourceText.From(source));
+
+        return solution.GetDocument(documentId)!;
+    }
+
+    private static async Task<List<CodeAction>> RegisterActionsAsync(Document document, Diagnostic diagnostic)
+    {
+        var actions = new List<CodeAction>();
+        var provider = new AM005_CaseSensitivityMismatchCodeFixProvider();
+
+        var context = new CodeFixContext(
+            document,
+            diagnostic,
+            (action, _) => actions.Add(action),
+            CancellationToken.None);
+
+        await provider.RegisterCodeFixesAsync(context);
+        return actions;
     }
 }

--- a/tests/AutoMapperAnalyzer.Tests/DataIntegrity/AM006_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/DataIntegrity/AM006_CodeFixTests.cs
@@ -275,6 +275,72 @@ public class AM006_CodeFixTests
     }
 
     [Fact]
+    public async Task AM006_ShouldSuppressFuzzyMatch_WhenBestCandidateIsAmbiguous()
+    {
+        const string testCode = """
+
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public string Eamil { get; set; }
+                                        public string Emial { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public string Email { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string expectedFixedCode = """
+
+                                         using AutoMapper;
+
+                                         namespace TestNamespace
+                                         {
+                                             public class Source
+                                             {
+                                                 public string Eamil { get; set; }
+                                                 public string Emial { get; set; }
+                                             }
+
+                                             public class Destination
+                                             {
+                                                 public string Email { get; set; }
+                                             }
+
+                                             public class TestProfile : Profile
+                                             {
+                                                 public TestProfile()
+                                                 {
+                                                     CreateMap<Source, Destination>().ForMember(dest => dest.Email, opt => opt.Ignore());
+                                                 }
+                                             }
+                                         }
+                                         """;
+
+        await VerifyFixAsync(
+            testCode,
+            AM006_UnmappedDestinationPropertyAnalyzer.UnmappedDestinationPropertyRule,
+            21, 13,
+            expectedFixedCode,
+            codeActionIndex: 0,
+            messageArgs: ["Email", "Source"]);
+    }
+
+    [Fact]
     public async Task AM006_ShouldBulkIgnoreAllUnmappedDestinationProperties()
     {
         const string testCode = """

--- a/tests/AutoMapperAnalyzer.Tests/DataIntegrity/AM011_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/DataIntegrity/AM011_CodeFixTests.cs
@@ -483,4 +483,71 @@ public class AM011_CodeFixTests
                 0); // Primary fix: default value (0m for decimal)
     }
 
+    [Fact]
+    public async Task AM011_ShouldSuppressFuzzyMatch_WhenBestCandidateIsAmbiguous()
+    {
+        const string testCode = """
+
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public string Eamil { get; set; }
+                                        public string Emial { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public required string Email { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string expectedFixedCode = """
+
+                                         using AutoMapper;
+
+                                         namespace TestNamespace
+                                         {
+                                             public class Source
+                                             {
+                                                 public string Eamil { get; set; }
+                                                 public string Emial { get; set; }
+                                             }
+
+                                             public class Destination
+                                             {
+                                                 public required string Email { get; set; }
+                                             }
+
+                                             public class TestProfile : Profile
+                                             {
+                                                 public TestProfile()
+                                                 {
+                                                     CreateMap<Source, Destination>().ForMember(dest => dest.Email, opt => opt.MapFrom(src => string.Empty));
+                                                 }
+                                             }
+                                         }
+                                         """;
+
+        await CodeFixVerifier<AM011_UnmappedRequiredPropertyAnalyzer, AM011_UnmappedRequiredPropertyCodeFixProvider>
+            .VerifyFixAsync(
+                testCode,
+                new DiagnosticResult(AM011_UnmappedRequiredPropertyAnalyzer.UnmappedRequiredPropertyRule)
+                    .WithLocation(21, 13)
+                    .WithArguments("Email"),
+                expectedFixedCode,
+                0);
+    }
+
 }

--- a/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM001_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM001_CodeFixTests.cs
@@ -300,6 +300,75 @@ public class AM001_CodeFixTests
     }
 
     [Fact]
+    public async Task AM001_ShouldApplyIterativeFixes_ForMultiplePropertyTypeMismatches()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public int Age { get; set; }
+                                        public double Score { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public string Age { get; set; }
+                                        public string Score { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string expectedFixedCode = """
+                                         using AutoMapper;
+
+                                         namespace TestNamespace
+                                         {
+                                             public class Source
+                                             {
+                                                 public int Age { get; set; }
+                                                 public double Score { get; set; }
+                                             }
+
+                                             public class Destination
+                                             {
+                                                 public string Age { get; set; }
+                                                 public string Score { get; set; }
+                                             }
+
+                                             public class TestProfile : Profile
+                                             {
+                                                 public TestProfile()
+                                                 {
+                                                     CreateMap<Source, Destination>().ForMember(dest => dest.Score, opt => opt.MapFrom(src => src.Score.ToString())).ForMember(dest => dest.Age, opt => opt.MapFrom(src => src.Age.ToString()));
+                                                 }
+                                             }
+                                         }
+                                         """;
+
+        DiagnosticResult[] diagnostics =
+        [
+            Diagnostic(AM001_PropertyTypeMismatchAnalyzer.PropertyTypeMismatchRule, 21, 13,
+                "Age", "Source", "int", "Destination", "string"),
+            Diagnostic(AM001_PropertyTypeMismatchAnalyzer.PropertyTypeMismatchRule, 21, 13,
+                "Score", "Source", "double", "Destination", "string")
+        ];
+
+        await CodeFixVerifier<AM001_PropertyTypeMismatchAnalyzer, AM001_PropertyTypeMismatchCodeFixProvider>
+            .VerifyFixWithIterationsAsync(testCode, diagnostics, expectedFixedCode, iterations: 2);
+    }
+
+    [Fact]
     public async Task AM001_ShouldFixNullableStringToIntWithParsePattern()
     {
         const string testCode = """

--- a/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM001_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM001_CodeFixTests.cs
@@ -1,6 +1,16 @@
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using AutoMapper;
 using AutoMapperAnalyzer.Analyzers.TypeSafety;
 using AutoMapperAnalyzer.Tests.Infrastructure;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Testing;
 
 namespace AutoMapperAnalyzer.Tests.TypeSafety;
@@ -198,7 +208,7 @@ public class AM001_CodeFixTests
                 expectedFixedCode);
     }
 
-    [Fact(Skip = "Analyzer limitation: multi-diagnostic coordination - see docs/TEST_LIMITATIONS.md #3")]
+    [Fact]
     public async Task AM001_ShouldFixMultiplePropertyTypeMismatches()
     {
         const string testCode = """
@@ -228,45 +238,65 @@ public class AM001_CodeFixTests
                                 }
                                 """;
 
-        // Fix the first property (Age)
-        const string expectedFixedCodeAfterFirstFix = """
-                                                      using AutoMapper;
+        Document document = CreateDocument(testCode);
+        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(document);
+        List<CodeAction> actions = await RegisterActionsAsync(document, diagnostics);
 
-                                                      namespace TestNamespace
-                                                      {
-                                                          public class Source
-                                                          {
-                                                              public int Age { get; set; }
-                                                              public double Score { get; set; }
-                                                          }
+        Assert.Collection(
+            actions.Select(action => action.Title),
+            title => Assert.Equal("Map 'Age' with conversion", title),
+            title => Assert.Equal("Ignore property 'Age'", title),
+            title => Assert.Equal("Map 'Score' with conversion", title),
+            title => Assert.Equal("Ignore property 'Score'", title));
 
-                                                          public class Destination
-                                                          {
-                                                              public string Age { get; set; }
-                                                              public string Score { get; set; }
-                                                          }
+        string updatedCode = await ApplyActionAsync(actions[0], document);
+        Assert.Contains(".ForMember(dest => dest.Age, opt => opt.MapFrom(src => src.Age.ToString()))", updatedCode,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("dest => dest.Score", updatedCode, StringComparison.Ordinal);
+    }
 
-                                                          public class TestProfile : Profile
-                                                          {
-                                                              public TestProfile()
-                                                              {
-                                                                  CreateMap<Source, Destination>().ForMember(dest => dest.Age, opt => opt.MapFrom(src => src.Age.ToString()));
-                                                              }
-                                                          }
-                                                      }
-                                                      """;
+    [Fact]
+    public async Task AM001_ShouldFixSecondPropertyTypeMismatch_WhenMultipleDiagnosticsExist()
+    {
+        const string testCode = """
+                                using AutoMapper;
 
-        await CodeFixVerifier<AM001_PropertyTypeMismatchAnalyzer, AM001_PropertyTypeMismatchCodeFixProvider>
-            .VerifyFixAsync(
-                testCode,
-                Diagnostic(AM001_PropertyTypeMismatchAnalyzer.PropertyTypeMismatchRule, 21, 13,
-                    "Age", "Source", "int", "Destination", "string"),
-                expectedFixedCodeAfterFirstFix,
-                new[]
-                {
-                    Diagnostic(AM001_PropertyTypeMismatchAnalyzer.PropertyTypeMismatchRule, 21, 13,
-                        "Score", "Source", "double", "Destination", "string")
-                });
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public int Age { get; set; }
+                                        public double Score { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public string Age { get; set; }
+                                        public string Score { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        Document document = CreateDocument(testCode);
+        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(document);
+        List<CodeAction> actions = await RegisterActionsAsync(document, diagnostics);
+
+        CodeAction scoreAction = Assert.Single(
+            actions,
+            action => action.Title == "Map 'Score' with conversion");
+        string updatedCode = await ApplyActionAsync(scoreAction, document);
+
+        Assert.Contains(".ForMember(dest => dest.Score, opt => opt.MapFrom(src => src.Score.ToString()))", updatedCode,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("dest => dest.Age", updatedCode, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -330,5 +360,69 @@ public class AM001_CodeFixTests
                 Diagnostic(AM001_PropertyTypeMismatchAnalyzer.PropertyTypeMismatchRule, 20, 13,
                     "Value", "Source", "string?", "Destination", "int"),
                 expectedFixedCode);
+    }
+
+    private static Document CreateDocument(string source)
+    {
+        var workspace = new AdhocWorkspace();
+        ProjectId projectId = ProjectId.CreateNewId();
+        DocumentId documentId = DocumentId.CreateNewId(projectId);
+
+        Solution solution = workspace.CurrentSolution
+            .AddProject(projectId, "AM001Tests", "AM001Tests", LanguageNames.CSharp)
+            .WithProjectCompilationOptions(projectId, new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+            .WithProjectParseOptions(projectId, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+
+        string trustedPlatformAssemblies = (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") ?? string.Empty;
+        foreach (string assemblyPath in trustedPlatformAssemblies.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(assemblyPath))
+            {
+                solution = solution.AddMetadataReference(projectId, MetadataReference.CreateFromFile(assemblyPath));
+            }
+        }
+
+        solution = solution
+            .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(Profile).Assembly.Location))
+            .AddDocument(documentId, "Test0.cs", SourceText.From(source));
+
+        return solution.GetDocument(documentId)!;
+    }
+
+    private static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(Document document)
+    {
+        Compilation compilation = (await document.Project.GetCompilationAsync())!;
+        return (await compilation.WithAnalyzers(
+                ImmutableArray.Create<DiagnosticAnalyzer>(new AM001_PropertyTypeMismatchAnalyzer()))
+            .GetAnalyzerDiagnosticsAsync())
+            .OrderBy(diagnostic => diagnostic.Location.SourceSpan.Start)
+            .ThenBy(diagnostic => diagnostic.GetMessage(CultureInfo.InvariantCulture), StringComparer.Ordinal)
+            .ToImmutableArray();
+    }
+
+    private static async Task<List<CodeAction>> RegisterActionsAsync(Document document, ImmutableArray<Diagnostic> diagnostics)
+    {
+        var actions = new List<CodeAction>();
+        var provider = new AM001_PropertyTypeMismatchCodeFixProvider();
+
+        var context = new CodeFixContext(
+            document,
+            diagnostics[0].Location.SourceSpan,
+            diagnostics,
+            (action, _) => actions.Add(action),
+            CancellationToken.None);
+
+        await provider.RegisterCodeFixesAsync(context);
+        return actions;
+    }
+
+    private static async Task<string> ApplyActionAsync(CodeAction action, Document originalDocument)
+    {
+        ImmutableArray<CodeActionOperation> operations = await action.GetOperationsAsync(CancellationToken.None);
+        ApplyChangesOperation applyChanges = Assert.IsType<ApplyChangesOperation>(operations.Single());
+
+        Document updatedDocument = applyChanges.ChangedSolution.GetDocument(originalDocument.Id)!;
+        SourceText updatedText = await updatedDocument.GetTextAsync();
+        return updatedText.ToString();
     }
 }


### PR DESCRIPTION
## Summary
- harden AM021 simple collection conversions so queue/stack suggestions generate compilable constructor-based mappings
- restore stable per-diagnostic AM001 actions, require unique-best fuzzy matches for AM006/AM011, and remove AM005 rename lightbulbs
- sync README, package metadata, and analyzer review tracker for the planned v2.30.0 release

## Validation
- dotnet build automapper-analyser.sln --configuration Release
- dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --configuration Release --no-restore
- dotnet build samples/AutoMapperAnalyzer.Samples/AutoMapperAnalyzer.Samples.csproj --configuration Release
- dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --filter "FullyQualifiedName~AM021_CodeFixTests|FullyQualifiedName~AM001_CodeFixTests|FullyQualifiedName~AM006_CodeFixTests|FullyQualifiedName~AM011_CodeFixTests|FullyQualifiedName~AM005_CodeFixIntegrationTests"

## Release Notes Draft
- fix AM021 queue/stack code generation so simple element conversions match the destination collection shape
- fix AM001 action registration for multi-diagnostic CreateMap sites
- suppress AM006/AM011 fuzzy-match actions unless there is a unique best candidate
- remove AM005 rename actions and keep only executable explicit-mapping fixes