### PR TITLE
Harden AM030 type-based converter usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [2.30.5] - 2026-04-26
+
+### Changed
+
+- Hardened AM030 unused-converter analysis so `ConvertUsing(typeof(MyConverter))` counts as real converter usage.
+- Added AM030 regression coverage for type-based `ConvertUsing` configuration.
+- Updated AM030 rule docs and analyzer health status to document supported converter usage forms.
+
+### Validation
+
+- Targeted AM030 analyzer tests.
+- Full `net10.0` solution test suite.
+- `git diff --check`.
+
 ## [2.30.4] - 2026-04-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet Version](https://img.shields.io/nuget/v/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=NuGet)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=Downloads)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/georgepwall1991/automapper-analyser/ci.yml?style=flat-square&logo=github&label=Build)](https://github.com/georgepwall1991/automapper-analyser/actions)
-[![Tests](https://img.shields.io/badge/Tests-643%20passing%2C%208%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
+[![Tests](https://img.shields.io/badge/Tests-644%20passing%2C%208%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
 [![.NET](https://img.shields.io/badge/.NET-4.8+%20%7C%206.0+%20%7C%208.0+%20%7C%209.0+%20%7C%2010.0+-512BD4?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 [![Coverage](https://img.shields.io/codecov/c/github/georgepwall1991/automapper-analyser?style=flat-square&logo=codecov&label=Coverage)](https://codecov.io/gh/georgepwall1991/automapper-analyser)
@@ -14,25 +14,26 @@ prevention*
 
 ---
 
-## 🎉 Latest Release: v2.30.4
+## 🎉 Latest Release: v2.30.5
 
-**AM022 Mapped Recursion Precision — quieter diagnostics for unrelated circular graphs**
+**AM030 Type-Based Converter Usage Precision — quieter unused-converter diagnostics**
 
 ✅ **Highlights**
 
-- Hardened AM022 so recursion diagnostics follow convention-mapped member paths instead of unrelated graph cycles.
-- Added AM022 coverage for mismatched recursive member names and independent circular graphs.
-- Suppressed ignored indirect recursive members when the top-level recursive destination path is configured with `Ignore`.
-- Documented the safe boundary for mapped recursion detection and explicit ignore suppression.
+- Hardened AM030 so `ConvertUsing(typeof(MyConverter))` counts as real converter usage.
+- Added AM030 coverage for type-based AutoMapper converter configuration.
+- Preserved existing generic and instance `ConvertUsing` handling.
+- Documented the supported AM030 converter usage forms.
 
 🧪 **Validation**
 
 - Full solution test validation passed on `net10.0`.
-- Full test suite passed with `643` passing and `8` skipped.
-- Release validation covered targeted AM022 regressions plus full solution verification before tagging.
+- Full test suite passed with `644` passing and `8` skipped.
+- Release validation covered targeted AM030 regressions plus full solution verification before tagging.
 
 ### Recent Releases
 
+- **v2.30.4**: AM022 mapped recursion precision with unrelated-cycle false-positive reductions.
 - **v2.30.3**: AM011 ForPath required-member boundary with explicit configuration coverage.
 - **v2.30.2**: AM003 assignable collection boundary suppression with targeted regression coverage.
 - **v2.30.1**: AM002 nullability contract alignment with descriptor-accurate docs and nullable-context regression coverage.
@@ -366,6 +367,7 @@ This isn't just another analyzer—it's built for **enterprise-grade reliability
 
 ### Recently Completed ✅
 
+- **v2.30.5**: AM030 type-based converter usage precision for `ConvertUsing(typeof(...))`
 - **v2.30.4**: AM022 mapped recursion precision with unrelated-cycle false-positive reductions
 - **v2.30.3**: AM011 ForPath required-member boundary with explicit-configuration regression coverage
 - **v2.30.2**: AM003 assignable collection boundary suppression with targeted regression coverage

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -41,7 +41,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | AM020 | Nested object mapping configuration missing | Complex Mappings | Warning | 4 | 4 | 4 | 5 | 5 | 5 | Low | The reference example in this repo: broad tests cover separate profiles, reverse maps, inheritance, records, interfaces, internal members, ForPath/string paths, and construction/conversion suppression. |
 | AM021 | Collection element type incompatibility | Complex Mappings | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | Good AM003 boundary discipline and recent fixer hardening for case-only names plus queue/stack output shape; keep expanding dictionary/custom-collection and reverse-map edge cases. |
 | AM022 | Infinite recursion risk | Complex Mappings | Warning | 3 | 3 | 4 | 4 | 4 | 4 | Medium | Useful and well tested for common cycles, MaxDepth, Ignore, collections, and reverse-map boundaries, but recursion analysis remains heuristic and may miss or over-report nuanced graph/DTO ownership patterns. |
-| AM030 | Custom type converter issues | Custom Conversions | Error/Warning/Info | 3 | 3 | 3 | 3 | 3 | 3 | Medium | The rule now focuses on converter implementation quality, null handling, and unused converters, but the single ID mixes distinct concepts and unused-converter analysis can be noisy when converters are wired externally. |
+| AM030 | Custom type converter issues | Custom Conversions | Error/Warning/Info | 3 | 4 | 3 | 4 | 4 | 3 | Low | The rule now recognizes generic, instance, and type-based `ConvertUsing` converter references, reducing unused-converter false positives. Remaining opportunities are mostly external DI/service-provider wiring and the mixed-concept shape of the single AM030 ID. |
 | AM031 | Performance warnings in mapping expressions | Performance | Warning/Info | 3 | 3 | 3 | 4 | 3 | 4 | Medium | Broad, valuable smell detector with many targeted tests, but expensive-operation heuristics are inherently fuzzy and fixer safety varies by issue type; docs should make the supported boundaries more explicit. |
 | AM041 | Duplicate mapping registration | Configuration | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | Strong compilation-wide registry, reverse-map awareness, cross-profile duplicate detection, and removal fixer coverage. Remaining risk is mainly nuanced intentional override/configuration ordering cases. |
 | AM050 | Redundant MapFrom configuration | Configuration | Info | 3 | 3 | 4 | 3 | 3 | 2 | Low | Safe cleanup rule with idempotent fixer tests, but product importance is low and analyzer semantics are intentionally narrow around direct same-name property lambdas. |
@@ -53,8 +53,8 @@ The next improvement batch should focus on rules where user impact and health ga
 | Priority | Rules | Work |
 | --- | --- | --- |
 | High | None | No implemented rule currently looks both high-impact and unhealthy enough to demand urgent intervention before normal release work. |
-| Medium | AM022, AM030, AM031 | Expand recursion/converter/performance boundary tests, and make manual-vs-executable fixer expectations explicit in docs. |
-| Low | AM001, AM002, AM003, AM004, AM005, AM006, AM011, AM020, AM021, AM041, AM050 | Treat as currently acceptable, reference examples, or low-impact cleanup rules. Improve opportunistically when touching nearby code. |
+| Medium | AM022, AM031 | Expand recursion/performance boundary tests, and make manual-vs-executable fixer expectations explicit in docs. |
+| Low | AM001, AM002, AM003, AM004, AM005, AM006, AM011, AM020, AM021, AM030, AM041, AM050 | Treat as currently acceptable, reference examples, or low-impact cleanup rules. Improve opportunistically when touching nearby code. |
 
 ## Cross-Cutting Findings
 
@@ -70,6 +70,6 @@ Architecture-style coverage currently comes from analyzer/fixer tests, conflict 
 
 Current local verification:
 
-- `/opt/homebrew/bin/dotnet test automapper-analyser.sln --no-restore --framework net10.0` passed: 640 passed, 8 skipped, 0 failed.
+- `/opt/homebrew/bin/dotnet test automapper-analyser.sln --no-restore --framework net10.0` passed: 644 passed, 8 skipped, 0 failed.
 - The restore/test run reported existing warnings worth tracking: AutoMapper 14.0.0 has advisory `GHSA-rvv3-g6hj-g44x`, several analyzer packaging/test-infrastructure warnings are present, and skipped-test warnings cover AM001, AM031, and AM050 scenarios.
 - `/opt/homebrew/bin/dotnet --list-runtimes` shows only .NET 10 runtimes in this local environment, so broader runtime verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/docs/ANALYZER_REVIEW_TRACKER.md
+++ b/docs/ANALYZER_REVIEW_TRACKER.md
@@ -29,6 +29,7 @@ Tracks analyzer-by-analyzer improvement passes focused on false positives, contr
 | Case-aware Suppression + Fix Routing | AM006, AM020, AM021 | main | v2.28.1 | Fixed AM021 source/destination property-name routing for case-only matches, added top-level parsing for string-literal member paths in shared suppression helpers, and expanded regression coverage for explicit configuration suppression and conflict ownership. |
 | Fixer Hardening Follow-up | AM001, AM005, AM006, AM011, AM021 | main | v2.30.0 | Fixed AM021 queue/stack conversion codegen, restored stable per-diagnostic AM001 action registration, required unique-best fuzzy matches for AM006/AM011, removed AM005 rename actions, and added targeted regression coverage for action ordering and ambiguous suggestions. |
 | AM022 (2nd pass) | Complex Mappings | main | v2.30.4 | Restricted recursion diagnostics to convention-mapped recursive member paths, suppressed ignored indirect recursive members, and added regression coverage for unrelated self-referencing/circular graphs. |
+| AM030 (2nd pass) | Complex Mappings | main | v2.30.5 | Counted type-based `ConvertUsing(typeof(MyConverter))` converter configuration as usage, reducing unused-converter false positives with targeted regression coverage. |
 
 ## In Progress
 

--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -868,6 +868,8 @@ Validates custom type converter implementations and detects converter-quality is
 - Unused converter declarations (`Info`)
 
 `AM030` no longer reports missing property-level conversion setup. Those mismatches are owned by `AM001`, `AM020`, and `AM021`.
+Unused-converter analysis treats generic, instance, and type-based converter configuration as usage, including
+`ConvertUsing<MyConverter>()`, `ConvertUsing(new MyConverter())`, and `ConvertUsing(typeof(MyConverter))`.
 
 #### Problem 1: Invalid Converter Signature
 
@@ -914,6 +916,13 @@ public class LegacyConverter : ITypeConverter<string, DateTime>
 
 // Converter declared but never used in ConvertUsing
 // ℹ️ AM030: Type converter 'LegacyConverter' is defined but not used
+```
+
+No diagnostic is reported when the converter is referenced through a supported AutoMapper converter overload:
+
+```csharp
+CreateMap<string, DateTime>()
+    .ConvertUsing(typeof(LegacyConverter)); // ✅ counted as usage
 ```
 
 #### Solutions

--- a/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
+++ b/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
@@ -17,7 +17,7 @@
         <!-- Fallback for local builds: 2.0.YYYYMMDD-local -->
         <MajorVersion>2</MajorVersion>
         <MinorVersion>30</MinorVersion>
-        <PatchVersion>4</PatchVersion>
+        <PatchVersion>5</PatchVersion>
         <BuildNumber Condition="'$(BuildNumber)' == ''"
         >$([System.DateTime]::Now.ToString('yyyyMMdd'))
         </BuildNumber
@@ -32,18 +32,18 @@
         <RepositoryUrl>https://github.com/georgepwall1991/automapper-analyser</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <PackageReleaseNotes>Version 2.30.4 - AM022 mapped recursion precision
+        <PackageReleaseNotes>Version 2.30.5 - AM030 type-based converter usage precision
 
             Changed:
-            - Hardened AM022 recursion diagnostics so unrelated self-referencing or circular graphs no longer report unless the recursive path is convention-mapped
-            - Added AM022 regression coverage for mismatched recursive member names, independent circular graphs, and ignored indirect recursive members
-            - Updated AM022 rule docs and analyzer health status to describe the mapped-member precision boundary
+            - Hardened AM030 unused-converter analysis so ConvertUsing(typeof(MyConverter)) counts as real converter usage
+            - Added AM030 regression coverage for type-based ConvertUsing configuration
+            - Updated AM030 rule docs and analyzer health status to document supported converter usage forms
 
             Validation:
-            - Full solution test suite passing on net10.0 with targeted AM022 regression coverage
+            - Full solution test suite passing on net10.0 with targeted AM030 regression coverage
             - git diff --check clean
 
-            Previous Release: v2.30.3 - AM011 ForPath required-member boundary
+            Previous Release: v2.30.4 - AM022 mapped recursion precision
         </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>

--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM030_CustomTypeConverterAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM030_CustomTypeConverterAnalyzer.cs
@@ -186,6 +186,14 @@ public class AM030_CustomTypeConverterAnalyzer : DiagnosticAnalyzer
 
         foreach (ArgumentSyntax argument in invocation.ArgumentList.Arguments)
         {
+            if (argument.Expression is TypeOfExpressionSyntax typeOfExpression &&
+                semanticModel.GetTypeInfo(typeOfExpression.Type).Type is INamedTypeSymbol typeOfArgument &&
+                ImplementsTypeConverter(typeOfArgument))
+            {
+                yield return typeOfArgument;
+                continue;
+            }
+
             TypeInfo typeInfo = semanticModel.GetTypeInfo(argument.Expression);
             ITypeSymbol? argumentType = typeInfo.Type ?? typeInfo.ConvertedType;
 

--- a/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM030_CustomTypeConverterTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM030_CustomTypeConverterTests.cs
@@ -268,4 +268,38 @@ public class AM030_CustomTypeConverterTests
             .ExpectNoDiagnostics()
             .RunAsync();
     }
+
+    [Fact]
+    public async Task AM030_ShouldNotReportDiagnostic_WhenTypeConverterTypeIsPassedToConvertUsing()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System;
+
+                                namespace TestNamespace
+                                {
+                                    public class TypeBasedConverter : ITypeConverter<string, DateTime>
+                                    {
+                                        public DateTime Convert(string source, DateTime destination, ResolutionContext context)
+                                        {
+                                            return DateTime.Parse(source);
+                                        }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<string, DateTime>().ConvertUsing(typeof(TypeBasedConverter));
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM030_CustomTypeConverterAnalyzer>()
+            .WithSource(testCode)
+            .ExpectNoDiagnostics()
+            .RunAsync();
+    }
 }


### PR DESCRIPTION
## Summary
- harden AM030 unused-converter analysis so `ConvertUsing(typeof(MyConverter))` counts as converter usage
- add AM030 regression coverage for type-based converter configuration
- update analyzer health, rule docs, changelog, README, and bump v2.30.5

## Impact
This reduces AM030 false positives for valid AutoMapper type-based converter registration while preserving generic and instance converter usage detection.

## Validation
- targeted AM030 analyzer tests passed: 18 passed
- local net10 solution test run passed: 644 passed, 8 skipped
- `git diff --check` clean
- local runtime check shows only .NET 10 runtimes; CI covers the repository workflow on GitHub