### PR TITLE
Add descriptor-level sample diagnostics coverage

### DIFF
--- a/samples/AutoMapperAnalyzer.Samples/AnalyzerOnly/AM030_InvalidConverterImplementation.cs
+++ b/samples/AutoMapperAnalyzer.Samples/AnalyzerOnly/AM030_InvalidConverterImplementation.cs
@@ -1,0 +1,10 @@
+using AutoMapper;
+
+namespace AutoMapperAnalyzer.Samples.AnalyzerOnly;
+
+/// <summary>
+///     Analyzer-only sample for the AM030 invalid converter implementation descriptor.
+/// </summary>
+public class MissingConvertStringToDateTimeConverter : ITypeConverter<string, DateTime>
+{
+}

--- a/samples/AutoMapperAnalyzer.Samples/AutoMapperAnalyzer.Samples.csproj
+++ b/samples/AutoMapperAnalyzer.Samples/AutoMapperAnalyzer.Samples.csproj
@@ -15,6 +15,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <Compile Remove="AnalyzerOnly/**/*.cs"/>
+    </ItemGroup>
+
+    <ItemGroup>
         <ProjectReference Include="../../src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
     </ItemGroup>
 

--- a/samples/AutoMapperAnalyzer.Samples/Conversions/TypeConverterExamples.cs
+++ b/samples/AutoMapperAnalyzer.Samples/Conversions/TypeConverterExamples.cs
@@ -258,13 +258,6 @@ public class NullUnsafeStringToGuidConverter : ITypeConverter<string?, Guid>
 }
 
 /// <summary>
-///     Example of an invalid converter implementation (for AM030 descriptor coverage)
-/// </summary>
-public abstract class MissingConvertStringToDateTimeConverter : ITypeConverter<string, DateTime>
-{
-}
-
-/// <summary>
 ///     Example of a proper scalar ITypeConverter implementation
 /// </summary>
 public class SafeStringToDateTimeScalarConverter : ITypeConverter<string?, DateTime>

--- a/samples/AutoMapperAnalyzer.Samples/Conversions/TypeConverterExamples.cs
+++ b/samples/AutoMapperAnalyzer.Samples/Conversions/TypeConverterExamples.cs
@@ -258,6 +258,13 @@ public class NullUnsafeStringToGuidConverter : ITypeConverter<string?, Guid>
 }
 
 /// <summary>
+///     Example of an invalid converter implementation (for AM030 descriptor coverage)
+/// </summary>
+public abstract class MissingConvertStringToDateTimeConverter : ITypeConverter<string, DateTime>
+{
+}
+
+/// <summary>
 ///     Example of a proper scalar ITypeConverter implementation
 /// </summary>
 public class SafeStringToDateTimeScalarConverter : ITypeConverter<string?, DateTime>

--- a/samples/AutoMapperAnalyzer.Samples/Performance/AM031_PerformanceExamples.cs
+++ b/samples/AutoMapperAnalyzer.Samples/Performance/AM031_PerformanceExamples.cs
@@ -110,6 +110,28 @@ public class AM031_PerformanceExamples
     }
 
     /// <summary>
+    ///     AM031: Expensive Computation in MapFrom
+    ///     This should trigger the expensive-computation AM031 descriptor
+    /// </summary>
+    public void ExpensiveComputationExample()
+    {
+        var config = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<PrimeCandidate, PrimeCandidateDto>()
+                // ❌ AM031: Prime checking does too much work inside mapping
+                .ForMember(dest => dest.IsPrime,
+                    opt => opt.MapFrom(src =>
+                        src.Number > 1 && !Enumerable.Range(2, (int)Math.Sqrt(src.Number) - 1)
+                            .Any(i => src.Number % i == 0)));
+        });
+
+        var mapper = config.CreateMapper();
+        var candidate = new PrimeCandidate { Id = 1, Number = 97 };
+
+        Console.WriteLine("❌ Expensive computation detected - calculate before mapping!");
+    }
+
+    /// <summary>
     ///     AM031: Task.Result Synchronous Access
     ///     This should trigger AM031 diagnostic
     /// </summary>
@@ -310,6 +332,18 @@ public class SalesReportDto
 {
     public int Id { get; set; }
     public double TotalWithAverage { get; set; }
+}
+
+public class PrimeCandidate
+{
+    public int Id { get; set; }
+    public int Number { get; set; }
+}
+
+public class PrimeCandidateDto
+{
+    public int Id { get; set; }
+    public bool IsPrime { get; set; }
 }
 
 public class AsyncDataService

--- a/samples/AutoMapperAnalyzer.Samples/TypeSafety/ManyNullableMismatches.cs
+++ b/samples/AutoMapperAnalyzer.Samples/TypeSafety/ManyNullableMismatches.cs
@@ -32,13 +32,25 @@ public class ManyNullableMismatches
         public string Notes { get; set; }
     }
 
+    public class NonNullableSource
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    public class NullableDest
+    {
+        public string? Name { get; set; }
+    }
+
     public class Profile : AutoMapper.Profile
     {
         public Profile()
         {
             // This should generate 10 AM002 diagnostics
             CreateMap<Source, Dest>();
+
+            // This should generate the AM002 non-nullable-to-nullable descriptor variant.
+            CreateMap<NonNullableSource, NullableDest>();
         }
     }
 }
-

--- a/tests/AutoMapperAnalyzer.Tests/Snapshots/sample-diagnostics.json
+++ b/tests/AutoMapperAnalyzer.Tests/Snapshots/sample-diagnostics.json
@@ -126,7 +126,7 @@
     "title": "Nullable to non-nullable mapping issue in AutoMapper configuration",
     "category": "AutoMapper.NullSafety",
     "filePath": "samples/AutoMapperAnalyzer.Samples/TypeSafety/ManyNullableMismatches.cs",
-    "line": 40,
+    "line": 50,
     "column": 13,
     "message": "Property 'Age' has nullable compatibility issue: Source.Age (int?) can be null but Dest.Age (int) is non-nullable",
     "fixTrustLevel": "Scaffold"
@@ -137,7 +137,7 @@
     "title": "Nullable to non-nullable mapping issue in AutoMapper configuration",
     "category": "AutoMapper.NullSafety",
     "filePath": "samples/AutoMapperAnalyzer.Samples/TypeSafety/ManyNullableMismatches.cs",
-    "line": 40,
+    "line": 50,
     "column": 13,
     "message": "Property 'Category' has nullable compatibility issue: Source.Category (string?) can be null but Dest.Category (string) is non-nullable",
     "fixTrustLevel": "Scaffold"
@@ -148,7 +148,7 @@
     "title": "Nullable to non-nullable mapping issue in AutoMapper configuration",
     "category": "AutoMapper.NullSafety",
     "filePath": "samples/AutoMapperAnalyzer.Samples/TypeSafety/ManyNullableMismatches.cs",
-    "line": 40,
+    "line": 50,
     "column": 13,
     "message": "Property 'Created' has nullable compatibility issue: Source.Created (System.DateTime?) can be null but Dest.Created (System.DateTime) is non-nullable",
     "fixTrustLevel": "Scaffold"
@@ -159,7 +159,7 @@
     "title": "Nullable to non-nullable mapping issue in AutoMapper configuration",
     "category": "AutoMapper.NullSafety",
     "filePath": "samples/AutoMapperAnalyzer.Samples/TypeSafety/ManyNullableMismatches.cs",
-    "line": 40,
+    "line": 50,
     "column": 13,
     "message": "Property 'Description' has nullable compatibility issue: Source.Description (string?) can be null but Dest.Description (string) is non-nullable",
     "fixTrustLevel": "Scaffold"
@@ -170,7 +170,7 @@
     "title": "Nullable to non-nullable mapping issue in AutoMapper configuration",
     "category": "AutoMapper.NullSafety",
     "filePath": "samples/AutoMapperAnalyzer.Samples/TypeSafety/ManyNullableMismatches.cs",
-    "line": 40,
+    "line": 50,
     "column": 13,
     "message": "Property 'Id' has nullable compatibility issue: Source.Id (System.Guid?) can be null but Dest.Id (System.Guid) is non-nullable",
     "fixTrustLevel": "Scaffold"
@@ -181,7 +181,7 @@
     "title": "Nullable to non-nullable mapping issue in AutoMapper configuration",
     "category": "AutoMapper.NullSafety",
     "filePath": "samples/AutoMapperAnalyzer.Samples/TypeSafety/ManyNullableMismatches.cs",
-    "line": 40,
+    "line": 50,
     "column": 13,
     "message": "Property 'IsActive' has nullable compatibility issue: Source.IsActive (bool?) can be null but Dest.IsActive (bool) is non-nullable",
     "fixTrustLevel": "Scaffold"
@@ -192,7 +192,7 @@
     "title": "Nullable to non-nullable mapping issue in AutoMapper configuration",
     "category": "AutoMapper.NullSafety",
     "filePath": "samples/AutoMapperAnalyzer.Samples/TypeSafety/ManyNullableMismatches.cs",
-    "line": 40,
+    "line": 50,
     "column": 13,
     "message": "Property 'Name' has nullable compatibility issue: Source.Name (string?) can be null but Dest.Name (string) is non-nullable",
     "fixTrustLevel": "Scaffold"
@@ -203,7 +203,7 @@
     "title": "Nullable to non-nullable mapping issue in AutoMapper configuration",
     "category": "AutoMapper.NullSafety",
     "filePath": "samples/AutoMapperAnalyzer.Samples/TypeSafety/ManyNullableMismatches.cs",
-    "line": 40,
+    "line": 50,
     "column": 13,
     "message": "Property 'Notes' has nullable compatibility issue: Source.Notes (string?) can be null but Dest.Notes (string) is non-nullable",
     "fixTrustLevel": "Scaffold"
@@ -214,7 +214,7 @@
     "title": "Nullable to non-nullable mapping issue in AutoMapper configuration",
     "category": "AutoMapper.NullSafety",
     "filePath": "samples/AutoMapperAnalyzer.Samples/TypeSafety/ManyNullableMismatches.cs",
-    "line": 40,
+    "line": 50,
     "column": 13,
     "message": "Property 'Tags' has nullable compatibility issue: Source.Tags (string?) can be null but Dest.Tags (string) is non-nullable",
     "fixTrustLevel": "Scaffold"
@@ -225,9 +225,20 @@
     "title": "Nullable to non-nullable mapping issue in AutoMapper configuration",
     "category": "AutoMapper.NullSafety",
     "filePath": "samples/AutoMapperAnalyzer.Samples/TypeSafety/ManyNullableMismatches.cs",
-    "line": 40,
+    "line": 50,
     "column": 13,
     "message": "Property 'Title' has nullable compatibility issue: Source.Title (string?) can be null but Dest.Title (string) is non-nullable",
+    "fixTrustLevel": "Scaffold"
+  },
+  {
+    "ruleId": "AM002",
+    "severity": "Warning",
+    "title": "Non-nullable to nullable mapping in AutoMapper configuration",
+    "category": "AutoMapper.NullSafety",
+    "filePath": "samples/AutoMapperAnalyzer.Samples/TypeSafety/ManyNullableMismatches.cs",
+    "line": 53,
+    "column": 13,
+    "message": "Property 'Name' mapping: NonNullableSource.Name (string) is non-nullable but NullableDest.Name (string?) is nullable",
     "fixTrustLevel": "Scaffold"
   },
   {
@@ -871,6 +882,17 @@
   {
     "ruleId": "AM030",
     "severity": "Warning",
+    "title": "Invalid type converter implementation",
+    "category": "AutoMapper.Converters",
+    "filePath": "samples/AutoMapperAnalyzer.Samples/Conversions/TypeConverterExamples.cs",
+    "line": 263,
+    "column": 23,
+    "message": "Type converter 'MissingConvertStringToDateTimeConverter' does not properly implement ITypeConverter<String, DateTime> or has invalid Convert method signature",
+    "fixTrustLevel": "LikelyRewrite"
+  },
+  {
+    "ruleId": "AM030",
+    "severity": "Warning",
     "title": "Type converter is defined but not used in mapping configuration",
     "category": "AutoMapper.Converters",
     "filePath": "samples/AutoMapperAnalyzer.Samples/SampleUsage.cs",
@@ -926,10 +948,21 @@
   {
     "ruleId": "AM031",
     "severity": "Warning",
+    "title": "Expensive computation in mapping expression",
+    "category": "AutoMapper.Performance",
+    "filePath": "samples/AutoMapperAnalyzer.Samples/Performance/AM031_PerformanceExamples.cs",
+    "line": 123,
+    "column": 40,
+    "message": "Property 'IsPrime' mapping contains expensive computation that may impact performance. Consider computing before mapping.",
+    "fixTrustLevel": "Scaffold"
+  },
+  {
+    "ruleId": "AM031",
+    "severity": "Warning",
     "title": "Synchronous access of async operation in mapping",
     "category": "AutoMapper.Performance",
     "filePath": "samples/AutoMapperAnalyzer.Samples/Performance/AM031_PerformanceExamples.cs",
-    "line": 125,
+    "line": 147,
     "column": 40,
     "message": "Property 'ExternalData' mapping uses Task.Result which can cause deadlocks. Perform async operations before mapping.",
     "fixTrustLevel": "Scaffold"
@@ -940,7 +973,7 @@
     "title": "Non-deterministic operation in mapping",
     "category": "AutoMapper.Performance",
     "filePath": "samples/AutoMapperAnalyzer.Samples/Performance/AM031_PerformanceExamples.cs",
-    "line": 150,
+    "line": 172,
     "column": 40,
     "message": "Property 'DaysOld' mapping uses DateTime.Now which produces non-deterministic results. Consider computing before mapping for testability.",
     "fixTrustLevel": "Scaffold"
@@ -951,7 +984,7 @@
     "title": "Expensive operation in mapping expression",
     "category": "AutoMapper.Performance",
     "filePath": "samples/AutoMapperAnalyzer.Samples/Performance/AM031_PerformanceExamples.cs",
-    "line": 175,
+    "line": 197,
     "column": 40,
     "message": "Property 'TypeName' mapping contains reflection operation that should be performed before mapping to avoid performance issues",
     "fixTrustLevel": "Scaffold"
@@ -962,7 +995,7 @@
     "title": "Expensive operation in mapping expression",
     "category": "AutoMapper.Performance",
     "filePath": "samples/AutoMapperAnalyzer.Samples/Performance/AM031_PerformanceExamples.cs",
-    "line": 197,
+    "line": 219,
     "column": 40,
     "message": "Property 'ApiResponse' mapping contains HTTP request that should be performed before mapping to avoid performance issues",
     "fixTrustLevel": "Scaffold"
@@ -973,7 +1006,7 @@
     "title": "Complex LINQ operation in mapping",
     "category": "AutoMapper.Performance",
     "filePath": "samples/AutoMapperAnalyzer.Samples/Performance/AM031_PerformanceExamples.cs",
-    "line": 217,
+    "line": 239,
     "column": 40,
     "message": "Property 'FilteredCount' mapping contains complex LINQ operation that may impact performance. Consider simplifying or computing before mapping.",
     "fixTrustLevel": "Scaffold"

--- a/tests/AutoMapperAnalyzer.Tests/Snapshots/sample-diagnostics.json
+++ b/tests/AutoMapperAnalyzer.Tests/Snapshots/sample-diagnostics.json
@@ -871,23 +871,34 @@
   {
     "ruleId": "AM030",
     "severity": "Warning",
+    "title": "Invalid type converter implementation",
+    "category": "AutoMapper.Converters",
+    "filePath": "samples/AutoMapperAnalyzer.Samples/AnalyzerOnly/AM030_InvalidConverterImplementation.cs",
+    "line": 8,
+    "column": 14,
+    "message": "Type converter 'MissingConvertStringToDateTimeConverter' does not properly implement ITypeConverter<String, DateTime> or has invalid Convert method signature",
+    "fixTrustLevel": "LikelyRewrite"
+  },
+  {
+    "ruleId": "AM030",
+    "severity": "Warning",
+    "title": "Type converter is defined but not used in mapping configuration",
+    "category": "AutoMapper.Converters",
+    "filePath": "samples/AutoMapperAnalyzer.Samples/AnalyzerOnly/AM030_InvalidConverterImplementation.cs",
+    "line": 8,
+    "column": 14,
+    "message": "Type converter 'MissingConvertStringToDateTimeConverter' is defined but not used in any CreateMap configuration",
+    "fixTrustLevel": "LikelyRewrite"
+  },
+  {
+    "ruleId": "AM030",
+    "severity": "Warning",
     "title": "Type converter may not handle null values properly",
     "category": "AutoMapper.Converters",
     "filePath": "samples/AutoMapperAnalyzer.Samples/Conversions/TypeConverterExamples.cs",
     "line": 253,
     "column": 17,
     "message": "Converter for 'NullUnsafeStringToGuidConverter' may not handle null values. Source type 'String' is nullable but converter doesn't check for null.",
-    "fixTrustLevel": "LikelyRewrite"
-  },
-  {
-    "ruleId": "AM030",
-    "severity": "Warning",
-    "title": "Invalid type converter implementation",
-    "category": "AutoMapper.Converters",
-    "filePath": "samples/AutoMapperAnalyzer.Samples/Conversions/TypeConverterExamples.cs",
-    "line": 263,
-    "column": 23,
-    "message": "Type converter 'MissingConvertStringToDateTimeConverter' does not properly implement ITypeConverter<String, DateTime> or has invalid Convert method signature",
     "fixTrustLevel": "LikelyRewrite"
   },
   {

--- a/tests/AutoMapperAnalyzer.Tests/Trust/RuleCatalogTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Trust/RuleCatalogTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Globalization;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -78,6 +79,47 @@ public partial class RuleCatalogTests
                 File.Exists(Path.Combine(repoRoot, rule.SamplePath)),
                 $"{rule.RuleId} sample path does not exist: {rule.SamplePath}");
         }
+    }
+
+    [Fact]
+    public void SampleDiagnosticsSnapshot_ShouldCoverEveryCatalogDescriptor()
+    {
+        string repoRoot = GetRepositoryRoot();
+        string snapshotPath = Path.Combine(
+            repoRoot,
+            "tests",
+            "AutoMapperAnalyzer.Tests",
+            "Snapshots",
+            "sample-diagnostics.json");
+
+        using JsonDocument snapshot = JsonDocument.Parse(File.ReadAllText(snapshotPath));
+        HashSet<DescriptorCoverageSnapshot> coveredDescriptors = snapshot.RootElement
+            .EnumerateArray()
+            .Select(element => new DescriptorCoverageSnapshot(
+                element.GetProperty("ruleId").GetString()!,
+                element.GetProperty("title").GetString()!,
+                element.GetProperty("category").GetString()!))
+            .ToHashSet();
+
+        DescriptorCoverageSnapshot[] missingDescriptors = RuleCatalog.Rules
+            .SelectMany(rule => rule.Descriptors.Select(descriptor => new DescriptorCoverageSnapshot(
+                rule.RuleId,
+                descriptor.Title.ToString(CultureInfo.InvariantCulture),
+                descriptor.Category)))
+            .Distinct()
+            .Where(descriptor => !coveredDescriptors.Contains(descriptor))
+            .OrderBy(descriptor => descriptor.RuleId, StringComparer.Ordinal)
+            .ThenBy(descriptor => descriptor.Title, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.True(
+            missingDescriptors.Length == 0,
+            "Sample diagnostics snapshot must cover every shipped catalog descriptor. Missing:"
+            + Environment.NewLine
+            + string.Join(
+                Environment.NewLine,
+                missingDescriptors.Select(descriptor =>
+                    $"{descriptor.RuleId} | {descriptor.Category} | {descriptor.Title}")));
     }
 
     [Fact]
@@ -231,4 +273,9 @@ public partial class RuleCatalogTests
         string Description,
         string HelpLinkUri,
         string CustomTags);
+
+    private sealed record DescriptorCoverageSnapshot(
+        string RuleId,
+        string Title,
+        string Category);
 }

--- a/tools/AnalyzerVerifier/Program.cs
+++ b/tools/AnalyzerVerifier/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.Build.Locator;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.MSBuild;
+using Microsoft.CodeAnalysis.Text;
 
 namespace AnalyzerVerifier;
 
@@ -152,6 +153,8 @@ internal static class Program
 
         using var workspace = MSBuildWorkspace.Create();
         Project project = await workspace.OpenProjectAsync(projectPath);
+        project = await AddAnalyzerOnlySampleDocumentsAsync(project, repoRoot);
+
         Compilation? compilation = await project.GetCompilationAsync();
         if (compilation == null)
         {
@@ -183,6 +186,40 @@ internal static class Program
             .ThenBy(snapshot => snapshot.Column)
             .ThenBy(snapshot => snapshot.Message, StringComparer.Ordinal)
             .ToArray();
+    }
+
+    private static async Task<Project> AddAnalyzerOnlySampleDocumentsAsync(Project project, string repoRoot)
+    {
+        string analyzerOnlyDirectory = Path.Combine(
+            repoRoot,
+            "samples",
+            "AutoMapperAnalyzer.Samples",
+            "AnalyzerOnly");
+
+        if (!Directory.Exists(analyzerOnlyDirectory))
+        {
+            return project;
+        }
+
+        foreach (string filePath in Directory
+                     .EnumerateFiles(analyzerOnlyDirectory, "*.cs", SearchOption.AllDirectories)
+                     .OrderBy(filePath => Path.GetRelativePath(repoRoot, filePath), StringComparer.Ordinal))
+        {
+            string source = await File.ReadAllTextAsync(filePath, Utf8NoBom);
+            string relativeDirectory = Path.GetRelativePath(analyzerOnlyDirectory, Path.GetDirectoryName(filePath)!);
+            string[] folders = relativeDirectory == "."
+                ? ["AnalyzerOnly"]
+                : ["AnalyzerOnly", .. relativeDirectory.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)];
+
+            project = project.AddDocument(
+                    Path.GetFileName(filePath),
+                    SourceText.From(source, Encoding.UTF8),
+                    folders,
+                    filePath)
+                .Project;
+        }
+
+        return project;
     }
 
     private static DiagnosticSnapshot ToSnapshot(


### PR DESCRIPTION
## Summary

- add a trust test that requires the sample diagnostics snapshot to cover every shipped `RuleCatalog` descriptor by rule ID, title, and category
- add sample cases for the previously uncovered descriptor variants: AM002 non-nullable-to-nullable, AM030 invalid converter implementation, and AM031 expensive computation
- regenerate `sample-diagnostics.json` so the new descriptor variants are intentional review artifacts

## Validation

- `/opt/homebrew/bin/dotnet run --project tools/AnalyzerVerifier/AnalyzerVerifier.csproj -- --check-catalog --check-snapshots`
- `/opt/homebrew/bin/dotnet build src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj --no-restore --configuration Release -warnaserror`
- `/opt/homebrew/bin/dotnet build tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --configuration Release -warnaserror`
- `/opt/homebrew/bin/dotnet test automapper-analyser.sln --no-restore --framework net10.0 --verbosity minimal`
- `tools/package-smoke.sh net8.0`
- `tools/package-smoke.sh net9.0`
- `tools/package-smoke.sh net10.0`
- negative check: temporarily removed the AM002 non-nullable-to-nullable snapshot entry and confirmed `SampleDiagnosticsSnapshot_ShouldCoverEveryCatalogDescriptor` fails with the missing descriptor listed