### PR TITLE
Harden AM031 source collection cache handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [2.30.6] - 2026-04-26
+
 ### Added
 
 - Added generated rule catalog and sample diagnostics snapshot checks to prevent descriptor, fixer, docs, and sample-output drift.
@@ -10,7 +12,18 @@
 
 ### Changed
 
+- Hardened AM031 multiple-enumeration analysis so diagnostics normalize source-rooted collection paths regardless of lambda parameter name.
+- Hardened AM031 cache fixes so nested source collections are rewritten safely and captured collections no longer offer invalid source-parameter cache actions.
+- Added AM031 Task-valued source-property `.Result` detection.
+- Updated AM031 rule docs and analyzer health status to document cache-fixer safety boundaries.
 - Consolidated PR validation into the main CI workflow and removed the duplicate simple-build workflow.
+
+### Validation
+
+- Targeted AM031 analyzer and code fix tests.
+- Full `net10.0` solution test suite.
+- Rule catalog and sample diagnostics snapshot checks.
+- `git diff --check`.
 
 ## [2.30.5] - 2026-04-26
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet Version](https://img.shields.io/nuget/v/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=NuGet)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=Downloads)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/georgepwall1991/automapper-analyser/ci.yml?style=flat-square&logo=github&label=Build)](https://github.com/georgepwall1991/automapper-analyser/actions)
-[![Tests](https://img.shields.io/badge/Tests-656%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
+[![Tests](https://img.shields.io/badge/Tests-662%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
 [![.NET](https://img.shields.io/badge/.NET-4.8+%20%7C%206.0+%20%7C%208.0+%20%7C%209.0+%20%7C%2010.0+-512BD4?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 [![Coverage](https://img.shields.io/codecov/c/github/georgepwall1991/automapper-analyser?style=flat-square&logo=codecov&label=Coverage)](https://codecov.io/gh/georgepwall1991/automapper-analyser)
@@ -14,25 +14,26 @@ prevention*
 
 ---
 
-## 🎉 Latest Release: v2.30.5
+## 🎉 Latest Release: v2.30.6
 
-**AM030 Type-Based Converter Usage Precision — quieter unused-converter diagnostics**
+**AM031 Source Collection Cache Precision — safer performance diagnostics and fixes**
 
 ✅ **Highlights**
 
-- Hardened AM030 so `ConvertUsing(typeof(MyConverter))` counts as real converter usage.
-- Added AM030 coverage for type-based AutoMapper converter configuration.
-- Preserved existing generic and instance `ConvertUsing` handling.
-- Documented the supported AM030 converter usage forms.
+- Normalized AM031 multiple-enumeration collection paths for any source lambda parameter name.
+- Made AM031 cache rewrites handle nested source collections such as `src.Customer.Orders`.
+- Suppressed unsafe cache actions for captured collections that cannot be rewritten from the source parameter.
+- Added AM031 detection for `Task.Result` on Task-valued source properties.
 
 🧪 **Validation**
 
 - Full solution test validation passed on `net10.0`.
-- Full test suite passed with `656` passing and `0` skipped.
-- Release validation covered targeted AM030 regressions plus full solution verification before tagging.
+- Full test suite passed with `662` passing and `0` skipped.
+- Release validation covered targeted AM031 regressions plus full solution verification before tagging.
 
 ### Recent Releases
 
+- **v2.30.5**: AM030 type-based converter usage precision for `ConvertUsing(typeof(...))`.
 - **v2.30.4**: AM022 mapped recursion precision with unrelated-cycle false-positive reductions.
 - **v2.30.3**: AM011 ForPath required-member boundary with explicit configuration coverage.
 - **v2.30.2**: AM003 assignable collection boundary suppression with targeted regression coverage.
@@ -173,7 +174,7 @@ Install-Package AutoMapperAnalyzer.Analyzers
 ### Project File (For CI/CD)
 
 ```xml
-<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.5">
+<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.6">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 </PackageReference>
@@ -367,6 +368,7 @@ This isn't just another analyzer—it's built for **enterprise-grade reliability
 
 ### Recently Completed ✅
 
+- **v2.30.6**: AM031 source collection cache precision with nested source paths and Task-property `.Result` coverage
 - **v2.30.5**: AM030 type-based converter usage precision for `ConvertUsing(typeof(...))`
 - **v2.30.4**: AM022 mapped recursion precision with unrelated-cycle false-positive reductions
 - **v2.30.3**: AM011 ForPath required-member boundary with explicit-configuration regression coverage

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -42,7 +42,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | AM021 | Collection element type incompatibility | Complex Mappings | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | Good AM003 boundary discipline and recent fixer hardening for case-only names plus queue/stack output shape; keep expanding dictionary/custom-collection and reverse-map edge cases. |
 | AM022 | Infinite recursion risk | Complex Mappings | Warning | 3 | 3 | 4 | 4 | 4 | 4 | Medium | Useful and well tested for common cycles, MaxDepth, Ignore, collections, and reverse-map boundaries, but recursion analysis remains heuristic and may miss or over-report nuanced graph/DTO ownership patterns. |
 | AM030 | Custom type converter issues | Custom Conversions | Error/Warning/Info | 3 | 4 | 3 | 4 | 4 | 3 | Low | The rule now recognizes generic, instance, and type-based `ConvertUsing` converter references, reducing unused-converter false positives. Remaining opportunities are mostly external DI/service-provider wiring and the mixed-concept shape of the single AM030 ID. |
-| AM031 | Performance warnings in mapping expressions | Performance | Warning/Info | 3 | 3 | 3 | 4 | 3 | 4 | Medium | Broad, valuable smell detector with many targeted tests, but expensive-operation heuristics are inherently fuzzy and fixer safety varies by issue type; docs should make the supported boundaries more explicit. |
+| AM031 | Performance warnings in mapping expressions | Performance | Warning/Info | 4 | 4 | 4 | 5 | 4 | 4 | Low | Multiple-enumeration diagnostics now normalize source-rooted collection paths, cache rewrites support nested source collections, unsafe captured-collection cache actions are suppressed, and Task-valued source-property `.Result` is covered. Remaining risk is mainly the intentionally heuristic nature of broad performance smells. |
 | AM041 | Duplicate mapping registration | Configuration | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | Strong compilation-wide registry, reverse-map awareness, cross-profile duplicate detection, and removal fixer coverage. Remaining risk is mainly nuanced intentional override/configuration ordering cases. |
 | AM050 | Redundant MapFrom configuration | Configuration | Info | 3 | 3 | 4 | 3 | 3 | 2 | Low | Safe cleanup rule with idempotent fixer tests, but product importance is low and analyzer semantics are intentionally narrow around direct same-name property lambdas. |
 
@@ -53,12 +53,12 @@ The next improvement batch should focus on rules where user impact and health ga
 | Priority | Rules | Work |
 | --- | --- | --- |
 | High | None | No implemented rule currently looks both high-impact and unhealthy enough to demand urgent intervention before normal release work. |
-| Medium | AM022, AM031 | Expand recursion/performance boundary tests, and make manual-vs-executable fixer expectations explicit in docs. |
-| Low | AM001, AM002, AM003, AM004, AM005, AM006, AM011, AM020, AM021, AM030, AM041, AM050 | Treat as currently acceptable, reference examples, or low-impact cleanup rules. Improve opportunistically when touching nearby code. |
+| Medium | AM022 | Expand recursion boundary tests around nuanced graph and DTO ownership patterns. |
+| Low | AM001, AM002, AM003, AM004, AM005, AM006, AM011, AM020, AM021, AM030, AM031, AM041, AM050 | Treat as currently acceptable, reference examples, or low-impact cleanup rules. Improve opportunistically when touching nearby code. |
 
 ## Cross-Cutting Findings
 
-- Public docs are useful but drift from implementation in several places. `AM004` and `AM005` remain obvious severity/wording mismatches between descriptors, README tables, and rule docs, while `AM002` has been realigned with its shipped Error/Info descriptors.
+- Public docs are useful but drift from implementation in several places. `AM004` and `AM005` remain obvious severity/wording mismatches between descriptors, README tables, and rule docs, while `AM002` and the AM031 performance-fixer boundaries have been realigned with shipped behavior.
 - Analyzer ownership is a real strength. The conflict tests and shared helpers make `AM001`/`AM002`/`AM003`/`AM020`/`AM021` boundaries much healthier than a file-count audit would suggest.
 - The project now has a checked-in `RuleCatalog` health contract plus generated `docs/RULE_CATALOG.md` and sample diagnostic snapshots that tie rule IDs to descriptors, fixers, docs anchors, sample paths, and fixer trust levels.
 - Diagnostic placement is generally at the mapping invocation or mapping lambda, not always the precise property/member token. That is acceptable for many AutoMapper configuration rules, but high-volume rules benefit from tighter placement when practical.
@@ -70,6 +70,6 @@ Architecture-style coverage currently comes from analyzer/fixer tests, conflict 
 
 Current local verification:
 
-- `/opt/homebrew/bin/dotnet test automapper-analyser.sln --no-restore --framework net10.0` passed: 656 passed, 0 skipped, 0 failed.
+- `/opt/homebrew/bin/dotnet test automapper-analyser.sln --no-restore --framework net10.0` passed: 662 passed, 0 skipped, 0 failed.
 - The trust-first pass removed active skipped tests, added drift validation, and moved intentional analyzer-test warnings into an explicit test-project warning baseline.
 - `/opt/homebrew/bin/dotnet --list-runtimes` shows only .NET 10 runtimes in this local environment, so broader runtime verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/docs/ANALYZER_REVIEW_TRACKER.md
+++ b/docs/ANALYZER_REVIEW_TRACKER.md
@@ -30,7 +30,8 @@ Tracks analyzer-by-analyzer improvement passes focused on false positives, contr
 | Fixer Hardening Follow-up | AM001, AM005, AM006, AM011, AM021 | main | v2.30.0 | Fixed AM021 queue/stack conversion codegen, restored stable per-diagnostic AM001 action registration, required unique-best fuzzy matches for AM006/AM011, removed AM005 rename actions, and added targeted regression coverage for action ordering and ambiguous suggestions. |
 | AM022 (2nd pass) | Complex Mappings | main | v2.30.4 | Restricted recursion diagnostics to convention-mapped recursive member paths, suppressed ignored indirect recursive members, and added regression coverage for unrelated self-referencing/circular graphs. |
 | AM030 (2nd pass) | Complex Mappings | main | v2.30.5 | Counted type-based `ConvertUsing(typeof(MyConverter))` converter configuration as usage, reducing unused-converter false positives with targeted regression coverage. |
-| Trust-first hardening | All | main | TBD | Added `RuleCatalog` drift checks, aligned package/docs/SDK workflow metadata, clarified fixer trust levels in code action titles/docs, and converted skipped AM001/AM031/AM050 tests into active coverage. |
+| AM031 (2nd pass) | Performance | main | v2.30.6 | Normalized multiple-enumeration source collection paths, made nested source cache rewrites executable, suppressed unsafe captured-collection cache actions, and detected Task-valued source-property `.Result`. |
+| Trust-first hardening | All | main | v2.30.6 | Added `RuleCatalog` drift checks, aligned package/docs/SDK workflow metadata, clarified fixer trust levels in code action titles/docs, and converted skipped AM001/AM031/AM050 tests into active coverage. |
 
 ## In Progress
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -724,7 +724,7 @@ dotnet pack --configuration Release
 
 # Test package locally
 cd test-install/NetCoreTest
-dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.5-local
+dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.6-local
 ```
 
 ---
@@ -908,4 +908,4 @@ dotnet build
 
 **Last Updated**: 2025-11-19
 **Maintainer**: George Wall
-**Version**: 2.30.5
+**Version**: 2.30.6

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -57,7 +57,7 @@ The AutoMapper Roslyn Analyzer project uses GitHub Actions for continuous integr
 
 **Triggers:**
 
-- Semantic version tags such as `v2.30.5`
+- Semantic version tags such as `v2.30.6`
 
 **Features:**
 
@@ -112,8 +112,8 @@ The AutoMapper Roslyn Analyzer project uses GitHub Actions for continuous integr
 ### Package Versioning
 
 - **Format**: Major.Minor.Patch (SemVer)
-- **Current**: 2.30.5
-- **Pre-release**: 2.30.5-preview, 2.30.5-beta
+- **Current**: 2.30.6
+- **Pre-release**: 2.30.6-preview, 2.30.6-beta
 
 ## 🔧 Configuration
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -43,7 +43,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.5">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -67,7 +67,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.5">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -86,7 +86,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="14.0.0" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.5">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -218,7 +218,7 @@ public class Destination
 
 2. **Verify Package Installation**
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.5">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.6">
      <PrivateAssets>all</PrivateAssets>
      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -280,4 +280,4 @@ This guide ensures smooth installation and usage across all supported .NET frame
 ---
 
 **Last Updated**: November 19, 2025
-**Version**: 2.30.5
+**Version**: 2.30.6

--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -1036,9 +1036,19 @@ CreateMap<Source, Destination>()
 // ⚠️ AM031: Task.Result can cause deadlocks
 ```
 
+Task-valued source members are also detected:
+
+```csharp
+CreateMap<Source, Destination>()
+    .ForMember(dest => dest.Data, opt => opt.MapFrom(src =>
+        src.DataTask.Result));  // ❌ Synchronous access
+```
+
 #### Solutions
 
 **Code Fix 1: Cache Collection Enumeration**
+
+AM031 offers this executable rewrite only when the repeated enumeration is rooted in the source mapping parameter, including nested source paths such as `src.Customer.Orders`. Captured fields, injected services, and other closure values keep manual-review actions because the analyzer cannot safely decide where those values should be cached.
 
 ```csharp
 CreateMap<Source, Destination>()
@@ -1068,7 +1078,7 @@ If source/destination have compatible same-name members, AM031 can remove the re
 - ✅ Reflection operations
 - ✅ Multiple collection enumerations
 - ✅ `DateTime.Now`, `Random`, `Guid.NewGuid()`
-- ✅ `Task.Result`, `Task.Wait()`
+- ✅ `Task.Result`, `Task.Wait()`, including Task-valued source properties
 - ✅ Complex LINQ (SelectMany chains)
 
 #### Configuration
@@ -1262,7 +1272,7 @@ using System.Diagnostics.CodeAnalysis;
 
 1. **Check package reference**:
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.5">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.6">
        <PrivateAssets>all</PrivateAssets>
        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>

--- a/docs/RULE_CATALOG.md
+++ b/docs/RULE_CATALOG.md
@@ -2,7 +2,7 @@
 
 This file is generated from `RuleCatalog`.
 
-Package version: `2.30.5`
+Package version: `2.30.6`
 
 | Rule ID | Descriptor Title | Severity | Category | Analyzer | Code Fix | Trust | Sample | Docs |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,4 +1,4 @@
-## Release 2.30.5
+## Release 2.30.6
 
 ### New Rules
 

--- a/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
+++ b/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
@@ -17,7 +17,7 @@
         <!-- Fallback for local builds: 2.0.YYYYMMDD-local -->
         <MajorVersion>2</MajorVersion>
         <MinorVersion>30</MinorVersion>
-        <PatchVersion>5</PatchVersion>
+        <PatchVersion>6</PatchVersion>
         <BuildNumber Condition="'$(BuildNumber)' == ''"
         >$([System.DateTime]::Now.ToString('yyyyMMdd'))
         </BuildNumber
@@ -32,18 +32,20 @@
         <RepositoryUrl>https://github.com/georgepwall1991/automapper-analyser</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <PackageReleaseNotes>Version 2.30.5 - AM030 type-based converter usage precision
+        <PackageReleaseNotes>Version 2.30.6 - AM031 source collection cache precision
 
             Changed:
-            - Hardened AM030 unused-converter analysis so ConvertUsing(typeof(MyConverter)) counts as real converter usage
-            - Added AM030 regression coverage for type-based ConvertUsing configuration
-            - Updated AM030 rule docs and analyzer health status to document supported converter usage forms
+            - Hardened AM031 multiple-enumeration diagnostics so source collection paths are normalized independently of lambda parameter names
+            - Hardened AM031 cache fixes so nested source collections rewrite safely and captured collections do not offer invalid cache actions
+            - Added AM031 Task-valued source-property Result detection
+            - Added generated trust artifacts, package smoke tests, and consolidated PR validation from the unreleased mainline
 
             Validation:
-            - Full solution test suite passing on net10.0 with targeted AM030 regression coverage
+            - Full solution test suite passing on net10.0 with targeted AM031 regression coverage
+            - Rule catalog and sample diagnostics snapshot checks passing
             - git diff --check clean
 
-            Previous Release: v2.30.4 - AM022 mapped recursion precision
+            Previous Release: v2.30.5 - AM030 type-based converter usage precision
         </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>

--- a/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningAnalyzer.cs
@@ -291,6 +291,7 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
         // Track collection accesses for multiple enumeration detection
         var collectionAccesses = new Dictionary<string, int>();
         var reportedIssueTypes = new HashSet<string>(StringComparer.Ordinal);
+        string? sourceParameterName = GetSourceParameterName(lambda);
 
         foreach (InvocationExpressionSyntax? invocation in invocations)
         {
@@ -382,7 +383,7 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
             // Track LINQ operations for multiple enumeration detection
             if (IsLinqEnumerationMethod(methodName))
             {
-                TrackCollectionAccess(invocation, collectionAccesses);
+                TrackCollectionAccess(invocation, collectionAccesses, sourceParameterName);
             }
 
             // Check for complex LINQ operations
@@ -414,6 +415,22 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
             {
                 string containingType = propertySymbol.ContainingType?.ToDisplayString() ?? "";
                 string propertyName_member = propertySymbol.Name;
+
+                if (IsTaskResultMemberAccess(memberAccess, propertySymbol))
+                {
+                    if (memberAccess.Expression is InvocationExpressionSyntax &&
+                        reportedIssueTypes.Contains(ExpensiveOperationIssueType))
+                    {
+                        continue;
+                    }
+
+                    if (reportedIssueTypes.Add(TaskResultIssueType))
+                    {
+                        ReportTaskResultDiagnostic(context, lambda, propertyName);
+                    }
+
+                    continue;
+                }
 
                 // Check for DateTime.Now, DateTime.UtcNow
                 if (containingType == "System.DateTime" &&
@@ -637,12 +654,26 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
             if (symbolInfo.Symbol is IPropertySymbol propertySymbol &&
                 propertySymbol.Name == "Result")
             {
-                string containingType = propertySymbol.ContainingType?.ToDisplayString() ?? "";
-                return containingType.StartsWith("System.Threading.Tasks.Task", StringComparison.Ordinal);
+                return IsTaskType(propertySymbol.ContainingType);
             }
         }
 
         return false;
+    }
+
+    private static bool IsTaskResultMemberAccess(
+        MemberAccessExpressionSyntax memberAccess,
+        IPropertySymbol propertySymbol)
+    {
+        return memberAccess.Name.Identifier.Text == "Result" &&
+               propertySymbol.Name == "Result" &&
+               IsTaskType(propertySymbol.ContainingType);
+    }
+
+    private static bool IsTaskType(ITypeSymbol? typeSymbol)
+    {
+        string containingType = typeSymbol?.ToDisplayString() ?? "";
+        return containingType.StartsWith("System.Threading.Tasks.Task", StringComparison.Ordinal);
     }
 
     private static bool IsTaskWaitAccess(string containingType, string methodName)
@@ -683,18 +714,19 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
             "First" or "FirstOrDefault" or "Last" or "LastOrDefault" or "Any" or "All";
     }
 
-    private static void TrackCollectionAccess(InvocationExpressionSyntax invocation,
-        Dictionary<string, int> collectionAccesses)
+    private static void TrackCollectionAccess(
+        InvocationExpressionSyntax invocation,
+        Dictionary<string, int> collectionAccesses,
+        string? sourceParameterName)
     {
         if (invocation.Expression is MemberAccessExpressionSyntax memberAccess)
         {
-            string collectionName = memberAccess.Expression.ToString();
-
-            // Normalize collection name (remove src. prefix if present)
-            if (collectionName.StartsWith("src."))
-            {
-                collectionName = collectionName.Substring(4);
-            }
+            string collectionName = TryGetSourceCollectionPath(
+                memberAccess.Expression,
+                sourceParameterName,
+                out string sourceCollectionPath)
+                ? sourceCollectionPath
+                : memberAccess.Expression.ToString();
 
             if (!collectionAccesses.ContainsKey(collectionName))
             {
@@ -703,6 +735,47 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
 
             collectionAccesses[collectionName]++;
         }
+    }
+
+    private static string? GetSourceParameterName(LambdaExpressionSyntax lambda)
+    {
+        return lambda switch
+        {
+            SimpleLambdaExpressionSyntax simpleLambda => simpleLambda.Parameter.Identifier.ValueText,
+            ParenthesizedLambdaExpressionSyntax parenthesizedLambda when parenthesizedLambda.ParameterList.Parameters.Count > 0
+                => parenthesizedLambda.ParameterList.Parameters[0].Identifier.ValueText,
+            _ => null
+        };
+    }
+
+    private static bool TryGetSourceCollectionPath(
+        ExpressionSyntax expression,
+        string? sourceParameterName,
+        out string collectionPath)
+    {
+        collectionPath = string.Empty;
+        if (string.IsNullOrEmpty(sourceParameterName))
+        {
+            return false;
+        }
+
+        var pathSegments = new Stack<string>();
+        ExpressionSyntax currentExpression = expression;
+        while (currentExpression is MemberAccessExpressionSyntax memberAccess)
+        {
+            pathSegments.Push(memberAccess.Name.Identifier.ValueText);
+            currentExpression = memberAccess.Expression;
+        }
+
+        if (currentExpression is not IdentifierNameSyntax identifier ||
+            !string.Equals(identifier.Identifier.ValueText, sourceParameterName, StringComparison.Ordinal) ||
+            pathSegments.Count == 0)
+        {
+            return false;
+        }
+
+        collectionPath = string.Join(".", pathSegments);
+        return true;
     }
 
     private static bool IsComplexLinqOperation(string methodName, InvocationExpressionSyntax invocation)

--- a/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningCodeFixProvider.cs
@@ -100,7 +100,7 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
                 .Select(GetCollectionName)
                 .FirstOrDefault(name => !string.IsNullOrEmpty(name));
 
-            if (!string.IsNullOrEmpty(collectionName))
+            if (!string.IsNullOrEmpty(collectionName) && CanCacheCollectionPath(lambda, collectionName!))
             {
                 RegisterMultipleEnumerationFix(context, operationContext.Root, lambda, propertyName!, collectionName!,
                     relatedDiagnostics);
@@ -265,6 +265,11 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
             return Task.FromResult(document);
         }
 
+        if (!IsValidMemberPath(collectionName))
+        {
+            return Task.FromResult(document);
+        }
+
         string cachedVariableName = CreateUniqueCacheVariableName(lambda, collectionName);
         ExpressionSyntax cachedCollectionExpression = CreateCachedCollectionExpression(parameterName!, collectionName);
         ExpressionSyntax updatedLambdaExpression =
@@ -314,7 +319,7 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
         return lambda switch
         {
             SimpleLambdaExpressionSyntax simpleLambda => simpleLambda.Parameter.Identifier.ValueText,
-            ParenthesizedLambdaExpressionSyntax parenthesizedLambda when parenthesizedLambda.ParameterList.Parameters.Count == 1
+            ParenthesizedLambdaExpressionSyntax parenthesizedLambda when parenthesizedLambda.ParameterList.Parameters.Count > 0
                 => parenthesizedLambda.ParameterList.Parameters[0].Identifier.ValueText,
             _ => null
         };
@@ -322,9 +327,12 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
 
     private static string CreateUniqueCacheVariableName(LambdaExpressionSyntax lambda, string collectionName)
     {
-        string baseName = string.IsNullOrEmpty(collectionName)
+        string collectionSegment = collectionName
+            .Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries)
+            .LastOrDefault() ?? string.Empty;
+        string baseName = string.IsNullOrEmpty(collectionSegment) || !SyntaxFacts.IsValidIdentifier(collectionSegment)
             ? "cachedCollection"
-            : char.ToLowerInvariant(collectionName[0]) + collectionName.Substring(1) + "Cache";
+            : char.ToLowerInvariant(collectionSegment[0]) + collectionSegment.Substring(1) + "Cache";
         var usedNames = lambda.DescendantTokens()
             .Where(token => token.IsKind(SyntaxKind.IdentifierToken))
             .Select(token => token.ValueText)
@@ -348,10 +356,7 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
 
     private static ExpressionSyntax CreateCachedCollectionExpression(string parameterName, string collectionName)
     {
-        MemberAccessExpressionSyntax sourceCollection = SyntaxFactory.MemberAccessExpression(
-            SyntaxKind.SimpleMemberAccessExpression,
-            SyntaxFactory.IdentifierName(parameterName),
-            SyntaxFactory.IdentifierName(collectionName));
+        ExpressionSyntax sourceCollection = CreateSourceCollectionExpression(parameterName, collectionName);
 
         return SyntaxFactory.InvocationExpression(
             SyntaxFactory.MemberAccessExpression(
@@ -359,6 +364,21 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
                 sourceCollection,
                 SyntaxFactory.IdentifierName("ToList")),
             SyntaxFactory.ArgumentList());
+    }
+
+    private static ExpressionSyntax CreateSourceCollectionExpression(string parameterName, string collectionName)
+    {
+        ExpressionSyntax sourceCollection = SyntaxFactory.IdentifierName(parameterName);
+
+        foreach (string segment in collectionName.Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries))
+        {
+            sourceCollection = SyntaxFactory.MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                sourceCollection,
+                SyntaxFactory.IdentifierName(segment));
+        }
+
+        return sourceCollection;
     }
 
     private static ExpressionSyntax ReplaceCollectionReferences(
@@ -371,6 +391,30 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
             expression.DescendantNodesAndSelf().OfType<MemberAccessExpressionSyntax>()
                 .Where(memberAccess => IsTargetCollectionAccess(memberAccess, parameterName, collectionName)),
             (originalNode, _) => SyntaxFactory.IdentifierName(cachedVariableName).WithTriviaFrom(originalNode));
+    }
+
+    private static bool CanCacheCollectionPath(LambdaExpressionSyntax lambda, string collectionName)
+    {
+        if (lambda.Body is not ExpressionSyntax lambdaExpression || !IsValidMemberPath(collectionName))
+        {
+            return false;
+        }
+
+        string? parameterName = GetLambdaParameterName(lambda);
+        if (string.IsNullOrEmpty(parameterName))
+        {
+            return false;
+        }
+
+        return lambdaExpression.DescendantNodesAndSelf()
+            .OfType<MemberAccessExpressionSyntax>()
+            .Any(memberAccess => IsTargetCollectionAccess(memberAccess, parameterName!, collectionName));
+    }
+
+    private static bool IsValidMemberPath(string collectionName)
+    {
+        string[] segments = collectionName.Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries);
+        return segments.Length > 0 && segments.All(SyntaxFacts.IsValidIdentifier);
     }
 
     private string? GetPropertyName(Diagnostic diagnostic)
@@ -411,9 +455,34 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
         string parameterName,
         string collectionName)
     {
-        return memberAccess.Expression is IdentifierNameSyntax identifier &&
-               string.Equals(identifier.Identifier.ValueText, parameterName, StringComparison.Ordinal) &&
-               string.Equals(memberAccess.Name.Identifier.ValueText, collectionName, StringComparison.Ordinal);
+        return TryGetSourceCollectionPath(memberAccess, parameterName, out string collectionPath) &&
+               string.Equals(collectionPath, collectionName, StringComparison.Ordinal);
+    }
+
+    private static bool TryGetSourceCollectionPath(
+        ExpressionSyntax expression,
+        string parameterName,
+        out string collectionPath)
+    {
+        collectionPath = string.Empty;
+
+        var pathSegments = new Stack<string>();
+        ExpressionSyntax currentExpression = expression;
+        while (currentExpression is MemberAccessExpressionSyntax memberAccess)
+        {
+            pathSegments.Push(memberAccess.Name.Identifier.ValueText);
+            currentExpression = memberAccess.Expression;
+        }
+
+        if (currentExpression is not IdentifierNameSyntax identifier ||
+            !string.Equals(identifier.Identifier.ValueText, parameterName, StringComparison.Ordinal) ||
+            pathSegments.Count == 0)
+        {
+            return false;
+        }
+
+        collectionPath = string.Join(".", pathSegments);
+        return true;
     }
 
     private static CompilationUnitSyntax AddUsingIfMissing(CompilationUnitSyntax root, string namespaceName)

--- a/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
@@ -99,7 +99,7 @@ public static class RuleCatalog
     /// <summary>
     ///     Current package version used by docs/package drift tests.
     /// </summary>
-    public const string CurrentPackageVersion = "2.30.5";
+    public const string CurrentPackageVersion = "2.30.6";
 
     /// <summary>
     ///     Implemented rules, grouped by public diagnostic ID.

--- a/tests/AutoMapperAnalyzer.Tests/Performance/AM031_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Performance/AM031_CodeFixTests.cs
@@ -304,6 +304,115 @@ public class AM031_CodeFixTests
     }
 
     [Fact]
+    public async Task AM031_ShouldRegisterAndApplyCachingFix_ForNestedSourceCollectionPath()
+    {
+        const string source = """
+                              using AutoMapper;
+                              using System.Collections.Generic;
+                              using System.Linq;
+
+                              namespace TestNamespace
+                              {
+                                  public class Customer
+                                  {
+                                      public List<int> Orders { get; set; } = new();
+                                  }
+
+                                  public class Source
+                                  {
+                                      public Customer Customer { get; set; } = new();
+                                  }
+
+                                  public class Destination
+                                  {
+                                      public int Total { get; set; }
+                                  }
+
+                                  public class TestProfile : Profile
+                                  {
+                                      public TestProfile()
+                                      {
+                                          CreateMap<Source, Destination>()
+                                              .ForMember(dest => dest.Total, opt => opt.MapFrom(src => src.Customer.Orders.Sum() + src.Customer.Orders.Average()));
+                                      }
+                                  }
+                              }
+                              """;
+
+        Document document = CreateDocument(source);
+        Diagnostic diagnostic = await CreateDiagnosticAtSourceLambdaAsync(
+            document,
+            AM031_PerformanceWarningAnalyzer.MultipleEnumerationRule,
+            "MultipleEnumeration",
+            "Total",
+            "Customer.Orders",
+            "Total",
+            "Customer.Orders");
+
+        List<CodeAction> actions = await RegisterActionsAsync(document, diagnostic);
+        CodeAction cacheAction = Assert.Single(
+            actions,
+            action => action.Title.Contains("Cache 'Customer.Orders' with ToList() for 'Total'",
+                StringComparison.Ordinal));
+
+        string updatedCode = await ApplyActionAsync(cacheAction, document);
+        Assert.Contains("ordersCache", updatedCode, StringComparison.Ordinal);
+        Assert.Contains("src.Customer.Orders.ToList()", updatedCode, StringComparison.Ordinal);
+        Assert.Contains("ordersCache.Sum()", updatedCode, StringComparison.Ordinal);
+        Assert.Contains("ordersCache.Average()", updatedCode, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task AM031_ShouldNotRegisterCachingFix_ForCapturedCollection()
+    {
+        const string source = """
+                              using AutoMapper;
+                              using System.Collections.Generic;
+                              using System.Linq;
+
+                              namespace TestNamespace
+                              {
+                                  public class Source
+                                  {
+                                      public int Id { get; set; }
+                                  }
+
+                                  public class Destination
+                                  {
+                                      public int Total { get; set; }
+                                  }
+
+                                  public class TestProfile : Profile
+                                  {
+                                      private readonly List<int> _numbers = new();
+
+                                      public TestProfile()
+                                      {
+                                          CreateMap<Source, Destination>()
+                                              .ForMember(dest => dest.Total, opt => opt.MapFrom(src => _numbers.Sum() + _numbers.Average()));
+                                      }
+                                  }
+                              }
+                              """;
+
+        Document document = CreateDocument(source);
+        Diagnostic diagnostic = await CreateDiagnosticAtSourceLambdaAsync(
+            document,
+            AM031_PerformanceWarningAnalyzer.MultipleEnumerationRule,
+            "MultipleEnumeration",
+            "Total",
+            "_numbers",
+            "Total",
+            "_numbers");
+
+        List<CodeAction> actions = await RegisterActionsAsync(document, diagnostic);
+
+        Assert.DoesNotContain(actions,
+            action => action.Title.Contains("Cache '_numbers' with ToList()", StringComparison.Ordinal));
+        Assert.Contains(actions, action => action.Title.Contains("Ignore mapping for 'Total'", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task AM031_ShouldNotRegisterFixes_ForNonAm031DiagnosticId()
     {
         const string source = """

--- a/tests/AutoMapperAnalyzer.Tests/Performance/AM031_PerformanceWarningTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Performance/AM031_PerformanceWarningTests.cs
@@ -181,6 +181,45 @@ public class AM031_PerformanceWarningTests
     }
 
     [Fact]
+    public async Task AM031_ShouldReportDiagnostic_WhenMultipleEnumerationUsesNonSrcParameterName()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Collections.Generic;
+                                using System.Linq;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public List<int> Numbers { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public int Total { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>()
+                                                .ForMember(dest => dest.Total, opt => opt.MapFrom(source => source.Numbers.Sum() + source.Numbers.Average()));
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM031_PerformanceWarningAnalyzer>()
+            .WithSource(testCode)
+            .ExpectDiagnostic(AM031_PerformanceWarningAnalyzer.MultipleEnumerationRule, 22, 67,
+                "Total", "Numbers")
+            .RunAsync();
+    }
+
+    [Fact]
     public async Task AM031_ShouldReportDiagnostic_WhenReflectionInMapFrom()
     {
         const string testCode = """
@@ -453,6 +492,44 @@ public class AM031_PerformanceWarningTests
             .ForAnalyzer<AM031_PerformanceWarningAnalyzer>()
             .WithSource(testCode)
             .ExpectDiagnostic(AM031_PerformanceWarningAnalyzer.TaskResultSynchronousAccessRule, 29, 66,
+                "Data")
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM031_ShouldReportDiagnostic_WhenTaskResultUsedOnTaskPropertyInMapFrom()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Threading.Tasks;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public Task<string> DataTask { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public string Data { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>()
+                                                .ForMember(dest => dest.Data, opt => opt.MapFrom(src => src.DataTask.Result));
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM031_PerformanceWarningAnalyzer>()
+            .WithSource(testCode)
+            .ExpectDiagnostic(AM031_PerformanceWarningAnalyzer.TaskResultSynchronousAccessRule, 21, 66,
                 "Data")
             .RunAsync();
     }


### PR DESCRIPTION
## Summary
- harden AM031 multiple-enumeration collection path normalization for non-`src` lambda parameters
- make AM031 cache rewrites support nested source collection paths and suppress unsafe captured-collection cache actions
- add Task-valued source-property `.Result` detection and update docs/analyzer-health for v2.30.6

## Impact
This improves AM031 precision and fixer safety while preserving conservative behavior for ambiguous or closure-based collection sources.

## Validation
- local `net10.0` solution test run passed with 662 tests
- `tools/AnalyzerVerifier` catalog and sample snapshot checks passed
- `git diff --check` clean
- local .NET 8/9 verification is blocked by missing runtimes; CI package smoke covers `net8.0`, `net9.0`, and `net10.0` consumer projects