### PR TITLE
Harden AM011 ForPath required member boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [2.30.3] - 2026-04-26
+
+### Changed
+
+- Hardened AM011 required-member diagnostics so explicit `ForPath` configuration no longer reports as unmapped.
+- Added AM011 regression coverage for direct and nested `ForPath` destination-member configuration.
+- Updated AM011 rule docs and analyzer health status to document explicit configuration and manual-review fixer boundaries.
+
+### Validation
+
+- Targeted AM011 analyzer tests.
+- Full `net10.0` solution test suite.
+- `git diff --check`.
+
 ## [2.30.2] - 2026-04-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet Version](https://img.shields.io/nuget/v/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=NuGet)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=Downloads)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/georgepwall1991/automapper-analyser/ci.yml?style=flat-square&logo=github&label=Build)](https://github.com/georgepwall1991/automapper-analyser/actions)
-[![Tests](https://img.shields.io/badge/Tests-638%20passing%2C%208%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
+[![Tests](https://img.shields.io/badge/Tests-640%20passing%2C%208%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
 [![.NET](https://img.shields.io/badge/.NET-4.8+%20%7C%206.0+%20%7C%208.0+%20%7C%209.0+%20%7C%2010.0+-512BD4?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 [![Coverage](https://img.shields.io/codecov/c/github/georgepwall1991/automapper-analyser?style=flat-square&logo=codecov&label=Coverage)](https://codecov.io/gh/georgepwall1991/automapper-analyser)
@@ -14,25 +14,26 @@ prevention*
 
 ---
 
-## 🎉 Latest Release: v2.30.2
+## 🎉 Latest Release: v2.30.3
 
-**AM003 Assignable Collection Boundary — quieter container diagnostics for safe collection contracts**
+**AM011 ForPath Required-Member Boundary — quieter diagnostics for explicit required-member configuration**
 
 ✅ **Highlights**
 
-- Hardened AM003 so source collections that already satisfy the destination contract no longer require explicit mapping.
-- Added AM003 coverage for array-to-interface and set-to-read-only-interface shapes.
-- Kept AM003 ownership focused on real container conversions while preserving AM021 ownership of element mismatches.
-- Updated rule docs and analyzer health status to document the safe assignable boundary.
+- Hardened AM011 so required members configured with `ForPath` no longer report as unmapped.
+- Added AM011 coverage for direct and nested `ForPath` destination-member configuration.
+- Documented the explicit configuration boundary across `ForMember`, `ForPath`, `ForCtorParam`, and custom construction.
+- Clarified that default-value and ignore code fixes are manual-review scaffolds for required members.
 
 🧪 **Validation**
 
 - Full solution test validation passed on `net10.0`.
-- Full test suite passed with `638` passing and `8` skipped.
-- Release validation covered targeted AM003 regressions plus full solution verification before tagging.
+- Full test suite passed with `640` passing and `8` skipped.
+- Release validation covered targeted AM011 regressions plus full solution verification before tagging.
 
 ### Recent Releases
 
+- **v2.30.2**: AM003 assignable collection boundary suppression with targeted regression coverage.
 - **v2.30.1**: AM002 nullability contract alignment with descriptor-accurate docs and nullable-context regression coverage.
 - **v2.30.0**: Fixer hardening for AM001, AM005, AM006, AM011, and AM021 with safer action selection.
 - **v2.29.0**: Smart primary fix and reduced fixer noise across the main data-integrity fixers.
@@ -170,7 +171,7 @@ Install-Package AutoMapperAnalyzer.Analyzers
 ### Project File (For CI/CD)
 
 ```xml
-<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.2">
+<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.3">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 </PackageReference>
@@ -364,6 +365,7 @@ This isn't just another analyzer—it's built for **enterprise-grade reliability
 
 ### Recently Completed ✅
 
+- **v2.30.3**: AM011 ForPath required-member boundary with explicit-configuration regression coverage
 - **v2.30.2**: AM003 assignable collection boundary suppression with targeted regression coverage
 - **v2.30.1**: AM002 nullability contract alignment with descriptor-accurate docs and nullable-context regression coverage
 - **v2.30.0**: Fixer hardening for AM001, AM005, AM006, AM011, and AM021 with safer action selection

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -37,7 +37,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | AM004 | Source property has no corresponding destination property | Data Integrity | Warning | 4 | 4 | 4 | 5 | 4 | 5 | Low | One of the strongest rules: reverse maps, records, inheritance, flattening, ctor params, custom construction, and fixer behavior have extensive coverage. Keep docs aligned because README/rule docs still imply older severity language in spots. |
 | AM005 | Property names differ only in casing | Data Integrity | Warning | 4 | 4 | 4 | 4 | 3 | 3 | Low | Focused and reasonably conservative with explicit mapping, source ignore, reverse-map, and executable fixer tests; docs/samples understate current Warning severity and should better explain intentional naming policies. |
 | AM006 | Destination property is not mapped | Data Integrity | Info | 4 | 4 | 4 | 4 | 4 | 4 | Low | Solid non-required counterpart to AM011 with flattening, reverse-map, ForPath, lookalike API, fuzzy-match, and bulk-ignore coverage; analyzer test count is lighter than AM004 but the risk is lower. |
-| AM011 | Required destination property is not mapped | Data Integrity | Error | 4 | 4 | 3 | 4 | 4 | 5 | Medium | Important runtime-failure guardrail with good required-member and reverse-map coverage; fixer still leans on default/constant/custom mapping scaffolds, so domain-safe mapping remains partly manual. |
+| AM011 | Required destination property is not mapped | Data Integrity | Error | 4 | 5 | 3 | 5 | 5 | 5 | Low | Important runtime-failure guardrail with required-member, reverse-map, constructor, custom-construction, and direct/nested ForPath coverage; fixer default/ignore actions are now documented as manual-review scaffolds. |
 | AM020 | Nested object mapping configuration missing | Complex Mappings | Warning | 4 | 4 | 4 | 5 | 5 | 5 | Low | The reference example in this repo: broad tests cover separate profiles, reverse maps, inheritance, records, interfaces, internal members, ForPath/string paths, and construction/conversion suppression. |
 | AM021 | Collection element type incompatibility | Complex Mappings | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | Good AM003 boundary discipline and recent fixer hardening for case-only names plus queue/stack output shape; keep expanding dictionary/custom-collection and reverse-map edge cases. |
 | AM022 | Infinite recursion risk | Complex Mappings | Warning | 3 | 3 | 4 | 4 | 4 | 4 | Medium | Useful and well tested for common cycles, MaxDepth, Ignore, collections, and reverse-map boundaries, but recursion analysis remains heuristic and may miss or over-report nuanced graph/DTO ownership patterns. |
@@ -53,8 +53,8 @@ The next improvement batch should focus on rules where user impact and health ga
 | Priority | Rules | Work |
 | --- | --- | --- |
 | High | None | No implemented rule currently looks both high-impact and unhealthy enough to demand urgent intervention before normal release work. |
-| Medium | AM011, AM022, AM030, AM031 | Expand required-member/converter/performance boundary tests, and make manual-vs-executable fixer expectations explicit in docs. |
-| Low | AM001, AM002, AM003, AM004, AM005, AM006, AM020, AM021, AM041, AM050 | Treat as currently acceptable, reference examples, or low-impact cleanup rules. Improve opportunistically when touching nearby code. |
+| Medium | AM022, AM030, AM031 | Expand recursion/converter/performance boundary tests, and make manual-vs-executable fixer expectations explicit in docs. |
+| Low | AM001, AM002, AM003, AM004, AM005, AM006, AM011, AM020, AM021, AM041, AM050 | Treat as currently acceptable, reference examples, or low-impact cleanup rules. Improve opportunistically when touching nearby code. |
 
 ## Cross-Cutting Findings
 
@@ -70,6 +70,6 @@ Architecture-style coverage currently comes from analyzer/fixer tests, conflict 
 
 Current local verification:
 
-- `/opt/homebrew/bin/dotnet test automapper-analyser.sln --no-restore --framework net10.0` passed: 638 passed, 8 skipped, 0 failed.
+- `/opt/homebrew/bin/dotnet test automapper-analyser.sln --no-restore --framework net10.0` passed: 640 passed, 8 skipped, 0 failed.
 - The restore/test run reported existing warnings worth tracking: AutoMapper 14.0.0 has advisory `GHSA-rvv3-g6hj-g44x`, several analyzer packaging/test-infrastructure warnings are present, and skipped-test warnings cover AM001, AM031, and AM050 scenarios.
 - `/opt/homebrew/bin/dotnet --list-runtimes` shows only .NET 10 runtimes in this local environment, so broader runtime verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -476,7 +476,7 @@ dotnet_diagnostic.AM006.severity = suggestion
 
 #### Description
 
-Detects destination properties marked as `required` (C# 11+) that have no corresponding source property.
+Detects destination properties marked as `required` (C# 11+) that have no corresponding source property or explicit destination configuration.
 
 #### Problem
 
@@ -524,7 +524,18 @@ CreateMap<Source, Destination>()
     .ForMember(dest => dest.Email, opt => opt.MapFrom(src => "noreply@example.com"));
 ```
 
-**Option 3: Make Property Optional**
+Use this only when the default value is valid domain data. The code fix may generate a compilable starter value such as `string.Empty`, `0`, or `false`, but required members usually deserve an intentional source mapping.
+
+**Option 3: Configure With ForPath**
+
+```csharp
+CreateMap<Source, Destination>()
+    .ForPath(dest => dest.Email, opt => opt.MapFrom(src => src.ContactEmail));
+```
+
+`AM011` treats `ForMember`, `ForPath`, and `ForCtorParam` as explicit required-member configuration. It also stays quiet when custom construction or conversion is present because those paths can initialize required members outside ordinary member mapping.
+
+**Option 4: Make Property Optional**
 
 ```csharp
 public class Destination
@@ -534,6 +545,8 @@ public class Destination
     public string? Email { get; set; }  // ✅ Now optional
 }
 ```
+
+**Manual Review Boundary**: The fixer can suggest a unique fuzzy source-property match or add a default-value mapping. If you choose to ignore a required member, verify that another construction path initializes it or that leaving it unset is intentional.
 
 #### Configuration
 

--- a/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
+++ b/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
@@ -17,7 +17,7 @@
         <!-- Fallback for local builds: 2.0.YYYYMMDD-local -->
         <MajorVersion>2</MajorVersion>
         <MinorVersion>30</MinorVersion>
-        <PatchVersion>2</PatchVersion>
+        <PatchVersion>3</PatchVersion>
         <BuildNumber Condition="'$(BuildNumber)' == ''"
         >$([System.DateTime]::Now.ToString('yyyyMMdd'))
         </BuildNumber
@@ -32,18 +32,18 @@
         <RepositoryUrl>https://github.com/georgepwall1991/automapper-analyser</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <PackageReleaseNotes>Version 2.30.2 - AM003 assignable collection boundary
+        <PackageReleaseNotes>Version 2.30.3 - AM011 ForPath required-member boundary
 
             Changed:
-            - Hardened AM003 collection-container diagnostics so implicitly assignable source collections do not require unnecessary explicit mapping
-            - Added AM003 regression coverage for array-to-interface and set-to-read-only-interface collection shapes
-            - Updated AM003 rule docs and analyzer health status to document the safe assignable boundary
+            - Hardened AM011 required-member diagnostics so explicit ForPath configuration does not report as unmapped
+            - Added AM011 regression coverage for direct and nested ForPath destination-member configuration
+            - Updated AM011 rule docs and analyzer health status to document explicit configuration and manual-review fixer boundaries
 
             Validation:
-            - Full solution test suite passing on net10.0 with targeted AM003 regression coverage
+            - Full solution test suite passing on net10.0 with targeted AM011 regression coverage
             - git diff --check clean
 
-            Previous Release: v2.30.1 - AM002 nullability contract alignment
+            Previous Release: v2.30.2 - AM003 assignable collection boundary
         </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>

--- a/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM011_UnmappedRequiredPropertyAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM011_UnmappedRequiredPropertyAnalyzer.cs
@@ -118,8 +118,8 @@ public class AM011_UnmappedRequiredPropertyAnalyzer : DiagnosticAnalyzer
                 continue; // Property is mapped from source, no issue
             }
 
-            // Check if this destination property is explicitly mapped via ForMember
-            if (IsPropertyConfiguredWithForMember(invocation, destinationProperty.Name, context.SemanticModel))
+            // Check if this destination property is explicitly mapped via ForMember/ForPath
+            if (IsPropertyConfiguredWithDestinationConfiguration(invocation, destinationProperty.Name, context.SemanticModel))
             {
                 continue; // Property is explicitly mapped, no issue
             }
@@ -220,30 +220,32 @@ public class AM011_UnmappedRequiredPropertyAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
-    private static bool IsPropertyConfiguredWithForMember(
+    private static bool IsPropertyConfiguredWithDestinationConfiguration(
         InvocationExpressionSyntax createMapInvocation,
         string propertyName,
         SemanticModel semanticModel)
     {
-        foreach (InvocationExpressionSyntax forMemberCall in GetScopedForMemberCalls(createMapInvocation))
+        foreach (InvocationExpressionSyntax mappingCall in GetScopedDestinationConfigurationCalls(createMapInvocation))
         {
-            if (!MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(forMemberCall, semanticModel, "ForMember"))
+            if (!MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(mappingCall, semanticModel, "ForMember") &&
+                !MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(mappingCall, semanticModel, "ForPath"))
             {
                 continue;
             }
 
-            if (forMemberCall.ArgumentList.Arguments.Count == 0)
+            if (mappingCall.ArgumentList.Arguments.Count == 0)
             {
                 continue;
             }
 
-            CSharpSyntaxNode? lambdaBody = AutoMapperAnalysisHelpers.GetLambdaBody(forMemberCall.ArgumentList.Arguments[0].Expression);
-            if (lambdaBody is not MemberAccessExpressionSyntax memberAccess)
+            string? selectedMember =
+                AM020MappingConfigurationHelpers.GetSelectedTopLevelMemberName(mappingCall.ArgumentList.Arguments[0].Expression);
+            if (selectedMember == null)
             {
                 continue;
             }
 
-            if (string.Equals(memberAccess.Name.Identifier.Text, propertyName, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(selectedMember, propertyName, StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }
@@ -252,10 +254,10 @@ public class AM011_UnmappedRequiredPropertyAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
-    private static IEnumerable<InvocationExpressionSyntax> GetScopedForMemberCalls(
+    private static IEnumerable<InvocationExpressionSyntax> GetScopedDestinationConfigurationCalls(
         InvocationExpressionSyntax createMapInvocation)
     {
-        var forMemberCalls = new List<InvocationExpressionSyntax>();
+        var mappingCalls = new List<InvocationExpressionSyntax>();
         SyntaxNode? currentNode = createMapInvocation.Parent;
 
         while (currentNode is MemberAccessExpressionSyntax memberAccess &&
@@ -267,15 +269,15 @@ public class AM011_UnmappedRequiredPropertyAnalyzer : DiagnosticAnalyzer
                 break;
             }
 
-            if (methodName == "ForMember")
+            if (methodName is "ForMember" or "ForPath")
             {
-                forMemberCalls.Add(invocation);
+                mappingCalls.Add(invocation);
             }
 
             currentNode = invocation.Parent;
         }
 
-        return forMemberCalls;
+        return mappingCalls;
     }
 
     private static bool IsAutoMapperCreateMapInvocation(

--- a/tests/AutoMapperAnalyzer.Tests/DataIntegrity/AM011_UnmappedRequiredPropertyTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/DataIntegrity/AM011_UnmappedRequiredPropertyTests.cs
@@ -444,6 +444,81 @@ public class AM011_UnmappedRequiredPropertyTests
     }
 
     [Fact]
+    public async Task AM011_ShouldNotReportDiagnostic_WhenRequiredPropertyMappedWithForPath()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public string Name { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public required string RequiredField { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>()
+                                                .ForPath(dest => dest.RequiredField, opt => opt.MapFrom(src => src.Name));
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM011_UnmappedRequiredPropertyAnalyzer>()
+            .WithSource(testCode)
+            .RunWithNoDiagnosticsAsync();
+    }
+
+    [Fact]
+    public async Task AM011_ShouldNotReportDiagnostic_WhenRequiredPropertyConfiguredByNestedForPath()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public string Street { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public required AddressDto Address { get; set; }
+                                    }
+
+                                    public class AddressDto
+                                    {
+                                        public string Street { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>()
+                                                .ForPath(dest => dest.Address.Street, opt => opt.MapFrom(src => src.Street));
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM011_UnmappedRequiredPropertyAnalyzer>()
+            .WithSource(testCode)
+            .RunWithNoDiagnosticsAsync();
+    }
+
+    [Fact]
     public async Task AM011_ShouldNotReportDiagnostic_WhenConstructUsingIsConfigured()
     {
         const string testCode = """


### PR DESCRIPTION
## Summary
- harden AM011 so explicit `ForPath` destination configuration no longer reports required members as unmapped
- add direct and nested `ForPath` regression coverage for AM011
- update rule docs, analyzer-health, README, changelog, and bump v2.30.3

## Impact
This improves analyzer precision by preserving AM011 coverage for truly unmapped required members while suppressing false positives for explicit AutoMapper configuration.

## Validation
- `/opt/homebrew/bin/dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter "FullyQualifiedName~AM011"` passed: 26 passed
- `/opt/homebrew/bin/dotnet test automapper-analyser.sln --no-restore --framework net10.0` passed: 640 passed, 8 skipped
- `git diff --check` clean
- CI covers broader hosted validation; local runtime list only includes .NET 10