### PR TITLE
Harden AM003 assignable collection boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [2.30.2] - 2026-04-26
+
+### Changed
+
+- Hardened AM003 collection-container diagnostics so implicitly assignable source collections no longer require unnecessary explicit mapping.
+- Added AM003 regression coverage for array-to-interface and set-to-read-only-interface collection shapes.
+- Updated AM003 rule docs and analyzer health status to document the safe assignable boundary.
+
+### Validation
+
+- Targeted AM003 analyzer and code fix tests.
+- Full `net10.0` solution test suite.
+- `git diff --check`.
+
 ## [2.30.1] - 2026-04-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet Version](https://img.shields.io/nuget/v/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=NuGet)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=Downloads)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/georgepwall1991/automapper-analyser/ci.yml?style=flat-square&logo=github&label=Build)](https://github.com/georgepwall1991/automapper-analyser/actions)
-[![Tests](https://img.shields.io/badge/Tests-637%20passing%2C%208%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
+[![Tests](https://img.shields.io/badge/Tests-638%20passing%2C%208%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
 [![.NET](https://img.shields.io/badge/.NET-4.8+%20%7C%206.0+%20%7C%208.0+%20%7C%209.0+%20%7C%2010.0+-512BD4?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 [![Coverage](https://img.shields.io/codecov/c/github/georgepwall1991/automapper-analyser?style=flat-square&logo=codecov&label=Coverage)](https://codecov.io/gh/georgepwall1991/automapper-analyser)
@@ -14,25 +14,26 @@ prevention*
 
 ---
 
-## 🎉 Latest Release: v2.30.1
+## 🎉 Latest Release: v2.30.2
 
-**AM002 Nullability Contract Alignment — descriptor-accurate docs and edge-case coverage**
+**AM003 Assignable Collection Boundary — quieter container diagnostics for safe collection contracts**
 
 ✅ **Highlights**
 
-- Aligned AM002 documentation with its real descriptor split: nullable source to non-nullable destination is `Error`, and non-nullable source to nullable destination is `Info`.
-- Added AM002 boundary coverage for oblivious reference nullability so disabled nullable annotations do not create noisy reference-type diagnostics.
-- Added AM002 regression coverage proving nullable value types remain protected even when nullable reference annotations are disabled.
-- Updated the analyzer health audit and rule coverage table so release docs match shipped behavior.
+- Hardened AM003 so source collections that already satisfy the destination contract no longer require explicit mapping.
+- Added AM003 coverage for array-to-interface and set-to-read-only-interface shapes.
+- Kept AM003 ownership focused on real container conversions while preserving AM021 ownership of element mismatches.
+- Updated rule docs and analyzer health status to document the safe assignable boundary.
 
 🧪 **Validation**
 
 - Full solution test validation passed on `net10.0`.
-- Full test suite passed with `637` passing and `8` skipped.
-- Release validation covered targeted AM002 regressions plus full solution verification before tagging.
+- Full test suite passed with `638` passing and `8` skipped.
+- Release validation covered targeted AM003 regressions plus full solution verification before tagging.
 
 ### Recent Releases
 
+- **v2.30.1**: AM002 nullability contract alignment with descriptor-accurate docs and nullable-context regression coverage.
 - **v2.30.0**: Fixer hardening for AM001, AM005, AM006, AM011, and AM021 with safer action selection.
 - **v2.29.0**: Smart primary fix and reduced fixer noise across the main data-integrity fixers.
 - **v2.28.2**: False-positive reduction, fixer UX improvements, and release workflow hardening.
@@ -169,7 +170,7 @@ Install-Package AutoMapperAnalyzer.Analyzers
 ### Project File (For CI/CD)
 
 ```xml
-<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.1">
+<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.2">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 </PackageReference>
@@ -363,6 +364,7 @@ This isn't just another analyzer—it's built for **enterprise-grade reliability
 
 ### Recently Completed ✅
 
+- **v2.30.2**: AM003 assignable collection boundary suppression with targeted regression coverage
 - **v2.30.1**: AM002 nullability contract alignment with descriptor-accurate docs and nullable-context regression coverage
 - **v2.30.0**: Fixer hardening for AM001, AM005, AM006, AM011, and AM021 with safer action selection
 - **v2.29.0**: Smart Primary Fix — reduced fixer noise to max 2 lightbulb options per diagnostic

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -33,7 +33,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |
 | AM001 | Property type mismatch | Type Safety | Error | 4 | 4 | 4 | 4 | 4 | 5 | Low | Strong semantic AutoMapper gating, ownership handoff to AM002/AM020/AM021, and solid fixer coverage; remaining gaps are mostly advanced conversion semantics and richer compile-time conversion modeling. |
 | AM002 | Nullable compatibility issue | Type Safety | Error/Info | 4 | 4 | 4 | 5 | 4 | 5 | Low | Descriptor-accurate docs now call out the Error/Info split, and regression tests cover oblivious reference nullability plus nullable value types in disabled nullable contexts. Remaining opportunities are advanced generic/nullability-flow semantics. |
-| AM003 | Collection type incompatibility | Type Safety | Error | 3 | 4 | 4 | 4 | 4 | 4 | Medium | The ownership split with AM021 is well tested, but collection-container knowledge is still a curated heuristic around common containers rather than a broad AutoMapper collection-conversion model. |
+| AM003 | Collection type incompatibility | Type Safety | Error | 4 | 4 | 4 | 5 | 4 | 4 | Low | Now suppresses container diagnostics when the source collection is implicitly assignable to the destination contract, with regression coverage for array/interface and set/read-only interface shapes. Remaining opportunities are broader custom/immutable collection semantics. |
 | AM004 | Source property has no corresponding destination property | Data Integrity | Warning | 4 | 4 | 4 | 5 | 4 | 5 | Low | One of the strongest rules: reverse maps, records, inheritance, flattening, ctor params, custom construction, and fixer behavior have extensive coverage. Keep docs aligned because README/rule docs still imply older severity language in spots. |
 | AM005 | Property names differ only in casing | Data Integrity | Warning | 4 | 4 | 4 | 4 | 3 | 3 | Low | Focused and reasonably conservative with explicit mapping, source ignore, reverse-map, and executable fixer tests; docs/samples understate current Warning severity and should better explain intentional naming policies. |
 | AM006 | Destination property is not mapped | Data Integrity | Info | 4 | 4 | 4 | 4 | 4 | 4 | Low | Solid non-required counterpart to AM011 with flattening, reverse-map, ForPath, lookalike API, fuzzy-match, and bulk-ignore coverage; analyzer test count is lighter than AM004 but the risk is lower. |
@@ -53,8 +53,8 @@ The next improvement batch should focus on rules where user impact and health ga
 | Priority | Rules | Work |
 | --- | --- | --- |
 | High | None | No implemented rule currently looks both high-impact and unhealthy enough to demand urgent intervention before normal release work. |
-| Medium | AM003, AM011, AM022, AM030, AM031 | Expand collection/converter/performance boundary tests, and make manual-vs-executable fixer expectations explicit in docs. |
-| Low | AM001, AM002, AM004, AM005, AM006, AM020, AM021, AM041, AM050 | Treat as currently acceptable, reference examples, or low-impact cleanup rules. Improve opportunistically when touching nearby code. |
+| Medium | AM011, AM022, AM030, AM031 | Expand required-member/converter/performance boundary tests, and make manual-vs-executable fixer expectations explicit in docs. |
+| Low | AM001, AM002, AM003, AM004, AM005, AM006, AM020, AM021, AM041, AM050 | Treat as currently acceptable, reference examples, or low-impact cleanup rules. Improve opportunistically when touching nearby code. |
 
 ## Cross-Cutting Findings
 
@@ -70,6 +70,6 @@ Architecture-style coverage currently comes from analyzer/fixer tests, conflict 
 
 Current local verification:
 
-- `/opt/homebrew/bin/dotnet test automapper-analyser.sln --no-restore --framework net10.0` passed: 637 passed, 8 skipped, 0 failed.
+- `/opt/homebrew/bin/dotnet test automapper-analyser.sln --no-restore --framework net10.0` passed: 638 passed, 8 skipped, 0 failed.
 - The restore/test run reported existing warnings worth tracking: AutoMapper 14.0.0 has advisory `GHSA-rvv3-g6hj-g44x`, several analyzer packaging/test-infrastructure warnings are present, and skipped-test warnings cover AM001, AM031, and AM050 scenarios.
 - `/opt/homebrew/bin/dotnet --list-runtimes` shows only .NET 10 runtimes in this local environment, so broader runtime verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -234,6 +234,7 @@ CreateMap<Source, Destination>()
 - ✅ `Stack` ↔ other collections
 - ❌ Element type mismatches (owned by `AM021`)
 - ❌ `List` → `Array` (AutoMapper handles this)
+- ❌ Source collections already assignable to the destination contract, such as `T[]` → `IEnumerable<T>` or `HashSet<T>` → `IReadOnlyCollection<T>`
 
 #### Configuration
 
@@ -706,7 +707,7 @@ public class MappingProfile : Profile
 
 `AM021` checks for an existing `CreateMap<SourceItem, DestinationItem>()` before reporting. If element mapping exists, no diagnostic is emitted.
 
-If collection containers are incompatible (`HashSet<T>` vs `List<T>`, `Queue<T>` vs `Stack<T>`, etc.), `AM003` owns the diagnostic.
+If collection containers are incompatible (`HashSet<T>` vs `List<T>`, `Queue<T>` vs `Stack<T>`, etc.), `AM003` owns the diagnostic. AM003 stays quiet when the source collection is already assignable to the destination collection contract.
 
 #### Solution
 

--- a/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
+++ b/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
@@ -17,7 +17,7 @@
         <!-- Fallback for local builds: 2.0.YYYYMMDD-local -->
         <MajorVersion>2</MajorVersion>
         <MinorVersion>30</MinorVersion>
-        <PatchVersion>1</PatchVersion>
+        <PatchVersion>2</PatchVersion>
         <BuildNumber Condition="'$(BuildNumber)' == ''"
         >$([System.DateTime]::Now.ToString('yyyyMMdd'))
         </BuildNumber
@@ -32,18 +32,18 @@
         <RepositoryUrl>https://github.com/georgepwall1991/automapper-analyser</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <PackageReleaseNotes>Version 2.30.1 - AM002 nullability contract alignment
+        <PackageReleaseNotes>Version 2.30.2 - AM003 assignable collection boundary
 
             Changed:
-            - Aligned AM002 docs with its descriptor split: nullable source to non-nullable destination is Error, non-nullable source to nullable destination is Info
-            - Added AM002 nullable-context regression coverage for oblivious reference types and nullable value types
-            - Updated analyzer health and README coverage metadata for the shipped rule severities
+            - Hardened AM003 collection-container diagnostics so implicitly assignable source collections do not require unnecessary explicit mapping
+            - Added AM003 regression coverage for array-to-interface and set-to-read-only-interface collection shapes
+            - Updated AM003 rule docs and analyzer health status to document the safe assignable boundary
 
             Validation:
-            - Full solution test suite passing on net10.0 with targeted AM002 regression coverage
+            - Full solution test suite passing on net10.0 with targeted AM003 regression coverage
             - git diff --check clean
 
-            Previous Release: v2.30.0 - fixer hardening and safer action selection
+            Previous Release: v2.30.1 - AM002 nullability contract alignment
         </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>

--- a/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM003_CollectionTypeIncompatibilityAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM003_CollectionTypeIncompatibilityAnalyzer.cs
@@ -147,8 +147,10 @@ public class AM003_CollectionTypeIncompatibilityAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // AM003 owns collection container incompatibilities.
-        if (AreCollectionTypesIncompatible(sourceProperty.Type, destinationProperty.Type))
+        // AM003 owns collection container incompatibilities, but should stay quiet
+        // when the source collection can already satisfy the destination contract.
+        if (!IsImplicitlyAssignable(sourceProperty.Type, destinationProperty.Type, context.SemanticModel.Compilation) &&
+            AreCollectionTypesIncompatible(sourceProperty.Type, destinationProperty.Type))
         {
             ImmutableDictionary<string, string?>.Builder properties =
                 ImmutableDictionary.CreateBuilder<string, string?>();
@@ -237,6 +239,12 @@ public class AM003_CollectionTypeIncompatibilityAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
+    }
+
+    private static bool IsImplicitlyAssignable(ITypeSymbol sourceType, ITypeSymbol destinationType, Compilation compilation)
+    {
+        Conversion conversion = compilation.ClassifyConversion(sourceType, destinationType);
+        return conversion.Exists && conversion.IsImplicit;
     }
 
     private static bool IsGenericCollection(ITypeSymbol type)

--- a/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM003_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM003_CodeFixTests.cs
@@ -203,7 +203,7 @@ public class AM003_CodeFixTests
     }
 
     [Fact]
-    public async Task AM003_ShouldFixArrayToIEnumerableConversion()
+    public async Task AM003_ShouldNotOfferFix_WhenSourceCollectionAssignableToDestinationInterface()
     {
         const string testCode = """
                                 using AutoMapper;
@@ -214,11 +214,13 @@ public class AM003_CodeFixTests
                                     public class Source
                                     {
                                         public string[] Tags { get; set; }
+                                        public HashSet<int> Values { get; set; }
                                     }
 
                                     public class Destination
                                     {
                                         public IEnumerable<string> Tags { get; set; }
+                                        public IReadOnlyCollection<int> Values { get; set; }
                                     }
 
                                     public class TestProfile : Profile
@@ -231,44 +233,7 @@ public class AM003_CodeFixTests
                                 }
                                 """;
 
-        const string expectedFixedCode = """
-                                         using AutoMapper;
-                                         using System.Collections.Generic;
-                                         using System.Linq;
-
-                                         namespace TestNamespace
-                                         {
-                                             public class Source
-                                             {
-                                                 public string[] Tags { get; set; }
-                                             }
-
-                                             public class Destination
-                                             {
-                                                 public IEnumerable<string> Tags { get; set; }
-                                             }
-
-                                             public class TestProfile : Profile
-                                             {
-                                                 public TestProfile()
-                                                 {
-                                                     CreateMap<Source, Destination>().ForMember(dest => dest.Tags, opt => opt.MapFrom(src => src.Tags.AsEnumerable()));
-                                                 }
-                                             }
-                                         }
-                                         """;
-
-        await VerifyFixAsync(
-            testCode,
-            AM003_CollectionTypeIncompatibilityAnalyzer.CollectionTypeIncompatibilityRule,
-            20,
-            13,
-            expectedFixedCode,
-            "Tags",
-            "Source",
-            "string[]",
-            "Destination",
-            "System.Collections.Generic.IEnumerable<string>");
+        await AnalyzerVerifier<AM003_CollectionTypeIncompatibilityAnalyzer>.VerifyAnalyzerAsync(testCode);
     }
 
     [Fact]

--- a/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM003_CollectionTypeIncompatibilityTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM003_CollectionTypeIncompatibilityTests.cs
@@ -259,6 +259,41 @@ public class AM003_CollectionTypeIncompatibilityTests
     }
 
     [Fact]
+    public async Task AM003_ShouldNotReportDiagnostic_WhenSourceCollectionAssignableToDestinationInterface()
+    {
+        const string testCode = """
+
+                                using AutoMapper;
+                                using System.Collections.Generic;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public string[] Tags { get; set; }
+                                        public HashSet<int> Numbers { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public IEnumerable<string> Tags { get; set; }
+                                        public IReadOnlyCollection<int> Numbers { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await AnalyzerVerifier<AM003_CollectionTypeIncompatibilityAnalyzer>.VerifyAnalyzerAsync(testCode);
+    }
+
+    [Fact]
     public async Task AM003_ShouldNotReportDiagnostic_WhenNumericElementTypesIncompatible()
     {
         const string testCode = """


### PR DESCRIPTION
## Summary
- harden AM003 so implicitly assignable source collections do not require explicit mapping
- add safe-pattern coverage for array-to-interface and set-to-read-only-interface shapes
- update docs/analyzer-health and bump v2.30.2

## Impact
This improves analyzer precision by catching real collection-container conversions while suppressing safe assignable collection contracts.

## Validation
- local AM003 test slice passed: 28 passed
- local net10 test run passed: 638 passed, 8 skipped
- git diff --check clean
- local .NET 8/9 verification is blocked because only .NET 10 runtimes are installed; CI covers the broader matrix