### PR TITLE
Harden AM002 nullability health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+## [2.30.1] - 2026-04-26
+
+### Changed
+
+- Aligned AM002 documentation with its shipped descriptor split: nullable source to non-nullable destination is `Error`, while non-nullable source to nullable destination is `Info`.
+- Added AM002 nullable-context regression coverage for oblivious reference types and nullable value types.
+- Updated analyzer health and README rule metadata so public severity guidance matches the implementation.
+
+### Validation
+
+- Targeted AM002 analyzer tests.
+- Full `net10.0` solution test suite.
+- `git diff --check`.
+
+## [2.30.0] - 2026-04-26
+
+### Fixed
+
+- Hardened AM001, AM005, AM006, AM011, and AM021 fixer behavior with safer action selection.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet Version](https://img.shields.io/nuget/v/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=NuGet)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=Downloads)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/georgepwall1991/automapper-analyser/ci.yml?style=flat-square&logo=github&label=Build)](https://github.com/georgepwall1991/automapper-analyser/actions)
-[![Tests](https://img.shields.io/badge/Tests-635%20passing%2C%208%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
+[![Tests](https://img.shields.io/badge/Tests-637%20passing%2C%208%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
 [![.NET](https://img.shields.io/badge/.NET-4.8+%20%7C%206.0+%20%7C%208.0+%20%7C%209.0+%20%7C%2010.0+-512BD4?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 [![Coverage](https://img.shields.io/codecov/c/github/georgepwall1991/automapper-analyser?style=flat-square&logo=codecov&label=Coverage)](https://codecov.io/gh/georgepwall1991/automapper-analyser)
@@ -14,26 +14,26 @@ prevention*
 
 ---
 
-## 🎉 Latest Release: v2.30.0
+## 🎉 Latest Release: v2.30.1
 
-**Fixer Hardening — safer actions for collections, fuzzy matches, and multi-diagnostic maps**
+**AM002 Nullability Contract Alignment — descriptor-accurate docs and edge-case coverage**
 
 ✅ **Highlights**
 
-- Fixed AM021 simple collection conversions for `Queue<T>` and `Stack<T>` so the suggested code now matches the destination collection shape.
-- Fixed AM001 so multiple type mismatches on the same `CreateMap` expose stable, per-property actions instead of only handling the first diagnostic.
-- Tightened AM006 and AM011 fuzzy matching to offer a mapping action only when there is a unique best candidate.
-- Removed AM005 rename-based lightbulbs and kept the explicit executable mapping action only.
-- Added targeted regression coverage for action ordering, ambiguous fuzzy matches, and queue/stack conversion fixes.
+- Aligned AM002 documentation with its real descriptor split: nullable source to non-nullable destination is `Error`, and non-nullable source to nullable destination is `Info`.
+- Added AM002 boundary coverage for oblivious reference nullability so disabled nullable annotations do not create noisy reference-type diagnostics.
+- Added AM002 regression coverage proving nullable value types remain protected even when nullable reference annotations are disabled.
+- Updated the analyzer health audit and rule coverage table so release docs match shipped behavior.
 
 🧪 **Validation**
 
-- Full solution builds passed in `Release`.
-- Full test suite passed with `635` passing and `8` skipped.
-- Release validation covered targeted fixer regressions plus full Release build/test passes before tagging.
+- Full solution test validation passed on `net10.0`.
+- Full test suite passed with `637` passing and `8` skipped.
+- Release validation covered targeted AM002 regressions plus full solution verification before tagging.
 
 ### Recent Releases
 
+- **v2.30.0**: Fixer hardening for AM001, AM005, AM006, AM011, and AM021 with safer action selection.
 - **v2.29.0**: Smart primary fix and reduced fixer noise across the main data-integrity fixers.
 - **v2.28.2**: False-positive reduction, fixer UX improvements, and release workflow hardening.
 - **v2.28.1**: Case-aware AM021 suppression and fixer reliability improvements.
@@ -169,7 +169,7 @@ Install-Package AutoMapperAnalyzer.Analyzers
 ### Project File (For CI/CD)
 
 ```xml
-<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.0">
+<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.1">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 </PackageReference>
@@ -284,21 +284,21 @@ public void ConfigureSafeUserMapping() { }
 | Rule                    | Description                    | Analyzer | Code Fix | Severity |
 |-------------------------|--------------------------------|----------|----------|----------|
 | **🔒 Type Safety**      |                                |          |          |
-| AM001                   | Property Type Mismatch         | ✅        | ✅        | Warning  |  
-| AM002                   | Nullable→Non-nullable          | ✅        | ✅        | Warning  |
-| AM003                   | Collection Incompatibility     | ✅        | ✅        | Warning  |
+| AM001                   | Property Type Mismatch         | ✅        | ✅        | Error    |
+| AM002                   | Nullable→Non-nullable          | ✅        | ✅        | Error / Info |
+| AM003                   | Collection Incompatibility     | ✅        | ✅        | Error    |
 | **📊 Data Integrity**   |                                |          |          |
-| AM004                   | Missing Destination Property   | ✅        | ✅        | Info     |
-| AM005                   | Case Sensitivity Issues        | ✅        | ✅        | Info     |
+| AM004                   | Missing Destination Property   | ✅        | ✅        | Warning  |
+| AM005                   | Case Sensitivity Issues        | ✅        | ✅        | Warning  |
 | AM006                   | Unmapped Destination Property  | ✅        | ✅        | Info     |
 | AM011                   | Required Property Missing      | ✅        | ✅        | Error    |
 | **🧩 Complex Mappings** |                                |          |          |
 | AM020                   | Nested Object Issues           | ✅        | ✅        | Warning  |
-| AM021                   | Collection Element Mismatch    | ✅        | ✅        | Warning  |  
+| AM021                   | Collection Element Mismatch    | ✅        | ✅        | Warning  |
 | AM022                   | Circular Reference Risk        | ✅        | ✅        | Warning  |
-| AM030                   | Custom Type Converter Issues   | ✅        | ✅        | Warning  |
+| AM030                   | Custom Type Converter Issues   | ✅        | ✅        | Error / Warning / Info |
 | **⚡ Performance**       |                                |          |          |
-| AM031                   | Performance Warnings           | ✅        | ✅        | Warning  |
+| AM031                   | Performance Warnings           | ✅        | ✅        | Warning / Info |
 | **⚙️ Configuration**    |                                |          |          |
 | AM041                   | Duplicate Mapping Registration | ✅        | ✅        | Warning  |
 | AM050                   | Redundant MapFrom              | ✅        | ✅        | Info     |
@@ -363,6 +363,7 @@ This isn't just another analyzer—it's built for **enterprise-grade reliability
 
 ### Recently Completed ✅
 
+- **v2.30.1**: AM002 nullability contract alignment with descriptor-accurate docs and nullable-context regression coverage
 - **v2.30.0**: Fixer hardening for AM001, AM005, AM006, AM011, and AM021 with safer action selection
 - **v2.29.0**: Smart Primary Fix — reduced fixer noise to max 2 lightbulb options per diagnostic
 - **v2.28.2**: False-positive reduction, fixer UX improvements, and release workflow hardening

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -1,0 +1,75 @@
+# Analyzer Health
+
+Reviewed: 2026-04-26
+
+This is a deliberately harsh health audit for the 14 implemented AutoMapper analyzer rule IDs in this repository. Several rule IDs expose multiple diagnostic descriptors, especially `AM002`, `AM022`, `AM030`, and `AM031`; the scorecard rates the public rule ID as the user experiences it.
+
+Every implemented rule currently has an analyzer and a code fix provider. Scores are 1-5, where `5` means reference-quality and hard to improve, `3` means usable but meaningfully incomplete, and `1` means unreliable or underbuilt.
+
+## Rubric
+
+| Metric | Meaning |
+| --- | --- |
+| Analyzer | Semantic depth, AutoMapper-awareness, fluent-chain handling, reverse-map handling, ownership boundaries, and diagnostic placement accuracy. |
+| False Positives | Conservatism around lookalike APIs, explicit configuration, custom construction/conversion, naming conventions, intentional usage, and ambiguous AutoMapper behavior. |
+| Fix Strategy | Safety, completeness, idempotence, diagnostic-specific routing, Fix All behavior, and whether generated code is executable rather than placeholder-heavy. |
+| Tests | Strength of analyzer, fixer, negative, edge-case, reverse-map, conflict/ownership, helper, and regression tests. |
+| Docs/Samples | Clarity and consistency of rule docs, samples, metadata, documented safe cases, severity accuracy, suppression guidance, and documented non-goals. |
+| Importance | User-facing usefulness based on frequency, severity, runtime failure/data-loss risk, performance impact, and actionability. |
+
+Harsh calibration notes:
+
+- A `5` is rare. For a fixable rule it requires broad analyzer coverage plus dedicated fixer coverage and strong negative tests.
+- Since all current rules have code fix providers, Fix Strategy is scored on the actual executable safety of the fixer, not just provider existence.
+- Multi-diagnostic IDs are penalized when one ID mixes substantially different product concepts or severities without equally strong docs/tests for each branch.
+- Info rules are scored by product value, not implementation effort. A healthy cleanup rule can still have low Importance.
+- Docs/Samples score existence and quality. Broad docs and samples do not get a free `5` when descriptor severities, README tables, and implementation details drift.
+
+Priority is a planning signal: `High` means the analyzer is important and has meaningful health gaps, `Medium` means useful follow-up work is warranted, and `Low` means no immediate work is needed.
+
+## Scorecard
+
+| Rule | Title | Domain | Severity | Analyzer | False Positives | Fix Strategy | Tests | Docs/Samples | Importance | Priority | Notes |
+| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |
+| AM001 | Property type mismatch | Type Safety | Error | 4 | 4 | 4 | 4 | 4 | 5 | Low | Strong semantic AutoMapper gating, ownership handoff to AM002/AM020/AM021, and solid fixer coverage; remaining gaps are mostly advanced conversion semantics and richer compile-time conversion modeling. |
+| AM002 | Nullable compatibility issue | Type Safety | Error/Info | 4 | 4 | 4 | 5 | 4 | 5 | Low | Descriptor-accurate docs now call out the Error/Info split, and regression tests cover oblivious reference nullability plus nullable value types in disabled nullable contexts. Remaining opportunities are advanced generic/nullability-flow semantics. |
+| AM003 | Collection type incompatibility | Type Safety | Error | 3 | 4 | 4 | 4 | 4 | 4 | Medium | The ownership split with AM021 is well tested, but collection-container knowledge is still a curated heuristic around common containers rather than a broad AutoMapper collection-conversion model. |
+| AM004 | Source property has no corresponding destination property | Data Integrity | Warning | 4 | 4 | 4 | 5 | 4 | 5 | Low | One of the strongest rules: reverse maps, records, inheritance, flattening, ctor params, custom construction, and fixer behavior have extensive coverage. Keep docs aligned because README/rule docs still imply older severity language in spots. |
+| AM005 | Property names differ only in casing | Data Integrity | Warning | 4 | 4 | 4 | 4 | 3 | 3 | Low | Focused and reasonably conservative with explicit mapping, source ignore, reverse-map, and executable fixer tests; docs/samples understate current Warning severity and should better explain intentional naming policies. |
+| AM006 | Destination property is not mapped | Data Integrity | Info | 4 | 4 | 4 | 4 | 4 | 4 | Low | Solid non-required counterpart to AM011 with flattening, reverse-map, ForPath, lookalike API, fuzzy-match, and bulk-ignore coverage; analyzer test count is lighter than AM004 but the risk is lower. |
+| AM011 | Required destination property is not mapped | Data Integrity | Error | 4 | 4 | 3 | 4 | 4 | 5 | Medium | Important runtime-failure guardrail with good required-member and reverse-map coverage; fixer still leans on default/constant/custom mapping scaffolds, so domain-safe mapping remains partly manual. |
+| AM020 | Nested object mapping configuration missing | Complex Mappings | Warning | 4 | 4 | 4 | 5 | 5 | 5 | Low | The reference example in this repo: broad tests cover separate profiles, reverse maps, inheritance, records, interfaces, internal members, ForPath/string paths, and construction/conversion suppression. |
+| AM021 | Collection element type incompatibility | Complex Mappings | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | Good AM003 boundary discipline and recent fixer hardening for case-only names plus queue/stack output shape; keep expanding dictionary/custom-collection and reverse-map edge cases. |
+| AM022 | Infinite recursion risk | Complex Mappings | Warning | 3 | 3 | 4 | 4 | 4 | 4 | Medium | Useful and well tested for common cycles, MaxDepth, Ignore, collections, and reverse-map boundaries, but recursion analysis remains heuristic and may miss or over-report nuanced graph/DTO ownership patterns. |
+| AM030 | Custom type converter issues | Custom Conversions | Error/Warning/Info | 3 | 3 | 3 | 3 | 3 | 3 | Medium | The rule now focuses on converter implementation quality, null handling, and unused converters, but the single ID mixes distinct concepts and unused-converter analysis can be noisy when converters are wired externally. |
+| AM031 | Performance warnings in mapping expressions | Performance | Warning/Info | 3 | 3 | 3 | 4 | 3 | 4 | Medium | Broad, valuable smell detector with many targeted tests, but expensive-operation heuristics are inherently fuzzy and fixer safety varies by issue type; docs should make the supported boundaries more explicit. |
+| AM041 | Duplicate mapping registration | Configuration | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | Strong compilation-wide registry, reverse-map awareness, cross-profile duplicate detection, and removal fixer coverage. Remaining risk is mainly nuanced intentional override/configuration ordering cases. |
+| AM050 | Redundant MapFrom configuration | Configuration | Info | 3 | 3 | 4 | 3 | 3 | 2 | Low | Safe cleanup rule with idempotent fixer tests, but product importance is low and analyzer semantics are intentionally narrow around direct same-name property lambdas. |
+
+## Planning Shortlist
+
+The next improvement batch should focus on rules where user impact and health gaps overlap:
+
+| Priority | Rules | Work |
+| --- | --- | --- |
+| High | None | No implemented rule currently looks both high-impact and unhealthy enough to demand urgent intervention before normal release work. |
+| Medium | AM003, AM011, AM022, AM030, AM031 | Expand collection/converter/performance boundary tests, and make manual-vs-executable fixer expectations explicit in docs. |
+| Low | AM001, AM002, AM004, AM005, AM006, AM020, AM021, AM041, AM050 | Treat as currently acceptable, reference examples, or low-impact cleanup rules. Improve opportunistically when touching nearby code. |
+
+## Cross-Cutting Findings
+
+- Public docs are useful but drift from implementation in several places. `AM004` and `AM005` remain obvious severity/wording mismatches between descriptors, README tables, and rule docs, while `AM002` has been realigned with its shipped Error/Info descriptors.
+- Analyzer ownership is a real strength. The conflict tests and shared helpers make `AM001`/`AM002`/`AM003`/`AM020`/`AM021` boundaries much healthier than a file-count audit would suggest.
+- The project has no generated rule catalog health contract like LinqContraband's catalog tooling. Rule metadata is distributed across descriptors, README, docs, samples, and the manual `AnalyzerVerifier`.
+- Diagnostic placement is generally at the mapping invocation or mapping lambda, not always the precise property/member token. That is acceptable for many AutoMapper configuration rules, but high-volume rules benefit from tighter placement when practical.
+- Several fixers intentionally produce advisory/default mapping scaffolds. That is fine, but docs should distinguish "safe executable rewrite" from "starter mapping the developer must review."
+
+## Verification Baseline
+
+Architecture-style coverage currently comes from analyzer/fixer tests, conflict ownership tests, helper tests, sample projects, documentation, and the manual `tools/AnalyzerVerifier` project. There is no checked-in rule-catalog generator or sample diagnostics verifier equivalent to the LinqContraband baseline.
+
+Current local verification:
+
+- `/opt/homebrew/bin/dotnet test automapper-analyser.sln --no-restore --framework net10.0` passed: 637 passed, 8 skipped, 0 failed.
+- The restore/test run reported existing warnings worth tracking: AutoMapper 14.0.0 has advisory `GHSA-rvv3-g6hj-g44x`, several analyzer packaging/test-infrastructure warnings are present, and skipped-test warnings cover AM001, AM031, and AM050 scenarios.
+- `/opt/homebrew/bin/dotnet --list-runtimes` shows only .NET 10 runtimes in this local environment, so broader runtime verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -112,12 +112,12 @@ dotnet_diagnostic.AM001.severity = error
 
 ### AM002: Nullable Compatibility Issue
 
-**Severity**: Warning 🟡
+**Severity**: Error 🔴 for nullable source to non-nullable destination; Info 🔵 for non-nullable source to nullable destination
 **Category**: AutoMapper.TypeSafety
 
 #### Description
 
-Detects nullable source properties mapped to non-nullable destination properties, which can cause `NullReferenceException` at runtime.
+Detects nullable source properties mapped to non-nullable destination properties, which can violate the destination nullable contract at runtime. It also reports an informational diagnostic when a non-nullable source maps to a nullable destination so teams can simplify or document intentionally widened nullability.
 
 #### Problem
 
@@ -137,12 +137,12 @@ public class MappingProfile : Profile
     public MappingProfile()
     {
         CreateMap<Source, Destination>();
-        // ⚠️ AM002: FirstName nullable compatibility issue
+        // ❌ AM002: FirstName nullable compatibility issue
     }
 }
 ```
 
-**Runtime Behavior**: If `source.FirstName == null`, destination property receives null, violating nullable contract.
+**Runtime Behavior**: If `source.FirstName == null`, the destination property receives null, violating its nullable contract.
 
 #### Solutions
 
@@ -171,10 +171,14 @@ public class Destination
 }
 ```
 
+#### Safe Cases
+
+AM002 does not report when the destination member is explicitly configured with `ForMember` or `ForPath`, when the map uses custom construction/conversion, when nullable reference annotations are disabled or oblivious, or when the nullable source and destination member have incompatible underlying types owned by `AM001`.
+
 #### Configuration
 
 ```ini
-dotnet_diagnostic.AM002.severity = warning
+dotnet_diagnostic.AM002.severity = error
 ```
 
 ---

--- a/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
+++ b/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
@@ -17,7 +17,7 @@
         <!-- Fallback for local builds: 2.0.YYYYMMDD-local -->
         <MajorVersion>2</MajorVersion>
         <MinorVersion>30</MinorVersion>
-        <PatchVersion>0</PatchVersion>
+        <PatchVersion>1</PatchVersion>
         <BuildNumber Condition="'$(BuildNumber)' == ''"
         >$([System.DateTime]::Now.ToString('yyyyMMdd'))
         </BuildNumber
@@ -32,19 +32,18 @@
         <RepositoryUrl>https://github.com/georgepwall1991/automapper-analyser</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <PackageReleaseNotes>Version 2.30.0 - Fixer hardening and safer action selection
+        <PackageReleaseNotes>Version 2.30.1 - AM002 nullability contract alignment
 
-            Fixes:
-            - Fixed AM021 queue and stack collection-element conversions to generate compilable constructor-based mappings
-            - Fixed AM001 so multi-diagnostic CreateMap sites register stable per-property actions instead of only the first mismatch
-            - Hardened AM006 and AM011 fuzzy matching to require a unique best candidate before offering speculative mapping actions
-            - Removed AM005 source-property rename suggestions and kept the executable explicit-mapping action only
+            Changed:
+            - Aligned AM002 docs with its descriptor split: nullable source to non-nullable destination is Error, non-nullable source to nullable destination is Info
+            - Added AM002 nullable-context regression coverage for oblivious reference types and nullable value types
+            - Updated analyzer health and README coverage metadata for the shipped rule severities
 
             Validation:
-            - Full solution builds in Release
-            - Full analyzer test suite passing in Release with targeted fixer regression coverage
+            - Full solution test suite passing on net10.0 with targeted AM002 regression coverage
+            - git diff --check clean
 
-            Previous Release: v2.29.0 - smart primary fix and reduced fixer noise
+            Previous Release: v2.30.0 - fixer hardening and safer action selection
         </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>

--- a/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM002_NullableCompatibilityAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM002_NullableCompatibilityAnalyzer.cs
@@ -141,7 +141,7 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
         string sourceTypeName = sourceProperty.Type.ToDisplayString();
         string destTypeName = destinationProperty.Type.ToDisplayString();
 
-        // Case 1: Nullable source -> Non-nullable destination (WARNING)
+        // Case 1: Nullable source -> Non-nullable destination (ERROR)
         if (IsNullableType(sourceProperty.Type) && !IsNullableType(destinationProperty.Type))
         {
             // Check if the underlying types are compatible

--- a/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM002_NullableCompatibilityTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM002_NullableCompatibilityTests.cs
@@ -552,4 +552,73 @@ public class AM002_NullableCompatibilityTests
 
         await AnalyzerVerifier<AM002_NullableCompatibilityAnalyzer>.VerifyAnalyzerAsync(testCode);
     }
+
+    [Fact]
+    public async Task AM002_ShouldNotReportDiagnostic_ForObliviousReferenceTypes()
+    {
+        string testCode = """
+
+                          #nullable disable
+                          using AutoMapper;
+
+                          namespace TestNamespace
+                          {
+                              public class Source
+                              {
+                                  public string Name { get; set; }
+                              }
+
+                              public class Destination
+                              {
+                                  public string Name { get; set; }
+                              }
+
+                              public class TestProfile : Profile
+                              {
+                                  public TestProfile()
+                                  {
+                                      CreateMap<Source, Destination>();
+                                  }
+                              }
+                          }
+                          """;
+
+        await AnalyzerVerifier<AM002_NullableCompatibilityAnalyzer>.VerifyAnalyzerAsync(testCode);
+    }
+
+    [Fact]
+    public async Task AM002_ShouldReportDiagnostic_ForNullableValueTypeInObliviousContext()
+    {
+        string testCode = """
+
+                          #nullable disable
+                          using AutoMapper;
+
+                          namespace TestNamespace
+                          {
+                              public class Source
+                              {
+                                  public int? Age { get; set; }
+                              }
+
+                              public class Destination
+                              {
+                                  public int Age { get; set; }
+                              }
+
+                              public class TestProfile : Profile
+                              {
+                                  public TestProfile()
+                                  {
+                                      CreateMap<Source, Destination>();
+                                  }
+                              }
+                          }
+                          """;
+
+        await AnalyzerVerifier<AM002_NullableCompatibilityAnalyzer>.VerifyAnalyzerAsync(
+            testCode,
+            Diagnostic(AM002_NullableCompatibilityAnalyzer.NullableToNonNullableRule, 21, 13, "Age", "Source", "int?",
+                "Destination", "int"));
+    }
 }


### PR DESCRIPTION
## Summary
- harden AM002 with nullable-context regression coverage
- align AM002 docs, README severity metadata, analyzer health, and changelog with the shipped Error/Info descriptor split
- bump package metadata to v2.30.1

## Impact
This improves analyzer precision by preserving quiet behavior for oblivious reference nullability while proving nullable value types still report safely, and it makes public docs match the analyzer contract.

## Validation
- `/opt/homebrew/bin/dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter 'FullyQualifiedName~AM002'` passed with 23 tests
- `/opt/homebrew/bin/dotnet test automapper-analyser.sln --no-restore --framework net10.0` passed with 637 tests, 8 skipped
- `git diff --check` clean
- CI covers broader hosted verification; local .NET 8/9 runtime verification is blocked because this machine only has .NET 10 runtimes installed