### PR TITLE
Harden AM022 mapped recursion precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [2.30.4] - 2026-04-26
+
+### Changed
+
+- Hardened AM022 recursion diagnostics so unrelated self-referencing or circular graphs no longer report unless the recursive path is convention-mapped.
+- Added AM022 regression coverage for mismatched recursive member names, independent circular graphs, and ignored indirect recursive members.
+- Updated AM022 rule docs and analyzer health status to describe the mapped-member precision boundary.
+
+### Validation
+
+- Targeted AM022 analyzer and code fix tests.
+- Full `net10.0` solution test suite.
+- `git diff --check`.
+
 ## [2.30.3] - 2026-04-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet Version](https://img.shields.io/nuget/v/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=NuGet)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=Downloads)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/georgepwall1991/automapper-analyser/ci.yml?style=flat-square&logo=github&label=Build)](https://github.com/georgepwall1991/automapper-analyser/actions)
-[![Tests](https://img.shields.io/badge/Tests-640%20passing%2C%208%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
+[![Tests](https://img.shields.io/badge/Tests-643%20passing%2C%208%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
 [![.NET](https://img.shields.io/badge/.NET-4.8+%20%7C%206.0+%20%7C%208.0+%20%7C%209.0+%20%7C%2010.0+-512BD4?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 [![Coverage](https://img.shields.io/codecov/c/github/georgepwall1991/automapper-analyser?style=flat-square&logo=codecov&label=Coverage)](https://codecov.io/gh/georgepwall1991/automapper-analyser)
@@ -14,25 +14,26 @@ prevention*
 
 ---
 
-## 🎉 Latest Release: v2.30.3
+## 🎉 Latest Release: v2.30.4
 
-**AM011 ForPath Required-Member Boundary — quieter diagnostics for explicit required-member configuration**
+**AM022 Mapped Recursion Precision — quieter diagnostics for unrelated circular graphs**
 
 ✅ **Highlights**
 
-- Hardened AM011 so required members configured with `ForPath` no longer report as unmapped.
-- Added AM011 coverage for direct and nested `ForPath` destination-member configuration.
-- Documented the explicit configuration boundary across `ForMember`, `ForPath`, `ForCtorParam`, and custom construction.
-- Clarified that default-value and ignore code fixes are manual-review scaffolds for required members.
+- Hardened AM022 so recursion diagnostics follow convention-mapped member paths instead of unrelated graph cycles.
+- Added AM022 coverage for mismatched recursive member names and independent circular graphs.
+- Suppressed ignored indirect recursive members when the top-level recursive destination path is configured with `Ignore`.
+- Documented the safe boundary for mapped recursion detection and explicit ignore suppression.
 
 🧪 **Validation**
 
 - Full solution test validation passed on `net10.0`.
-- Full test suite passed with `640` passing and `8` skipped.
-- Release validation covered targeted AM011 regressions plus full solution verification before tagging.
+- Full test suite passed with `643` passing and `8` skipped.
+- Release validation covered targeted AM022 regressions plus full solution verification before tagging.
 
 ### Recent Releases
 
+- **v2.30.3**: AM011 ForPath required-member boundary with explicit configuration coverage.
 - **v2.30.2**: AM003 assignable collection boundary suppression with targeted regression coverage.
 - **v2.30.1**: AM002 nullability contract alignment with descriptor-accurate docs and nullable-context regression coverage.
 - **v2.30.0**: Fixer hardening for AM001, AM005, AM006, AM011, and AM021 with safer action selection.
@@ -171,7 +172,7 @@ Install-Package AutoMapperAnalyzer.Analyzers
 ### Project File (For CI/CD)
 
 ```xml
-<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.3">
+<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.4">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 </PackageReference>
@@ -365,6 +366,7 @@ This isn't just another analyzer—it's built for **enterprise-grade reliability
 
 ### Recently Completed ✅
 
+- **v2.30.4**: AM022 mapped recursion precision with unrelated-cycle false-positive reductions
 - **v2.30.3**: AM011 ForPath required-member boundary with explicit-configuration regression coverage
 - **v2.30.2**: AM003 assignable collection boundary suppression with targeted regression coverage
 - **v2.30.1**: AM002 nullability contract alignment with descriptor-accurate docs and nullable-context regression coverage

--- a/docs/ANALYZER_REVIEW_TRACKER.md
+++ b/docs/ANALYZER_REVIEW_TRACKER.md
@@ -28,6 +28,7 @@ Tracks analyzer-by-analyzer improvement passes focused on false positives, contr
 | Ownership + Fixer Hardening | AM003, AM005, AM011, AM020, AM021, AM022, AM030, AM031 | main | TBD | Enforced single-owner overlap policy (AM003 vs AM021, removed property-level AM030 overlap), added strict symbol-only AutoMapper gating, implemented AM030 unused-converter reporting, and hardened fixers to executable-first actions (AM005 rename/explicit map, AM011 placeholder removal + legacy parser fallback, AM031 safe fixes only). |
 | Case-aware Suppression + Fix Routing | AM006, AM020, AM021 | main | v2.28.1 | Fixed AM021 source/destination property-name routing for case-only matches, added top-level parsing for string-literal member paths in shared suppression helpers, and expanded regression coverage for explicit configuration suppression and conflict ownership. |
 | Fixer Hardening Follow-up | AM001, AM005, AM006, AM011, AM021 | main | v2.30.0 | Fixed AM021 queue/stack conversion codegen, restored stable per-diagnostic AM001 action registration, required unique-best fuzzy matches for AM006/AM011, removed AM005 rename actions, and added targeted regression coverage for action ordering and ambiguous suggestions. |
+| AM022 (2nd pass) | Complex Mappings | main | v2.30.4 | Restricted recursion diagnostics to convention-mapped recursive member paths, suppressed ignored indirect recursive members, and added regression coverage for unrelated self-referencing/circular graphs. |
 
 ## In Progress
 

--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -753,7 +753,8 @@ dotnet_diagnostic.AM021.severity = warning
 
 #### Description
 
-Detects circular reference patterns in object graphs that can cause stack overflow without `MaxDepth` configuration.
+Detects circular reference patterns in convention-mapped object graphs that can cause stack overflow without `MaxDepth`
+configuration.
 
 #### Problem
 
@@ -820,7 +821,8 @@ CreateMap<SourcePerson, DestinationPerson>()
 
 #### Indirect Cycles
 
-Also detects indirect circular references:
+Also detects indirect circular references when the cycle is reachable through matching source and destination member
+names:
 
 ```csharp
 public class SourceA { public SourceB RelatedB { get; set; } }
@@ -838,6 +840,10 @@ public class MappingProfile : Profile
     }
 }
 ```
+
+AM022 is intentionally conservative: unrelated cycles on the source and destination types do not report unless the
+recursive member path is actually convention-mapped. Ignoring the top-level recursive destination member with
+`ForMember(..., opt => opt.Ignore())` or `ForPath(..., opt => opt.Ignore())` also suppresses the diagnostic.
 
 #### Configuration
 

--- a/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
+++ b/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
@@ -17,7 +17,7 @@
         <!-- Fallback for local builds: 2.0.YYYYMMDD-local -->
         <MajorVersion>2</MajorVersion>
         <MinorVersion>30</MinorVersion>
-        <PatchVersion>3</PatchVersion>
+        <PatchVersion>4</PatchVersion>
         <BuildNumber Condition="'$(BuildNumber)' == ''"
         >$([System.DateTime]::Now.ToString('yyyyMMdd'))
         </BuildNumber
@@ -32,18 +32,18 @@
         <RepositoryUrl>https://github.com/georgepwall1991/automapper-analyser</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <PackageReleaseNotes>Version 2.30.3 - AM011 ForPath required-member boundary
+        <PackageReleaseNotes>Version 2.30.4 - AM022 mapped recursion precision
 
             Changed:
-            - Hardened AM011 required-member diagnostics so explicit ForPath configuration does not report as unmapped
-            - Added AM011 regression coverage for direct and nested ForPath destination-member configuration
-            - Updated AM011 rule docs and analyzer health status to document explicit configuration and manual-review fixer boundaries
+            - Hardened AM022 recursion diagnostics so unrelated self-referencing or circular graphs no longer report unless the recursive path is convention-mapped
+            - Added AM022 regression coverage for mismatched recursive member names, independent circular graphs, and ignored indirect recursive members
+            - Updated AM022 rule docs and analyzer health status to describe the mapped-member precision boundary
 
             Validation:
-            - Full solution test suite passing on net10.0 with targeted AM011 regression coverage
+            - Full solution test suite passing on net10.0 with targeted AM022 regression coverage
             - git diff --check clean
 
-            Previous Release: v2.30.2 - AM003 assignable collection boundary
+            Previous Release: v2.30.3 - AM011 ForPath required-member boundary
         </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>

--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM022_InfiniteRecursionAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM022_InfiniteRecursionAnalyzer.cs
@@ -136,16 +136,7 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
         }
 
         HashSet<string> ignoredProperties = GetIgnoredProperties(invocation, reverseMapInvocation);
-
-        // Check circular properties between types
-        HashSet<string> circularProperties = FindCircularProperties(sourceType, destinationType);
-        if (circularProperties.Count > 0 && circularProperties.All(prop => ignoredProperties.Contains(prop)))
-        {
-            return true;
-        }
-
-        // Check self-referencing properties in destination type
-        HashSet<string> selfReferencingDestProperties = FindSelfReferencingProperties(destinationType);
+        HashSet<string> selfReferencingDestProperties = FindRecursiveDestinationProperties(sourceType, destinationType);
         if (
             selfReferencingDestProperties.Count > 0
             && selfReferencingDestProperties.All(prop => ignoredProperties.Contains(prop))
@@ -252,8 +243,8 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // Check for self-referencing types on both sides to reduce false positives.
-        if (IsSelfReferencing(sourceType) && IsSelfReferencing(destinationType))
+        // Check for self-referencing mapped properties on both sides to reduce false positives.
+        if (HasMappedSelfReference(sourceType, destinationType))
         {
             var diagnostic = Diagnostic.Create(
                 SelfReferencingTypeRule,
@@ -266,8 +257,8 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // Check for circular references on both source and destination graphs.
-        if (HasCircularReference(sourceType, sourceType) && HasCircularReference(destinationType, destinationType))
+        // Check for circular references reachable through convention-mapped member paths.
+        if (HasMappedCircularReference(sourceType, destinationType))
         {
             var diagnostic = Diagnostic.Create(
                 InfiniteRecursionRiskRule,
@@ -280,27 +271,20 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    private static bool IsSelfReferencing(ITypeSymbol? type)
+    private static bool HasMappedSelfReference(ITypeSymbol? sourceType, ITypeSymbol? destinationType)
     {
-        if (type == null)
+        if (sourceType == null || destinationType == null)
         {
             return false;
         }
 
-        IEnumerable<IPropertySymbol> properties =
-            AutoMapperAnalysisHelpers.GetMappableProperties(type, requireSetter: false);
-
-        foreach (IPropertySymbol? property in properties)
+        foreach ((IPropertySymbol sourceProperty, IPropertySymbol destinationProperty) in
+                 GetConventionMappedPropertyPairs(sourceType, destinationType))
         {
-            // Check direct self-reference
-            if (SymbolEqualityComparer.Default.Equals(property.Type, type))
-            {
-                return true;
-            }
-
-            // Check collection of self-type
-            ITypeSymbol? elementType = AutoMapperAnalysisHelpers.GetCollectionElementType(property.Type);
-            if (elementType != null && SymbolEqualityComparer.Default.Equals(elementType, type))
+            if (
+                IsSelfReference(sourceProperty.Type, sourceType)
+                && IsSelfReference(destinationProperty.Type, destinationType)
+            )
             {
                 return true;
             }
@@ -309,7 +293,44 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
-    private static bool HasCircularReference(
+    private static HashSet<string> FindRecursiveDestinationProperties(
+        INamedTypeSymbol sourceType,
+        INamedTypeSymbol destinationType
+    )
+    {
+        var recursiveProperties = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+        visited.Add(GetTypePairKey(sourceType, destinationType));
+
+        foreach ((IPropertySymbol sourceProperty, IPropertySymbol destinationProperty) in
+                 GetConventionMappedPropertyPairs(sourceType, destinationType))
+        {
+            ITypeSymbol sourcePropertyType = UnwrapCollectionElementType(sourceProperty.Type);
+            ITypeSymbol destinationPropertyType = UnwrapCollectionElementType(destinationProperty.Type);
+
+            if (IsSimpleType(sourcePropertyType) || IsSimpleType(destinationPropertyType))
+            {
+                continue;
+            }
+
+            if (
+                HasMappedCircularReferenceRecursive(
+                    sourcePropertyType,
+                    destinationPropertyType,
+                    new HashSet<string>(visited, StringComparer.Ordinal),
+                    1,
+                    10
+                )
+            )
+            {
+                recursiveProperties.Add(destinationProperty.Name);
+            }
+        }
+
+        return recursiveProperties;
+    }
+
+    private static bool HasMappedCircularReference(
         ITypeSymbol? sourceType,
         ITypeSymbol? destinationType
     )
@@ -319,112 +340,104 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        var visited = new HashSet<ITypeSymbol>(SymbolEqualityComparer.Default);
-        return HasCircularReferenceRecursive(sourceType, destinationType, visited, 0, 10);
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+        return HasMappedCircularReferenceRecursive(sourceType, destinationType, visited, 0, 10);
     }
 
-    private static bool HasCircularReferenceRecursive(
+    private static bool HasMappedCircularReferenceRecursive(
         ITypeSymbol? currentSourceType,
-        ITypeSymbol? targetDestType,
-        HashSet<ITypeSymbol> visited,
+        ITypeSymbol? currentDestinationType,
+        HashSet<string> visited,
         int depth,
         int maxDepth
     )
     {
         // Prevent stack overflow by limiting recursion depth
-        if (depth > maxDepth || currentSourceType == null || targetDestType == null)
+        if (depth > maxDepth || currentSourceType == null || currentDestinationType == null)
         {
             return false;
         }
 
-        // If we've already visited this type, we have a cycle
-        if (visited.Contains(currentSourceType))
+        string typePairKey = GetTypePairKey(currentSourceType, currentDestinationType);
+        if (visited.Contains(typePairKey))
         {
             return true;
         }
 
-        visited.Add(currentSourceType);
+        visited.Add(typePairKey);
 
-        IEnumerable<IPropertySymbol> properties =
-            AutoMapperAnalysisHelpers.GetMappableProperties(currentSourceType, requireSetter: false);
-
-        foreach (IPropertySymbol? property in properties)
+        foreach ((IPropertySymbol sourceProperty, IPropertySymbol destinationProperty) in
+                 GetConventionMappedPropertyPairs(currentSourceType, currentDestinationType))
         {
-            ITypeSymbol propertyType = property.Type;
+            ITypeSymbol sourcePropertyType = UnwrapCollectionElementType(sourceProperty.Type);
+            ITypeSymbol destinationPropertyType = UnwrapCollectionElementType(destinationProperty.Type);
 
             // Skip value types and system types
-            if (IsSimpleType(propertyType))
+            if (IsSimpleType(sourcePropertyType) || IsSimpleType(destinationPropertyType))
             {
                 continue;
             }
 
-            // Check collection element types
-            ITypeSymbol? elementType = AutoMapperAnalysisHelpers.GetCollectionElementType(propertyType);
-            if (elementType != null)
-            {
-                propertyType = elementType;
-            }
-
-            if (propertyType is ITypeSymbol namedPropertyType)
-            {
-                // If this property references back to our target destination type
-                if (SymbolEqualityComparer.Default.Equals(namedPropertyType, targetDestType))
-                {
-                    return true;
-                }
-
-                // Recursively check this property's type
-                if (
-                    HasCircularReferenceRecursive(
-                        namedPropertyType,
-                        targetDestType,
-                        new HashSet<ITypeSymbol>(visited, SymbolEqualityComparer.Default),
-                        depth + 1,
-                        maxDepth
-                    )
+            if (
+                HasMappedCircularReferenceRecursive(
+                    sourcePropertyType,
+                    destinationPropertyType,
+                    new HashSet<string>(visited, StringComparer.Ordinal),
+                    depth + 1,
+                    maxDepth
                 )
-                {
-                    return true;
-                }
+            )
+            {
+                return true;
             }
         }
 
-        visited.Remove(currentSourceType);
         return false;
     }
 
-    private static HashSet<string> FindCircularProperties(
-        INamedTypeSymbol sourceType,
-        INamedTypeSymbol destinationType
+    private static IEnumerable<(IPropertySymbol SourceProperty, IPropertySymbol DestinationProperty)>
+        GetConventionMappedPropertyPairs(
+            ITypeSymbol sourceType,
+            ITypeSymbol destinationType
     )
     {
-        var circularProperties = new HashSet<string>();
-        IEnumerable<IPropertySymbol> sourceProperties =
-            AutoMapperAnalysisHelpers.GetMappableProperties(sourceType, requireSetter: false);
+        Dictionary<string, IPropertySymbol> sourceProperties = AutoMapperAnalysisHelpers
+            .GetMappableProperties(sourceType, requireSetter: false)
+            .GroupBy(property => property.Name, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.OrdinalIgnoreCase);
 
-        foreach (IPropertySymbol? property in sourceProperties)
+        foreach (IPropertySymbol destinationProperty in
+                 AutoMapperAnalysisHelpers.GetMappableProperties(destinationType, requireSetter: false))
         {
-            // Check if property type references back to destination type
-            if (SymbolEqualityComparer.Default.Equals(property.Type, destinationType))
+            if (sourceProperties.TryGetValue(destinationProperty.Name, out IPropertySymbol? sourceProperty))
             {
-                circularProperties.Add(property.Name);
-                continue;
-            }
-
-            // Check collection element types
-            ITypeSymbol? elementType = AutoMapperAnalysisHelpers.GetCollectionElementType(property.Type);
-            if (
-                elementType != null
-                && SymbolEqualityComparer.Default.Equals(elementType, destinationType)
-            )
-            {
-                circularProperties.Add(property.Name);
+                yield return (sourceProperty, destinationProperty);
             }
         }
-
-        return circularProperties;
     }
 
+    private static bool IsSelfReference(ITypeSymbol propertyType, ITypeSymbol containingType)
+    {
+        return SymbolEqualityComparer.Default.Equals(propertyType, containingType)
+               || SymbolEqualityComparer.Default.Equals(
+                   AutoMapperAnalysisHelpers.GetCollectionElementType(propertyType),
+                   containingType
+               );
+    }
+
+    private static ITypeSymbol UnwrapCollectionElementType(ITypeSymbol type)
+    {
+        return AutoMapperAnalysisHelpers.GetCollectionElementType(type) ?? type;
+    }
+
+    private static string GetTypePairKey(ITypeSymbol sourceType, ITypeSymbol destinationType)
+    {
+        return string.Concat(
+            sourceType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            "->",
+            destinationType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)
+        );
+    }
 
     private static bool IsSimpleType(ITypeSymbol type)
     {

--- a/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM022_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM022_CodeFixTests.cs
@@ -219,28 +219,38 @@ public class AM022_CodeFixTests
     }
 
     [Fact]
-    public async Task AM022_ShouldAddMaxDepth_ForCrossTypeCircularReferenceRisk()
+    public async Task AM022_ShouldAddMaxDepth_ForTwoTypeCircularReferenceRisk()
     {
         const string testCode = """
                                 using AutoMapper;
 
                                 namespace TestNamespace
                                 {
-                                    public class SourceEntity
+                                    public class SourceParent
                                     {
-                                        public DestEntity RelatedDest { get; set; }
+                                        public SourceChild Child { get; set; }
                                     }
 
-                                    public class DestEntity
+                                    public class SourceChild
                                     {
-                                        public SourceEntity RelatedSource { get; set; }
+                                        public SourceParent Parent { get; set; }
+                                    }
+
+                                    public class DestParent
+                                    {
+                                        public DestChild Child { get; set; }
+                                    }
+
+                                    public class DestChild
+                                    {
+                                        public DestParent Parent { get; set; }
                                     }
 
                                     public class TestProfile : Profile
                                     {
                                         public TestProfile()
                                         {
-                                            CreateMap<SourceEntity, DestEntity>();
+                                            CreateMap<SourceParent, DestParent>();
                                         }
                                     }
                                 }
@@ -251,21 +261,31 @@ public class AM022_CodeFixTests
 
                                          namespace TestNamespace
                                          {
-                                             public class SourceEntity
+                                             public class SourceParent
                                              {
-                                                 public DestEntity RelatedDest { get; set; }
+                                                 public SourceChild Child { get; set; }
                                              }
 
-                                             public class DestEntity
+                                             public class SourceChild
                                              {
-                                                 public SourceEntity RelatedSource { get; set; }
+                                                 public SourceParent Parent { get; set; }
+                                             }
+
+                                             public class DestParent
+                                             {
+                                                 public DestChild Child { get; set; }
+                                             }
+
+                                             public class DestChild
+                                             {
+                                                 public DestParent Parent { get; set; }
                                              }
 
                                              public class TestProfile : Profile
                                              {
                                                  public TestProfile()
                                                  {
-                                                     CreateMap<SourceEntity, DestEntity>().MaxDepth(2);
+                                                     CreateMap<SourceParent, DestParent>().MaxDepth(2);
                                                  }
                                              }
                                          }
@@ -275,8 +295,8 @@ public class AM022_CodeFixTests
             .VerifyFixAsync(
                 testCode,
                 new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule)
-                    .WithLocation(19, 13)
-                    .WithArguments("SourceEntity", "DestEntity"),
+                    .WithLocation(29, 13)
+                    .WithArguments("SourceParent", "DestParent"),
                 expectedFixedCode);
     }
 

--- a/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM022_InfiniteRecursionTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM022_InfiniteRecursionTests.cs
@@ -317,7 +317,7 @@ public class AM022_InfiniteRecursionTests
     }
 
     [Fact]
-    public async Task AM022_ShouldReportDiagnostic_WhenSourceAndDestinationReferenceEachOther()
+    public async Task AM022_ShouldNotReportDiagnostic_WhenCrossTypePropertiesAreNotMappedByConvention()
     {
         const string testCode = """
                                 using AutoMapper;
@@ -347,8 +347,7 @@ public class AM022_InfiniteRecursionTests
         await DiagnosticTestFramework
             .ForAnalyzer<AM022_InfiniteRecursionAnalyzer>()
             .WithSource(testCode)
-            .ExpectDiagnostic(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule, 19, 13, "SourceEntity",
-                "DestEntity")
+            .ExpectNoDiagnostics()
             .RunAsync();
     }
 
@@ -847,6 +846,135 @@ public class AM022_InfiniteRecursionTests
             .WithSource(testCode)
             .ExpectDiagnostic(AM022_InfiniteRecursionAnalyzer.SelfReferencingTypeRule, 23, 13, "SourcePerson",
                 "DestPerson")
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM022_ShouldNotReportDiagnostic_WhenSelfReferencingMemberNamesDoNotMatch()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class SourceNode
+                                    {
+                                        public string Name { get; set; }
+                                        public SourceNode Parent { get; set; }
+                                    }
+
+                                    public class DestNode
+                                    {
+                                        public string Name { get; set; }
+                                        public DestNode Manager { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<SourceNode, DestNode>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM022_InfiniteRecursionAnalyzer>()
+            .WithSource(testCode)
+            .ExpectNoDiagnostics()
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM022_ShouldNotReportDiagnostic_WhenCircularGraphsUseDifferentMemberNames()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class SourceA
+                                    {
+                                        public SourceB Child { get; set; }
+                                    }
+
+                                    public class SourceB
+                                    {
+                                        public SourceA Owner { get; set; }
+                                    }
+
+                                    public class DestA
+                                    {
+                                        public DestB Related { get; set; }
+                                    }
+
+                                    public class DestB
+                                    {
+                                        public DestA Root { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<SourceA, DestA>();
+                                            CreateMap<SourceB, DestB>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM022_InfiniteRecursionAnalyzer>()
+            .WithSource(testCode)
+            .ExpectNoDiagnostics()
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM022_ShouldNotReportDiagnostic_WhenIndirectRecursiveTopLevelPropertyIgnored()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class SourceA
+                                    {
+                                        public SourceB Child { get; set; }
+                                    }
+
+                                    public class SourceB
+                                    {
+                                        public SourceA Owner { get; set; }
+                                    }
+
+                                    public class DestA
+                                    {
+                                        public DestB Child { get; set; }
+                                    }
+
+                                    public class DestB
+                                    {
+                                        public DestA Owner { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<SourceA, DestA>()
+                                                .ForMember(dest => dest.Child, opt => opt.Ignore());
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM022_InfiniteRecursionAnalyzer>()
+            .WithSource(testCode)
+            .ExpectNoDiagnostics()
             .RunAsync();
     }
 }


### PR DESCRIPTION
## Summary
- harden AM022 so recursion diagnostics only follow convention-mapped recursive member paths
- add AM022 regression coverage for mismatched member names, independent circular graphs, and ignored indirect recursion
- update docs/analyzer-health metadata and bump v2.30.4

## Impact
This improves analyzer precision by avoiding unrelated circular-graph false positives while preserving diagnostics for reachable mapped recursion paths.

## Validation
- targeted AM022 analyzer and code fix tests passed: 39 passed
- local net10 test run passed: 643 passed, 8 skipped
- git diff --check clean
- CI covers the GitHub runner environment