### PR TITLE
[codex] Harden analyzer trust checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,12 @@ jobs:
       - name: Build analyzer (with CodeFixes)
         run: |
           echo "Building unified analyzer package (includes CodeFixes)..."
-          dotnet build src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj --no-restore --configuration Release
+          dotnet build src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj --no-restore --configuration Release -warnaserror
 
       - name: Build test project
         run: |
           echo "Building test project..."
-          dotnet build tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --configuration Release
+          dotnet build tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --configuration Release -warnaserror
 
       - name: Run unit tests with code coverage
         run: |
@@ -85,10 +85,16 @@ jobs:
       - name: Build unified analyzer package
         run: |
           # Build unified analyzer (includes CodeFixes)
-          dotnet build src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj --no-restore --configuration Release
+          dotnet build src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj --no-restore --configuration Release -warnaserror
 
       - name: Pack unified analyzer
         run: dotnet pack src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj --no-build --configuration Release --output ./packages
+
+      - name: Verify package contents
+        run: |
+          unzip -l ./packages/*.nupkg | grep -E "analyzers/dotnet/cs/AutoMapperAnalyzer.Analyzers.dll"
+          unzip -l ./packages/*.nupkg | grep -E "README.md"
+          unzip -l ./packages/*.nupkg | grep -E "icon.png"
 
       - name: Upload packages as artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
@@ -45,4 +45,3 @@ jobs:
         uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{matrix.language}}"
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: |
-            6.0.x
-            8.0.x
-            9.0.x
+          dotnet-version: 10.0.x
 
       - name: Extract version from tag
         id: get_version
@@ -41,10 +38,10 @@ jobs:
         run: dotnet restore
 
       - name: Build analyzer
-        run: dotnet build src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj --configuration Release --no-restore
+        run: dotnet build src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj --configuration Release --no-restore -warnaserror
 
       - name: Build test project
-        run: dotnet build tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --configuration Release --no-restore
+        run: dotnet build tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --configuration Release --no-restore -warnaserror
 
       - name: Run all tests
         run: dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --configuration Release --no-build --verbosity normal

--- a/.github/workflows/simple-build.yml
+++ b/.github/workflows/simple-build.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main, develop ]
 
 env:
-  DOTNET_VERSION: '9.0.x'
+  DOTNET_VERSION: '10.0.x'
   SOLUTION_FILE: 'automapper-analyser.sln'
 
 jobs:
@@ -27,8 +27,11 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore ${{ env.SOLUTION_FILE }}
 
-      - name: Build solution
-        run: dotnet build ${{ env.SOLUTION_FILE }} --no-restore --configuration Release
+      - name: Build analyzer
+        run: dotnet build src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj --no-restore --configuration Release -warnaserror
+
+      - name: Build tests
+        run: dotnet build tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --configuration Release -warnaserror
 
       - name: Run unit tests
-        run: dotnet test ${{ env.SOLUTION_FILE }} --no-build --configuration Release --verbosity normal
+        run: dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-build --configuration Release --verbosity normal

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet Version](https://img.shields.io/nuget/v/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=NuGet)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=Downloads)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/georgepwall1991/automapper-analyser/ci.yml?style=flat-square&logo=github&label=Build)](https://github.com/georgepwall1991/automapper-analyser/actions)
-[![Tests](https://img.shields.io/badge/Tests-644%20passing%2C%208%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
+[![Tests](https://img.shields.io/badge/Tests-656%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
 [![.NET](https://img.shields.io/badge/.NET-4.8+%20%7C%206.0+%20%7C%208.0+%20%7C%209.0+%20%7C%2010.0+-512BD4?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 [![Coverage](https://img.shields.io/codecov/c/github/georgepwall1991/automapper-analyser?style=flat-square&logo=codecov&label=Coverage)](https://codecov.io/gh/georgepwall1991/automapper-analyser)
@@ -28,7 +28,7 @@ prevention*
 🧪 **Validation**
 
 - Full solution test validation passed on `net10.0`.
-- Full test suite passed with `644` passing and `8` skipped.
+- Full test suite passed with `656` passing and `0` skipped.
 - Release validation covered targeted AM030 regressions plus full solution verification before tagging.
 
 ### Recent Releases
@@ -173,7 +173,7 @@ Install-Package AutoMapperAnalyzer.Analyzers
 ### Project File (For CI/CD)
 
 ```xml
-<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.4">
+<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.5">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 </PackageReference>

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -60,16 +60,16 @@ The next improvement batch should focus on rules where user impact and health ga
 
 - Public docs are useful but drift from implementation in several places. `AM004` and `AM005` remain obvious severity/wording mismatches between descriptors, README tables, and rule docs, while `AM002` has been realigned with its shipped Error/Info descriptors.
 - Analyzer ownership is a real strength. The conflict tests and shared helpers make `AM001`/`AM002`/`AM003`/`AM020`/`AM021` boundaries much healthier than a file-count audit would suggest.
-- The project has no generated rule catalog health contract like LinqContraband's catalog tooling. Rule metadata is distributed across descriptors, README, docs, samples, and the manual `AnalyzerVerifier`.
+- The project now has a checked-in `RuleCatalog` health contract that ties rule IDs to descriptors, fixers, docs anchors, sample paths, and fixer trust levels.
 - Diagnostic placement is generally at the mapping invocation or mapping lambda, not always the precise property/member token. That is acceptable for many AutoMapper configuration rules, but high-volume rules benefit from tighter placement when practical.
-- Several fixers intentionally produce advisory/default mapping scaffolds. That is fine, but docs should distinguish "safe executable rewrite" from "starter mapping the developer must review."
+- Several fixers intentionally produce advisory/default mapping scaffolds. That is fine, and docs/code-action titles now distinguish "safe executable rewrite" from "starter mapping the developer must review."
 
 ## Verification Baseline
 
-Architecture-style coverage currently comes from analyzer/fixer tests, conflict ownership tests, helper tests, sample projects, documentation, and the manual `tools/AnalyzerVerifier` project. There is no checked-in rule-catalog generator or sample diagnostics verifier equivalent to the LinqContraband baseline.
+Architecture-style coverage currently comes from analyzer/fixer tests, conflict ownership tests, helper tests, sample projects, documentation, the checked-in `RuleCatalog`, and the manual `tools/AnalyzerVerifier` project.
 
 Current local verification:
 
-- `/opt/homebrew/bin/dotnet test automapper-analyser.sln --no-restore --framework net10.0` passed: 644 passed, 8 skipped, 0 failed.
-- The restore/test run reported existing warnings worth tracking: AutoMapper 14.0.0 has advisory `GHSA-rvv3-g6hj-g44x`, several analyzer packaging/test-infrastructure warnings are present, and skipped-test warnings cover AM001, AM031, and AM050 scenarios.
+- `/opt/homebrew/bin/dotnet test automapper-analyser.sln --no-restore --framework net10.0` passed: 656 passed, 0 skipped, 0 failed.
+- The trust-first pass removed active skipped tests, added drift validation, and moved intentional analyzer-test warnings into an explicit test-project warning baseline.
 - `/opt/homebrew/bin/dotnet --list-runtimes` shows only .NET 10 runtimes in this local environment, so broader runtime verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/docs/ANALYZER_REVIEW_TRACKER.md
+++ b/docs/ANALYZER_REVIEW_TRACKER.md
@@ -30,6 +30,7 @@ Tracks analyzer-by-analyzer improvement passes focused on false positives, contr
 | Fixer Hardening Follow-up | AM001, AM005, AM006, AM011, AM021 | main | v2.30.0 | Fixed AM021 queue/stack conversion codegen, restored stable per-diagnostic AM001 action registration, required unique-best fuzzy matches for AM006/AM011, removed AM005 rename actions, and added targeted regression coverage for action ordering and ambiguous suggestions. |
 | AM022 (2nd pass) | Complex Mappings | main | v2.30.4 | Restricted recursion diagnostics to convention-mapped recursive member paths, suppressed ignored indirect recursive members, and added regression coverage for unrelated self-referencing/circular graphs. |
 | AM030 (2nd pass) | Complex Mappings | main | v2.30.5 | Counted type-based `ConvertUsing(typeof(MyConverter))` converter configuration as usage, reducing unused-converter false positives with targeted regression coverage. |
+| Trust-first hardening | All | main | TBD | Added `RuleCatalog` drift checks, aligned package/docs/SDK workflow metadata, clarified fixer trust levels in code action titles/docs, and converted skipped AM001/AM031/AM050 tests into active coverage. |
 
 ## In Progress
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -436,6 +436,15 @@ context.RegisterCodeFix(
 
 The analyzer uses several helper classes to share common functionality:
 
+### RuleCatalog
+
+`RuleCatalog` is the checked-in trust contract for implemented rules. It groups descriptors by public rule ID and records
+the analyzer type, code fix provider type, diagnostic docs anchor, sample path, and fixer trust level.
+
+Trust tests compare this catalog against analyzer `SupportedDiagnostics`, fixable IDs, rule docs, package metadata, and
+sample files. When a descriptor, fixer, docs section, or package version changes, the catalog validation tests should fail
+until all public-facing metadata is aligned.
+
 ### AutoMapperAnalysisHelpers
 
 Located in `Helpers/AutoMapperAnalysisHelpers.cs`, this is the **core utility class**:
@@ -711,7 +720,7 @@ dotnet pack --configuration Release
 
 # Test package locally
 cd test-install/NetCoreTest
-dotnet add package AutoMapperAnalyzer.Analyzers --version 2.4.1-local
+dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.5-local
 ```
 
 ---
@@ -895,4 +904,4 @@ dotnet build
 
 **Last Updated**: 2025-11-19
 **Maintainer**: George Wall
-**Version**: 2.4.1
+**Version**: 2.30.5

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -17,43 +17,26 @@ The AutoMapper Roslyn Analyzer project uses GitHub Actions for continuous integr
 
 #### Build and Test
 
-- Sets up .NET 9.0 environment
+- Sets up .NET 10.0 environment
 - Restores NuGet packages with caching
-- Builds solution in Release configuration
+- Builds analyzer and test projects in Release configuration with `-warnaserror`
 - Runs unit tests with code coverage collection
 - Uploads coverage reports to Codecov
+- Builds samples, where analyzer warnings are expected demonstration output
 
 #### Package Analyzer
 
 - Runs only on pushes to `main` branch
 - Creates NuGet packages for analyzer and code fixes
+- Verifies package contents include the analyzer DLL, README, and icon
 - Uploads packages as build artifacts
 
-#### Validate Samples
+### 2. Simple Build (`.github/workflows/simple-build.yml`)
 
-- Builds and runs sample scenarios
-- Ensures examples work correctly
-- Validates analyzer behavior with real code
+- Mirrors the main build/test path on .NET 10.0.
+- Treats unexpected build warnings as errors.
 
-#### Security Scan
-
-- Runs Trivy vulnerability scanner
-- Uploads results to GitHub Security tab
-- Scans for security vulnerabilities in dependencies
-
-#### Code Quality Analysis
-
-- Integrates with SonarCloud for code quality metrics
-- Analyzes code for bugs, vulnerabilities, and code smells
-- Tracks technical debt and maintainability
-
-#### Release
-
-- Triggers only with `[release]` in commit message
-- Publishes packages to NuGet.org
-- Creates GitHub releases with artifacts
-
-### 2. CodeQL Security Analysis (`.github/workflows/codeql.yml`)
+### 3. CodeQL Security Analysis (`.github/workflows/codeql.yml`)
 
 **Triggers:**
 
@@ -67,7 +50,19 @@ The AutoMapper Roslyn Analyzer project uses GitHub Actions for continuous integr
 - Detects potential security vulnerabilities
 - Integrates with GitHub Security tab
 
-### 3. Dependency Updates (`.github/dependabot.yml`)
+### 4. Release to NuGet (`.github/workflows/release.yml`)
+
+**Triggers:**
+
+- Semantic version tags such as `v2.30.5`
+
+**Features:**
+
+- Builds and tests with .NET 10.0.
+- Packs with the version extracted from the tag.
+- Publishes to NuGet and creates a GitHub release.
+
+### 5. Dependency Updates (`.github/dependabot.yml`)
 
 **Automated Updates:**
 
@@ -80,32 +75,31 @@ The AutoMapper Roslyn Analyzer project uses GitHub Actions for continuous integr
 
 ### Code Coverage
 
-- Target: >90% code coverage
+- Target: 80% project coverage and 75% patch coverage
 - Tool: Coverlet with XPlat Code Coverage
 - Reporting: Codecov integration
 - Configuration: `coverlet.runsettings`
 
 ### Security Scanning
 
-- **Trivy**: Vulnerability scanning for dependencies
 - **CodeQL**: Static analysis for C# security issues
 - **Dependabot**: Automated dependency updates
 
 ### Code Quality
 
-- **SonarCloud**: Code quality and maintainability
 - **Roslyn Analyzers**: Static code analysis
-- **EditorConfig**: Consistent code formatting
+- **Rule catalog tests**: Descriptor, docs, sample, package, and workflow drift detection
+- **Warnings as errors**: CI builds fail on unexpected warnings outside the managed test warning baseline in `docs/WARNING_BASELINE.md`
 
 ## 🚀 Release Process
 
 ### Manual Release
 
 1. Ensure all tests pass
-2. Update version numbers in project files
-3. Commit with `[release]` in message
-4. Push to `main` branch
-5. Pipeline automatically:
+2. Update version numbers and release notes
+3. Tag the release with `vMajor.Minor.Patch`
+4. Push the tag
+5. The release pipeline automatically:
    - Creates NuGet packages
    - Publishes to NuGet.org
    - Creates GitHub release
@@ -113,8 +107,8 @@ The AutoMapper Roslyn Analyzer project uses GitHub Actions for continuous integr
 ### Package Versioning
 
 - **Format**: Major.Minor.Patch (SemVer)
-- **Current**: 2.4.1
-- **Pre-release**: 2.4.1-preview, 2.4.1-beta
+- **Current**: 2.30.5
+- **Pre-release**: 2.30.5-preview, 2.30.5-beta
 
 ## 🔧 Configuration
 
@@ -125,15 +119,17 @@ Configure these in GitHub repository settings:
 | Secret | Description | Required For |
 |--------|-------------|--------------|
 | `NUGET_API_KEY` | NuGet.org API key for publishing | Release pipeline |
-| `SONAR_TOKEN` | SonarCloud authentication token | Code quality analysis |
 | `CODECOV_TOKEN` | Codecov upload token | Coverage reporting |
 
 ### Environment Variables
 
 | Variable | Value | Description |
 |----------|-------|-------------|
-| `DOTNET_VERSION` | '9.0.x' | .NET SDK version |
+| `DOTNET_VERSION` | '10.0.x' | .NET SDK version |
 | `SOLUTION_FILE` | 'automapper-analyser.sln' | Solution file path |
+
+`global.json` pins the local SDK feature band to `10.0.200` with `latestFeature` roll-forward so developer machines can
+use patched 10.0 SDKs such as `10.0.203` without invalid SDK-version warnings.
 
 ## 📝 Pipeline Files
 
@@ -141,13 +137,15 @@ Configure these in GitHub repository settings:
 .github/
 ├── workflows/
 │   ├── ci.yml              # Main CI/CD pipeline
+│   ├── simple-build.yml    # Secondary build validation
+│   ├── release.yml         # NuGet release pipeline
 │   └── codeql.yml          # Security analysis
 ├── dependabot.yml          # Dependency updates
 └── CODEOWNERS              # Code review assignments
 
 docs/
 ├── CI-CD.md               # This documentation
-└── CONTRIBUTING.md        # Contribution guidelines
+└── WARNING_BASELINE.md    # Managed warning suppressions
 
 coverlet.runsettings       # Code coverage configuration
 ```
@@ -162,7 +160,6 @@ coverlet.runsettings       # Code coverage configuration
 
 ### Quality Metrics
 
-- **SonarCloud**: Code quality dashboard
 - **Codecov**: Coverage trends and reports
 - **GitHub Security**: Vulnerability alerts
 
@@ -203,7 +200,6 @@ dotnet run --project samples/AutoMapperAnalyzer.Samples
 
 - [GitHub Actions Documentation](https://docs.github.com/en/actions)
 - [.NET Build Tasks](https://docs.microsoft.com/en-us/dotnet/core/tools/)
-- [SonarCloud Integration](https://sonarcloud.io/documentation/)
 - [Codecov Documentation](https://docs.codecov.io/)
 - [Dependabot Configuration](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically)
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -43,7 +43,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.4.1">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -67,7 +67,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.4.1">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -86,7 +86,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="14.0.0" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.4.1">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -218,7 +218,7 @@ public class Destination
 
 2. **Verify Package Installation**
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.4.1">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.5">
      <PrivateAssets>all</PrivateAssets>
      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -280,4 +280,4 @@ This guide ensures smooth installation and usage across all supported .NET frame
 ---
 
 **Last Updated**: November 19, 2025
-**Version**: 2.4.1
+**Version**: 2.30.5

--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -46,6 +46,19 @@ To avoid duplicate/conflicting diagnostics, each issue pattern has a single prim
 | Nested complex property requires map (`Address` -> `AddressDto`) | `AM020` | `AM030` |
 | Converter implementation quality problems | `AM030` | none |
 
+### Code Fix Trust Levels
+
+The checked-in `RuleCatalog` class classifies fixers so users can tell whether an action is a direct rewrite or starter
+configuration:
+
+| Trust Level | Meaning | Examples |
+|----------|-------|---------|
+| **Safe rewrite** | Behavior-preserving or convention-equivalent cleanup. | Removing redundant `MapFrom`, adding a missing nested `CreateMap`. |
+| **Likely rewrite** | Reasonable generated mapping that should still be reviewed for domain policy. | Numeric/string conversions, collection conversion helpers, `MaxDepth`. |
+| **Scaffold** | Compile-safe starter code or explicit suppression that requires manual review. | Default-value mappings and `Ignore()` actions for required/unmapped/performance diagnostics. |
+
+Code action titles mark manual-review suppressions explicitly.
+
 ---
 
 ## Type Safety Rules
@@ -1246,7 +1259,7 @@ using System.Diagnostics.CodeAnalysis;
 
 1. **Check package reference**:
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.24.0">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.5">
        <PrivateAssets>all</PrivateAssets>
        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>

--- a/docs/TEST_LIMITATIONS.md
+++ b/docs/TEST_LIMITATIONS.md
@@ -1,15 +1,15 @@
 # Test Limitations
 
-This document tracks known test limitations referenced by `[Fact(Skip = ...)]` messages.
+This project should not carry silent skipped tests. Historical `[Fact(Skip = ...)]` cases have been converted into one of:
 
-1. **Field/dependency type resolution in analyzer tests**
-   Some scenarios that rely on injected service fields (for example `_db`, `_service`) are difficult to model reliably in current analyzer test harness setups and can produce unstable symbol resolution.
+- normal regression tests when the harness can now model the scenario;
+- negative tests when the old skipped case described invalid analyzer behavior;
+- documented warning-baseline entries in `docs/WARNING_BASELINE.md` when the limitation belongs to analyzer-test scaffolding rather than production analyzer behavior.
 
-2. **Code-fix context span/registration constraints**
-   Some Roslyn testing combinations reject otherwise valid code-fix registrations when diagnostics are reported on larger spans or chain expressions. These scenarios are avoided in current integration tests until harness behavior is standardized.
+Known harness caveats remain documented in the test project warning baseline:
 
-3. **AM001 advanced expression-tree conversion patterns**
-   Certain string-to-numeric conversion patterns and multi-diagnostic coordination paths are not consistently fixable in a deterministic single-pass code-fix test; those cases remain skipped until analyzer/fixer coordination is refactored.
+- analyzer-test helper types intentionally trigger Roslyn analyzer-authoring warnings;
+- trust validation tests intentionally read repository files;
+- AutoMapper 14 remains pinned for compatibility coverage while AutoMapper 15 introduces licensing/API changes.
 
-4. **Invalid-converter and compiler-error co-reporting**
-   Tests that intentionally create invalid converter implementations may emit both analyzer diagnostics and compiler errors, requiring explicit dual-diagnostic expectations and careful harness setup.
+The full suite is expected to run with `0` skipped tests.

--- a/docs/WARNING_BASELINE.md
+++ b/docs/WARNING_BASELINE.md
@@ -1,0 +1,14 @@
+# Warning Baseline
+
+CI treats unexpected analyzer/test-project warnings as errors for the analyzer and test projects.
+
+The test project intentionally suppresses a small baseline:
+
+| Warning | Reason |
+| --- | --- |
+| `NU1903` | Tests and samples pin AutoMapper 14 for compatibility while AutoMapper 15 has licensing/API changes. |
+| `RS1035` | Trust validation tests intentionally read repository files to detect docs/package drift. |
+| `RS1038`, `RS1041`, `RS2008` | Test-only analyzer scaffolding and descriptor helpers are not shipped analyzer implementations. |
+| `CA1305`, `CA1861` | Test source builders and assertion helpers prefer readability over production globalization/performance guidance. |
+
+Production analyzer builds are expected to pass with `0` warnings under `-warnaserror`.

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "10.0.0",
-    "rollForward": "latestMajor",
+    "version": "10.0.200",
+    "rollForward": "latestFeature",
     "allowPrerelease": false
   }
 }

--- a/samples/AutoMapperAnalyzer.Samples/AutoMapperAnalyzer.Samples.csproj
+++ b/samples/AutoMapperAnalyzer.Samples/AutoMapperAnalyzer.Samples.csproj
@@ -6,6 +6,8 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
+        <!-- AutoMapper 14 is pinned for pre-license compatibility samples. -->
+        <NoWarn>$(NoWarn);NU1903</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM021_CollectionElementMismatchCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM021_CollectionElementMismatchCodeFixProvider.cs
@@ -114,7 +114,7 @@ public class AM021_CollectionElementMismatchCodeFixProvider : AutoMapperCodeFixP
 
             context.RegisterCodeFix(
                 CodeAction.Create(
-                    $"Ignore property '{destinationPropertyNameValue}'",
+                    $"Ignore property '{destinationPropertyNameValue}' (manual review)",
                     cancellationToken =>
                         AddIgnoreAsync(context.Document, operationContext.Root, invocation, destinationPropertyNameValue),
                     $"AM021_Ignore_{destinationPropertyNameValue}"),

--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM022_InfiniteRecursionCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM022_InfiniteRecursionCodeFixProvider.cs
@@ -63,7 +63,7 @@ public class AM022_InfiniteRecursionCodeFixProvider : AutoMapperCodeFixProviderB
                 string propertyName = selfReferencingProperties[0];
                 context.RegisterCodeFix(
                     CodeAction.Create(
-                        $"Ignore self-referencing property '{propertyName}'",
+                        $"Ignore self-referencing property '{propertyName}' (manual review)",
                         cancellationToken =>
                             AddIgnoreAsync(context.Document, operationContext.Root, invocation, propertyName),
                         $"AM022_Ignore_{propertyName}"),
@@ -94,7 +94,7 @@ public class AM022_InfiniteRecursionCodeFixProvider : AutoMapperCodeFixProviderB
                     // Offer to ignore all self-referencing properties as alternative
                     context.RegisterCodeFix(
                         CodeAction.Create(
-                            $"Ignore all {selfReferencingProperties.Count} self-referencing properties",
+                            $"Ignore all {selfReferencingProperties.Count} self-referencing properties (manual review)",
                             cancellationToken =>
                                 AddIgnoreMultipleAsync(context.Document, operationContext.Root, invocation,
                                     selfReferencingProperties),

--- a/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM011_UnmappedRequiredPropertyCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM011_UnmappedRequiredPropertyCodeFixProvider.cs
@@ -16,8 +16,10 @@ namespace AutoMapperAnalyzer.Analyzers.DataIntegrity;
 [Shared]
 public class AM011_UnmappedRequiredPropertyCodeFixProvider : AutoMapperCodeFixProviderBase
 {
+    /// <inheritdoc />
     public override ImmutableArray<string> FixableDiagnosticIds => ["AM011"];
 
+    /// <inheritdoc />
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
         await ProcessDiagnosticsAsync(
@@ -67,7 +69,7 @@ public class AM011_UnmappedRequiredPropertyCodeFixProvider : AutoMapperCodeFixPr
                     string defaultValue = TypeConversionHelper.GetDefaultValueForType(propertyType);
                     ctx.RegisterCodeFix(
                         CodeAction.Create(
-                            $"Map '{propertyName}' to default value ({defaultValue})",
+                            $"Scaffold default mapping for '{propertyName}' ({defaultValue})",
                             cancellationToken =>
                             {
                                 var newInvocation = CodeFixSyntaxHelper.CreateForMemberWithMapFrom(
@@ -81,7 +83,7 @@ public class AM011_UnmappedRequiredPropertyCodeFixProvider : AutoMapperCodeFixPr
                 // Option 2 (fallback): Ignore
                 ctx.RegisterCodeFix(
                     CodeAction.Create(
-                        $"Ignore required property '{propertyName}'",
+                        $"Ignore required property '{propertyName}' (manual review)",
                         cancellationToken =>
                         {
                             var newInvocation = CodeFixSyntaxHelper.CreateForMemberWithIgnore(invocation, propertyName);

--- a/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningCodeFixProvider.cs
@@ -140,7 +140,7 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
     {
         context.RegisterCodeFix(
             CodeAction.Create(
-                $"Ignore mapping for '{propertyName}'",
+                $"Ignore mapping for '{propertyName}' (manual review)",
                 cancellationToken => ReplaceWithIgnoreAsync(
                     context.Document,
                     root,

--- a/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
@@ -1,0 +1,239 @@
+using System.Collections.Immutable;
+using AutoMapperAnalyzer.Analyzers.ComplexMappings;
+using AutoMapperAnalyzer.Analyzers.Configuration;
+using AutoMapperAnalyzer.Analyzers.DataIntegrity;
+using AutoMapperAnalyzer.Analyzers.Performance;
+using AutoMapperAnalyzer.Analyzers.TypeSafety;
+using Microsoft.CodeAnalysis;
+
+namespace AutoMapperAnalyzer.Analyzers;
+
+/// <summary>
+///     Classifies how much review a generated code fix normally needs before a developer accepts it.
+/// </summary>
+public enum CodeFixTrustLevel
+{
+    /// <summary>
+    ///     The fix is behavior-preserving or removes configuration AutoMapper already handles by convention.
+    /// </summary>
+    SafeRewrite,
+
+    /// <summary>
+    ///     The fix is semantically reasonable, but a developer should verify the chosen mapping policy.
+    /// </summary>
+    LikelyRewrite,
+
+    /// <summary>
+    ///     The fix is compile-safe starter code or an explicit suppression that requires manual review.
+    /// </summary>
+    Scaffold
+}
+
+/// <summary>
+///     Rule metadata used by tests, documentation validation, and release hygiene checks.
+/// </summary>
+public sealed class RuleCatalogEntry
+{
+    /// <summary>
+    ///     Creates a rule catalog entry.
+    /// </summary>
+    public RuleCatalogEntry(
+        string ruleId,
+        string documentationAnchor,
+        string samplePath,
+        Type analyzerType,
+        Type codeFixProviderType,
+        CodeFixTrustLevel fixTrustLevel,
+        ImmutableArray<DiagnosticDescriptor> descriptors)
+    {
+        RuleId = ruleId;
+        DocumentationAnchor = documentationAnchor;
+        SamplePath = samplePath;
+        AnalyzerType = analyzerType;
+        CodeFixProviderType = codeFixProviderType;
+        FixTrustLevel = fixTrustLevel;
+        Descriptors = descriptors;
+    }
+
+    /// <summary>
+    ///     The public diagnostic rule ID.
+    /// </summary>
+    public string RuleId { get; }
+
+    /// <summary>
+    ///     Anchor in docs/DIAGNOSTIC_RULES.md for this rule.
+    /// </summary>
+    public string DocumentationAnchor { get; }
+
+    /// <summary>
+    ///     Relative path to a checked-in sample that exercises or documents the rule.
+    /// </summary>
+    public string SamplePath { get; }
+
+    /// <summary>
+    ///     Analyzer type that owns this rule.
+    /// </summary>
+    public Type AnalyzerType { get; }
+
+    /// <summary>
+    ///     Code fix provider type for this rule.
+    /// </summary>
+    public Type CodeFixProviderType { get; }
+
+    /// <summary>
+    ///     Trust classification for the rule's generated fixes.
+    /// </summary>
+    public CodeFixTrustLevel FixTrustLevel { get; }
+
+    /// <summary>
+    ///     Descriptors exposed under this public rule ID.
+    /// </summary>
+    public ImmutableArray<DiagnosticDescriptor> Descriptors { get; }
+}
+
+/// <summary>
+///     Central catalog for implemented AutoMapper analyzer rules.
+/// </summary>
+public static class RuleCatalog
+{
+    /// <summary>
+    ///     Current package version used by docs/package drift tests.
+    /// </summary>
+    public const string CurrentPackageVersion = "2.30.5";
+
+    /// <summary>
+    ///     Implemented rules, grouped by public diagnostic ID.
+    /// </summary>
+    public static ImmutableArray<RuleCatalogEntry> Rules { get; } =
+    [
+        new(
+            "AM001",
+            "### AM001: Property Type Mismatch",
+            "samples/AutoMapperAnalyzer.Samples/TypeSafety/TypeSafetyExamples.cs",
+            typeof(AM001_PropertyTypeMismatchAnalyzer),
+            typeof(AM001_PropertyTypeMismatchCodeFixProvider),
+            CodeFixTrustLevel.LikelyRewrite,
+            [AM001_PropertyTypeMismatchAnalyzer.PropertyTypeMismatchRule]),
+        new(
+            "AM002",
+            "### AM002: Nullable Compatibility Issue",
+            "samples/AutoMapperAnalyzer.Samples/TypeSafety/ManyNullableMismatches.cs",
+            typeof(AM002_NullableCompatibilityAnalyzer),
+            typeof(AM002_NullableCompatibilityCodeFixProvider),
+            CodeFixTrustLevel.Scaffold,
+            [
+                AM002_NullableCompatibilityAnalyzer.NullableToNonNullableRule,
+                AM002_NullableCompatibilityAnalyzer.NonNullableToNullableRule
+            ]),
+        new(
+            "AM003",
+            "### AM003: Collection Type Incompatibility",
+            "samples/AutoMapperAnalyzer.Samples/TypeSafety/TypeSafetyExamples.cs",
+            typeof(AM003_CollectionTypeIncompatibilityAnalyzer),
+            typeof(AM003_CollectionTypeIncompatibilityCodeFixProvider),
+            CodeFixTrustLevel.LikelyRewrite,
+            [AM003_CollectionTypeIncompatibilityAnalyzer.CollectionTypeIncompatibilityRule]),
+        new(
+            "AM004",
+            "### AM004: Missing Destination Property",
+            "samples/AutoMapperAnalyzer.Samples/MissingProperties/MissingPropertyExamples.cs",
+            typeof(AM004_MissingDestinationPropertyAnalyzer),
+            typeof(AM004_MissingDestinationPropertyCodeFixProvider),
+            CodeFixTrustLevel.LikelyRewrite,
+            [AM004_MissingDestinationPropertyAnalyzer.MissingDestinationPropertyRule]),
+        new(
+            "AM005",
+            "### AM005: Case Sensitivity Mismatch",
+            "samples/AutoMapperAnalyzer.Samples/MissingProperties/MissingPropertyExamples.cs",
+            typeof(AM005_CaseSensitivityMismatchAnalyzer),
+            typeof(AM005_CaseSensitivityMismatchCodeFixProvider),
+            CodeFixTrustLevel.LikelyRewrite,
+            [AM005_CaseSensitivityMismatchAnalyzer.CaseSensitivityMismatchRule]),
+        new(
+            "AM006",
+            "### AM006: Unmapped Destination Property",
+            "samples/AutoMapperAnalyzer.Samples/UnmappedDestination/UnmappedDestinationExamples.cs",
+            typeof(AM006_UnmappedDestinationPropertyAnalyzer),
+            typeof(AM006_UnmappedDestinationPropertyCodeFixProvider),
+            CodeFixTrustLevel.Scaffold,
+            [AM006_UnmappedDestinationPropertyAnalyzer.UnmappedDestinationPropertyRule]),
+        new(
+            "AM011",
+            "### AM011: Unmapped Required Property",
+            "samples/AutoMapperAnalyzer.Samples/DataIntegrity/ManyUnmappedRequiredProps.cs",
+            typeof(AM011_UnmappedRequiredPropertyAnalyzer),
+            typeof(AM011_UnmappedRequiredPropertyCodeFixProvider),
+            CodeFixTrustLevel.Scaffold,
+            [AM011_UnmappedRequiredPropertyAnalyzer.UnmappedRequiredPropertyRule]),
+        new(
+            "AM020",
+            "### AM020: Nested Object Mapping Issue",
+            "samples/AutoMapperAnalyzer.Samples/CodeFixDemo.cs",
+            typeof(AM020_NestedObjectMappingAnalyzer),
+            typeof(AM020_NestedObjectMappingCodeFixProvider),
+            CodeFixTrustLevel.SafeRewrite,
+            [AM020_NestedObjectMappingAnalyzer.NestedObjectMappingMissingRule]),
+        new(
+            "AM021",
+            "### AM021: Collection Element Mismatch",
+            "samples/AutoMapperAnalyzer.Samples/ComplexTypes/ComplexTypeMappingExamples.cs",
+            typeof(AM021_CollectionElementMismatchAnalyzer),
+            typeof(AM021_CollectionElementMismatchCodeFixProvider),
+            CodeFixTrustLevel.LikelyRewrite,
+            [AM021_CollectionElementMismatchAnalyzer.CollectionElementIncompatibilityRule]),
+        new(
+            "AM022",
+            "### AM022: Infinite Recursion Risk",
+            "samples/AutoMapperAnalyzer.Samples/ComplexTypes/ComplexTypeMappingExamples.cs",
+            typeof(AM022_InfiniteRecursionAnalyzer),
+            typeof(AM022_InfiniteRecursionCodeFixProvider),
+            CodeFixTrustLevel.LikelyRewrite,
+            [
+                AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule,
+                AM022_InfiniteRecursionAnalyzer.SelfReferencingTypeRule
+            ]),
+        new(
+            "AM030",
+            "### AM030: Custom Type Converter Issues",
+            "samples/AutoMapperAnalyzer.Samples/Conversions/TypeConverterExamples.cs",
+            typeof(AM030_CustomTypeConverterAnalyzer),
+            typeof(AM030_CustomTypeConverterCodeFixProvider),
+            CodeFixTrustLevel.LikelyRewrite,
+            [
+                AM030_CustomTypeConverterAnalyzer.InvalidConverterImplementationRule,
+                AM030_CustomTypeConverterAnalyzer.ConverterNullHandlingIssueRule,
+                AM030_CustomTypeConverterAnalyzer.UnusedTypeConverterRule
+            ]),
+        new(
+            "AM031",
+            "### AM031: Performance Warning",
+            "samples/AutoMapperAnalyzer.Samples/Performance/AM031_PerformanceExamples.cs",
+            typeof(AM031_PerformanceWarningAnalyzer),
+            typeof(AM031_PerformanceWarningCodeFixProvider),
+            CodeFixTrustLevel.Scaffold,
+            [
+                AM031_PerformanceWarningAnalyzer.ExpensiveOperationInMapFromRule,
+                AM031_PerformanceWarningAnalyzer.MultipleEnumerationRule,
+                AM031_PerformanceWarningAnalyzer.ExpensiveComputationRule,
+                AM031_PerformanceWarningAnalyzer.TaskResultSynchronousAccessRule,
+                AM031_PerformanceWarningAnalyzer.ComplexLinqOperationRule,
+                AM031_PerformanceWarningAnalyzer.NonDeterministicOperationRule
+            ]),
+        new(
+            "AM041",
+            "### AM041: Duplicate Mapping Registration",
+            "samples/AutoMapperAnalyzer.Samples/Configuration/AM041_DuplicateMappingExamples.cs",
+            typeof(AM041_DuplicateMappingAnalyzer),
+            typeof(AM041_DuplicateMappingCodeFixProvider),
+            CodeFixTrustLevel.SafeRewrite,
+            [AM041_DuplicateMappingAnalyzer.DuplicateMappingRule]),
+        new(
+            "AM050",
+            "### AM050: Redundant MapFrom Configuration",
+            "samples/AutoMapperAnalyzer.Samples/Configuration/AM050_RedundantMapFromExamples.cs",
+            typeof(AM050_RedundantMapFromAnalyzer),
+            typeof(AM050_RedundantMapFromCodeFixProvider),
+            CodeFixTrustLevel.SafeRewrite,
+            [AM050_RedundantMapFromAnalyzer.RedundantMapFromRule])
+    ];
+}

--- a/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM001_PropertyTypeMismatchCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM001_PropertyTypeMismatchCodeFixProvider.cs
@@ -88,7 +88,7 @@ public class AM001_PropertyTypeMismatchCodeFixProvider : AutoMapperCodeFixProvid
 
             context.RegisterCodeFix(
                 CodeAction.Create(
-                    $"Ignore property '{propertyNameValue}'",
+                    $"Ignore property '{propertyNameValue}' (manual review)",
                     cancellationToken =>
                         AddIgnoreAsync(context.Document, diagnostic, propertyNameValue, cancellationToken),
                     $"AM001_Ignore_{propertyNameValue}"),

--- a/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM002_NullableCompatibilityCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM002_NullableCompatibilityCodeFixProvider.cs
@@ -73,7 +73,7 @@ public class AM002_NullableCompatibilityCodeFixProvider : AutoMapperCodeFixProvi
             // Option 1: Map with default value
             context.RegisterCodeFix(
                 CodeAction.Create(
-                    $"Map '{propertyName}' with default value ({defaultValue})",
+                    $"Scaffold default mapping for '{propertyName}' ({defaultValue})",
                     cancellationToken => AddMapFromAsync(context.Document, invocation, propertyName!,
                         $"src.{propertyName} ?? {defaultValue}", cancellationToken),
                     $"AM002_DefaultValue_{propertyName}"),
@@ -82,7 +82,7 @@ public class AM002_NullableCompatibilityCodeFixProvider : AutoMapperCodeFixProvi
             // Option 2: Ignore property
             context.RegisterCodeFix(
                 CodeAction.Create(
-                    $"Ignore property '{propertyName}'",
+                    $"Ignore property '{propertyName}' (manual review)",
                     cancellationToken => AddIgnoreAsync(context.Document, invocation, propertyName!, cancellationToken),
                     $"AM002_Ignore_{propertyName}"),
                 diagnostic);

--- a/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM003_CollectionTypeIncompatibilityCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM003_CollectionTypeIncompatibilityCodeFixProvider.cs
@@ -130,7 +130,7 @@ public class AM003_CollectionTypeIncompatibilityCodeFixProvider : AutoMapperCode
 
                 context.RegisterCodeFix(
                     CodeAction.Create(
-                        $"Ignore property '{propertyName}'",
+                        $"Ignore property '{propertyName}' (manual review)",
                         ct => AddIgnoreAsync(context.Document, operationContext.Root, invocation, propertyName),
                         $"Ignore_{propertyName}"),
                     diagnostic);

--- a/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj
+++ b/tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj
@@ -8,6 +8,8 @@
         <IsTestProject>true</IsTestProject>
         <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
         <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+        <!-- Managed warning baseline for analyzer-test harness scaffolding and pinned AutoMapper 14 compatibility. -->
+        <NoWarn>$(NoWarn);NU1903;RS1035;RS1038;RS1041;RS2008;CA1305;CA1861</NoWarn>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="6.0.4">

--- a/tests/AutoMapperAnalyzer.Tests/Configuration/AM050_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Configuration/AM050_CodeFixTests.cs
@@ -118,7 +118,7 @@ public class AM050_CodeFixTests
             .VerifyFixAsync(testCode, expected, fixedCode);
     }
 
-    [Fact(Skip = "Test framework iteration count mismatch - fixer works correctly in practice")]
+    [Fact]
     public async Task Should_Remove_MultipleRedundantMappings()
     {
         const string testCode = """
@@ -186,7 +186,7 @@ public class AM050_CodeFixTests
         ];
 
         await CodeFixVerifier<AM050_RedundantMapFromAnalyzer, AM050_RedundantMapFromCodeFixProvider>
-            .VerifyFixWithIterationsAsync(testCode, diagnostics, fixedCode, iterations: 2);
+            .VerifyFixWithIterationsAsync(testCode, diagnostics, fixedCode, iterations: 3);
     }
 
     [Fact]
@@ -233,7 +233,7 @@ public class AM050_CodeFixTests
             .VerifyFixAsync(testCode, expected, fixedCode);
     }
 
-    [Fact(Skip = "Test framework iteration count mismatch - fixer works correctly in practice")]
+    [Fact]
     public async Task Should_Remove_RedundantMapping_NumericTypes()
     {
         const string testCode = """
@@ -294,11 +294,11 @@ public class AM050_CodeFixTests
         ];
 
         await CodeFixVerifier<AM050_RedundantMapFromAnalyzer, AM050_RedundantMapFromCodeFixProvider>
-            .VerifyFixWithIterationsAsync(testCode, diagnostics, fixedCode, iterations: 1);
+            .VerifyFixWithIterationsAsync(testCode, diagnostics, fixedCode, iterations: 2);
     }
 
-    [Fact(Skip = "Test invalid: Address to AddressDto are different types - mapping IS needed")]
-    public async Task Should_Remove_RedundantMapping_ComplexTypes()
+    [Fact]
+    public async Task Should_NotRemove_NonRedundantMapping_ComplexTypes()
     {
         const string testCode = """
                                 using AutoMapper;
@@ -320,31 +320,8 @@ public class AM050_CodeFixTests
                                 }
                                 """;
 
-        const string fixedCode = """
-                                 using AutoMapper;
-
-                                 public class Address { public string Street { get; set; } }
-                                 public class AddressDto { public string Street { get; set; } }
-
-                                 public class Source { public Address Address { get; set; } }
-                                 public class Destination { public AddressDto Address { get; set; } }
-
-                                 public class MyProfile : Profile
-                                 {
-                                     public MyProfile()
-                                     {
-                                         CreateMap<Address, AddressDto>();
-                                         CreateMap<Source, Destination>();
-                                     }
-                                 }
-                                 """;
-
-        DiagnosticResult expected = new DiagnosticResult(AM050_RedundantMapFromAnalyzer.RedundantMapFromRule)
-            .WithLocation(15, 45)
-            .WithArguments("Address");
-
-        await CodeFixVerifier<AM050_RedundantMapFromAnalyzer, AM050_RedundantMapFromCodeFixProvider>
-            .VerifyFixAsync(testCode, expected, fixedCode);
+        await AnalyzerVerifier<AM050_RedundantMapFromAnalyzer>
+            .VerifyAnalyzerAsync(testCode);
     }
 
     [Fact]
@@ -371,7 +348,7 @@ public class AM050_CodeFixTests
             .VerifyAnalyzerAsync(testCode);
     }
 
-    [Fact(Skip = "Test framework iteration count mismatch - fixer works correctly in practice")]
+    [Fact]
     public async Task Should_Remove_RedundantMapping_RecordTypes()
     {
         const string testCode = """
@@ -414,7 +391,7 @@ public class AM050_CodeFixTests
         ];
 
         await CodeFixVerifier<AM050_RedundantMapFromAnalyzer, AM050_RedundantMapFromCodeFixProvider>
-            .VerifyFixWithIterationsAsync(testCode, diagnostics, fixedCode, iterations: 1);
+            .VerifyFixWithIterationsAsync(testCode, diagnostics, fixedCode, iterations: 2);
     }
 
     [Fact]
@@ -483,7 +460,7 @@ public class AM050_CodeFixTests
             .VerifyAnalyzerAsync(testCode);
     }
 
-    [Fact(Skip = "Test framework iteration count mismatch - fixer works correctly in practice")]
+    [Fact]
     public async Task Should_Preserve_NonRedundantMappings_InChain()
     {
         const string testCode = """
@@ -550,7 +527,7 @@ public class AM050_CodeFixTests
         ];
 
         await CodeFixVerifier<AM050_RedundantMapFromAnalyzer, AM050_RedundantMapFromCodeFixProvider>
-            .VerifyFixWithIterationsAsync(testCode, diagnostics, fixedCode, iterations: 1);
+            .VerifyFixWithIterationsAsync(testCode, diagnostics, fixedCode, iterations: 2);
     }
 
     [Fact]

--- a/tests/AutoMapperAnalyzer.Tests/Infrastructure/CodeFixVerifier.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Infrastructure/CodeFixVerifier.cs
@@ -50,7 +50,7 @@ internal static class CodeFixVerifier<TAnalyzer, TCodeFix>
         AddAutoMapperReferences(test.FixedState);
 
         int remainingCount = remainingDiagnostics?.Length ?? 0;
-        int expectedCount = expectedDiagnostics?.Length ?? 1;
+        int expectedCount = expectedDiagnostics.Length;
         int defaultIterations = Math.Max(1, Math.Max(remainingCount + 1, expectedCount));
 
         int finalIterations = iterations ?? defaultIterations;

--- a/tests/AutoMapperAnalyzer.Tests/Performance/AM031_PerformanceWarningTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Performance/AM031_PerformanceWarningTests.cs
@@ -5,7 +5,7 @@ namespace AutoMapperAnalyzer.Tests.Performance;
 
 public class AM031_PerformanceWarningTests
 {
-    [Fact(Skip = "Test framework limitation: field type resolution - see docs/TEST_LIMITATIONS.md #1")]
+    [Fact]
     public async Task AM031_ShouldReportDiagnostic_WhenDatabaseCallInMapFrom()
     {
         const string testCode = """
@@ -52,7 +52,7 @@ public class AM031_PerformanceWarningTests
         await DiagnosticTestFramework
             .ForAnalyzer<AM031_PerformanceWarningAnalyzer>()
             .WithSource(testCode)
-            .ExpectDiagnostic(AM031_PerformanceWarningAnalyzer.ExpensiveOperationInMapFromRule, 35, 102,
+            .ExpectDiagnostic(AM031_PerformanceWarningAnalyzer.ExpensiveOperationInMapFromRule, 35, 72,
                 "OrderCount", "database query")
             .RunAsync();
     }
@@ -411,7 +411,7 @@ public class AM031_PerformanceWarningTests
             .RunAsync();
     }
 
-    [Fact(Skip = "Test framework limitation: field type resolution - see docs/TEST_LIMITATIONS.md #1")]
+    [Fact]
     public async Task AM031_ShouldReportDiagnostic_WhenTaskResultUsedInMapFrom()
     {
         const string testCode = """

--- a/tests/AutoMapperAnalyzer.Tests/Trust/RuleCatalogTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Trust/RuleCatalogTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using AutoMapperAnalyzer.Analyzers;
@@ -89,23 +90,20 @@ public partial class RuleCatalogTests
     {
         string repoRoot = GetRepositoryRoot();
 
-        var globalJson = XDocument.Load(Path.Combine(repoRoot, "src", "AutoMapperAnalyzer.Analyzers", "AutoMapperAnalyzer.Analyzers.csproj"));
+        var analyzerProject = XDocument.Load(Path.Combine(repoRoot, "src", "AutoMapperAnalyzer.Analyzers", "AutoMapperAnalyzer.Analyzers.csproj"));
         Assert.Equal(
             "README.md",
-            globalJson.Root?.Element("PropertyGroup")?.Element("PackageReadmeFile")?.Value);
+            analyzerProject.Root?.Element("PropertyGroup")?.Element("PackageReadmeFile")?.Value);
         Assert.Equal(
             "icon.png",
-            globalJson.Root?.Element("PropertyGroup")?.Element("PackageIcon")?.Value);
+            analyzerProject.Root?.Element("PropertyGroup")?.Element("PackageIcon")?.Value);
 
         string projectXml = File.ReadAllText(Path.Combine(repoRoot, "src", "AutoMapperAnalyzer.Analyzers", "AutoMapperAnalyzer.Analyzers.csproj"));
         Assert.Contains(@"PackagePath=""analyzers\dotnet\cs\", projectXml, StringComparison.Ordinal);
         Assert.Contains(@"PackagePath=""analyzers\dotnet\", projectXml, StringComparison.Ordinal);
 
-        string sdkVersion = XDocument.Parse(ConvertJsonToXml(File.ReadAllText(Path.Combine(repoRoot, "global.json"))))
-            .Root!
-            .Element("sdk")!
-            .Element("version")!
-            .Value;
+        using JsonDocument globalJson = JsonDocument.Parse(File.ReadAllText(Path.Combine(repoRoot, "global.json")));
+        string sdkVersion = globalJson.RootElement.GetProperty("sdk").GetProperty("version").GetString()!;
         Assert.Matches(@"^\d+\.\d+\.[1-9]\d{2}$", sdkVersion);
 
         string ci = File.ReadAllText(Path.Combine(repoRoot, ".github", "workflows", "ci.yml"));
@@ -143,15 +141,6 @@ public partial class RuleCatalogTests
         Assert.NotNull(directory);
         return directory!.FullName;
     }
-
-    private static string ConvertJsonToXml(string json)
-    {
-        string sdkVersion = GlobalJsonVersionRegex().Match(json).Groups["version"].Value;
-        return $"<root><sdk><version>{sdkVersion}</version></sdk></root>";
-    }
-
-    [GeneratedRegex(@"""version""\s*:\s*""(?<version>[^""]+)""")]
-    private static partial Regex GlobalJsonVersionRegex();
 
     [GeneratedRegex(@"AutoMapperAnalyzer\.Analyzers""\s+Version=""(?<version>\d+\.\d+\.\d+)""")]
     private static partial Regex AnalyzerPackageVersionRegex();

--- a/tests/AutoMapperAnalyzer.Tests/Trust/RuleCatalogTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Trust/RuleCatalogTests.cs
@@ -1,0 +1,161 @@
+using System.Collections.Immutable;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using AutoMapperAnalyzer.Analyzers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace AutoMapperAnalyzer.Tests.Trust;
+
+public partial class RuleCatalogTests
+{
+    [Fact]
+    public void RuleCatalog_ShouldMatchAnalyzerDescriptorsAndFixers()
+    {
+        Assert.Equal(14, RuleCatalog.Rules.Length);
+        Assert.Equal(RuleCatalog.Rules.Length, RuleCatalog.Rules.Select(rule => rule.RuleId).Distinct().Count());
+
+        foreach (RuleCatalogEntry rule in RuleCatalog.Rules)
+        {
+            Assert.All(rule.Descriptors, descriptor => Assert.Equal(rule.RuleId, descriptor.Id));
+            Assert.True(Enum.IsDefined(rule.FixTrustLevel));
+
+            var analyzer = Assert.IsAssignableFrom<DiagnosticAnalyzer>(
+                Activator.CreateInstance(rule.AnalyzerType));
+            ImmutableArray<DiagnosticDescriptor> supportedDiagnostics = analyzer.SupportedDiagnostics;
+
+            Assert.Equal(
+                rule.Descriptors.Select(ToDescriptorSnapshot),
+                supportedDiagnostics.Select(ToDescriptorSnapshot));
+
+            var fixer = Assert.IsAssignableFrom<CodeFixProvider>(
+                Activator.CreateInstance(rule.CodeFixProviderType));
+            Assert.Contains(rule.RuleId, fixer.FixableDiagnosticIds);
+        }
+    }
+
+    [Fact]
+    public void RuleCatalog_ShouldPointToDocumentedRulesAndSamples()
+    {
+        string repoRoot = GetRepositoryRoot();
+        string ruleDocs = File.ReadAllText(Path.Combine(repoRoot, "docs", "DIAGNOSTIC_RULES.md"));
+
+        foreach (RuleCatalogEntry rule in RuleCatalog.Rules)
+        {
+            Assert.Contains(rule.DocumentationAnchor, ruleDocs, StringComparison.Ordinal);
+            Assert.True(
+                File.Exists(Path.Combine(repoRoot, rule.SamplePath)),
+                $"{rule.RuleId} sample path does not exist: {rule.SamplePath}");
+        }
+    }
+
+    [Fact]
+    public void VersionReferences_ShouldStayAlignedWithPackageMetadata()
+    {
+        string repoRoot = GetRepositoryRoot();
+        string currentVersion = GetPackageVersion(repoRoot);
+        Assert.Equal(RuleCatalog.CurrentPackageVersion, currentVersion);
+
+        string readme = File.ReadAllText(Path.Combine(repoRoot, "README.md"));
+        Assert.Contains($"Latest Release: v{currentVersion}", readme, StringComparison.Ordinal);
+
+        string[] markdownFiles =
+        [
+            Path.Combine(repoRoot, "README.md"),
+            Path.Combine(repoRoot, "docs", "ARCHITECTURE.md"),
+            Path.Combine(repoRoot, "docs", "CI-CD.md"),
+            Path.Combine(repoRoot, "docs", "COMPATIBILITY.md"),
+            Path.Combine(repoRoot, "docs", "DIAGNOSTIC_RULES.md")
+        ];
+
+        foreach (string markdownFile in markdownFiles)
+        {
+            string content = File.ReadAllText(markdownFile);
+            foreach (Match match in AnalyzerPackageVersionRegex().Matches(content))
+            {
+                Assert.Equal(currentVersion, match.Groups["version"].Value);
+            }
+
+            foreach (Match match in DotnetAddPackageVersionRegex().Matches(content))
+            {
+                Assert.StartsWith(currentVersion, match.Groups["version"].Value, StringComparison.Ordinal);
+            }
+        }
+    }
+
+    [Fact]
+    public void ToolingAndPackageMetadata_ShouldHaveTrustChecks()
+    {
+        string repoRoot = GetRepositoryRoot();
+
+        var globalJson = XDocument.Load(Path.Combine(repoRoot, "src", "AutoMapperAnalyzer.Analyzers", "AutoMapperAnalyzer.Analyzers.csproj"));
+        Assert.Equal(
+            "README.md",
+            globalJson.Root?.Element("PropertyGroup")?.Element("PackageReadmeFile")?.Value);
+        Assert.Equal(
+            "icon.png",
+            globalJson.Root?.Element("PropertyGroup")?.Element("PackageIcon")?.Value);
+
+        string projectXml = File.ReadAllText(Path.Combine(repoRoot, "src", "AutoMapperAnalyzer.Analyzers", "AutoMapperAnalyzer.Analyzers.csproj"));
+        Assert.Contains(@"PackagePath=""analyzers\dotnet\cs\", projectXml, StringComparison.Ordinal);
+        Assert.Contains(@"PackagePath=""analyzers\dotnet\", projectXml, StringComparison.Ordinal);
+
+        string sdkVersion = XDocument.Parse(ConvertJsonToXml(File.ReadAllText(Path.Combine(repoRoot, "global.json"))))
+            .Root!
+            .Element("sdk")!
+            .Element("version")!
+            .Value;
+        Assert.Matches(@"^\d+\.\d+\.[1-9]\d{2}$", sdkVersion);
+
+        string ci = File.ReadAllText(Path.Combine(repoRoot, ".github", "workflows", "ci.yml"));
+        Assert.Contains("DOTNET_VERSION: '10.0.x'", ci, StringComparison.Ordinal);
+        Assert.Contains("-warnaserror", ci, StringComparison.Ordinal);
+        Assert.Contains("Verify package contents", ci, StringComparison.Ordinal);
+    }
+
+    private static (string Id, string Title, DiagnosticSeverity Severity, string Category) ToDescriptorSnapshot(
+        DiagnosticDescriptor descriptor)
+    {
+        return (descriptor.Id, descriptor.Title.ToString(), descriptor.DefaultSeverity, descriptor.Category);
+    }
+
+    private static string GetPackageVersion(string repoRoot)
+    {
+        XDocument project = XDocument.Load(
+            Path.Combine(repoRoot, "src", "AutoMapperAnalyzer.Analyzers", "AutoMapperAnalyzer.Analyzers.csproj"));
+        XElement propertyGroup = project.Root!.Element("PropertyGroup")!;
+        return string.Join(
+            ".",
+            propertyGroup.Element("MajorVersion")!.Value,
+            propertyGroup.Element("MinorVersion")!.Value,
+            propertyGroup.Element("PatchVersion")!.Value);
+    }
+
+    private static string GetRepositoryRoot()
+    {
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+        while (directory != null && !File.Exists(Path.Combine(directory.FullName, "automapper-analyser.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        Assert.NotNull(directory);
+        return directory!.FullName;
+    }
+
+    private static string ConvertJsonToXml(string json)
+    {
+        string sdkVersion = GlobalJsonVersionRegex().Match(json).Groups["version"].Value;
+        return $"<root><sdk><version>{sdkVersion}</version></sdk></root>";
+    }
+
+    [GeneratedRegex(@"""version""\s*:\s*""(?<version>[^""]+)""")]
+    private static partial Regex GlobalJsonVersionRegex();
+
+    [GeneratedRegex(@"AutoMapperAnalyzer\.Analyzers""\s+Version=""(?<version>\d+\.\d+\.\d+)""")]
+    private static partial Regex AnalyzerPackageVersionRegex();
+
+    [GeneratedRegex(@"dotnet add package AutoMapperAnalyzer\.Analyzers --version (?<version>\d+\.\d+\.\d+(?:-[\w.-]+)?)")]
+    private static partial Regex DotnetAddPackageVersionRegex();
+}

--- a/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM001_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM001_CodeFixTests.cs
@@ -147,7 +147,7 @@ public class AM001_CodeFixTests
                 expectedFixedCode);
     }
 
-    [Fact(Skip = "Analyzer limitation: expression tree patterns - see docs/TEST_LIMITATIONS.md #3")]
+    [Fact]
     public async Task AM001_ShouldFixStringToIntConversionWithParse()
     {
         const string testCode = """
@@ -245,9 +245,9 @@ public class AM001_CodeFixTests
         Assert.Collection(
             actions.Select(action => action.Title),
             title => Assert.Equal("Map 'Age' with conversion", title),
-            title => Assert.Equal("Ignore property 'Age'", title),
+            title => Assert.Equal("Ignore property 'Age' (manual review)", title),
             title => Assert.Equal("Map 'Score' with conversion", title),
-            title => Assert.Equal("Ignore property 'Score'", title));
+            title => Assert.Equal("Ignore property 'Score' (manual review)", title));
 
         string updatedCode = await ApplyActionAsync(actions[0], document);
         Assert.Contains(".ForMember(dest => dest.Age, opt => opt.MapFrom(src => src.Age.ToString()))", updatedCode,


### PR DESCRIPTION
## Summary

- add a checked-in rule catalog for analyzer descriptors, fixers, docs anchors, samples, and fixer trust levels
- add trust validation tests for catalog, docs, package version, SDK, CI, and package contents
- align .NET 10 tooling/CI docs and fix stale package version references
- remove skipped-test debt by converting AM001, AM031, and AM050 cases into active tests or valid negative coverage
- clarify manual-review/scaffold code action titles for ignore/default-style fixes

## Review notes

- Supersedes draft PR #77, which stayed draft because the connector mark-ready mutation errored.
- Self-review tightened the new trust test to parse `global.json` with `System.Text.Json` instead of an XML workaround.

## Validation

- `/opt/homebrew/bin/dotnet test automapper-analyser.sln --no-restore --framework net10.0 --verbosity minimal`
- `/opt/homebrew/bin/dotnet build src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj --no-restore --configuration Release -warnaserror`
- `/opt/homebrew/bin/dotnet build tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --configuration Release -warnaserror`
- sample project build verified with expected analyzer demonstration warnings
- package content check verified analyzer DLL, README, and icon
- `git diff --check`