### PR TITLE
Harden AM050 redundant MapFrom detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+## [2.30.10] - 2026-04-26
+
+### Changed
+
+- Hardened AM050 redundant `MapFrom` detection so cleanup diagnostics require proven source/destination property type compatibility.
+- Added AM050 regression coverage for string-based `ForMember` destination members with compatible and incompatible same-name properties.
+- Preserved property-specific AM050 code action titles for string-based destination members.
+- Updated analyzer health status to record the AM050 false-positive hardening pass.
+
+### Validation
+
+- Targeted AM050 analyzer and code fix tests.
+- Full `net10.0` solution test suite.
+- `git diff --check`.
+
 ## [2.30.9] - 2026-04-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet Version](https://img.shields.io/nuget/v/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=NuGet)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=Downloads)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/georgepwall1991/automapper-analyser/ci.yml?style=flat-square&logo=github&label=Build)](https://github.com/georgepwall1991/automapper-analyser/actions)
-[![Tests](https://img.shields.io/badge/Tests-672%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
+[![Tests](https://img.shields.io/badge/Tests-675%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
 [![.NET](https://img.shields.io/badge/.NET-4.8+%20%7C%206.0+%20%7C%208.0+%20%7C%209.0+%20%7C%2010.0+-512BD4?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 [![Coverage](https://img.shields.io/codecov/c/github/georgepwall1991/automapper-analyser?style=flat-square&logo=codecov&label=Coverage)](https://codecov.io/gh/georgepwall1991/automapper-analyser)
@@ -14,24 +14,25 @@ prevention*
 
 ---
 
-## 🎉 Latest Release: v2.30.9
+## 🎉 Latest Release: v2.30.10
 
-**AM004/AM005 Severity Documentation Trust — rule docs match shipped descriptors**
+**AM050 Proven Redundant MapFrom Cleanup — safe rewrite only when types match**
 
 ✅ **Highlights**
 
-- Aligns AM004 and AM005 rule docs with shipped Warning severity and descriptor categories.
-- Documents AM031's mixed Warning/Info descriptor severity in the rule docs.
-- Adds catalog trust coverage so documented severity lines stay aligned with analyzer descriptors.
+- Requires AM050 cleanup diagnostics to prove same-name source and destination member types are compatible.
+- Supports string-based `ForMember("Name", ...)` when the destination property resolves through `CreateMap`.
+- Suppresses same-name string-member cleanup when source and destination types differ.
 
 🧪 **Validation**
 
 - Full solution test validation passed on `net10.0`.
-- Full test suite passed with `672` passing and `0` skipped.
-- Release validation covered targeted rule catalog trust tests plus full solution verification before tagging.
+- Full test suite passed with `675` passing and `0` skipped.
+- Release validation covered targeted AM050 analyzer/code fix tests plus full solution verification before tagging.
 
 ### Recent Releases
 
+- **v2.30.10**: AM050 proven redundant `MapFrom` cleanup for string-based members and type-safe suppressions.
 - **v2.30.9**: AM004/AM005 severity documentation trust with descriptor-aligned rule docs.
 - **v2.30.8**: AM030 null-guard fixer precision without invasive `using System` edits.
 - **v2.30.7**: AM022 recursion boundary precision for nested-map chains and explicit recursion controls.
@@ -177,7 +178,7 @@ Install-Package AutoMapperAnalyzer.Analyzers
 ### Project File (For CI/CD)
 
 ```xml
-<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.9">
+<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.10">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 </PackageReference>
@@ -371,6 +372,7 @@ This isn't just another analyzer—it's built for **enterprise-grade reliability
 
 ### Recently Completed ✅
 
+- **v2.30.10**: AM050 proven redundant `MapFrom` cleanup for string-based members and type-safe suppressions
 - **v2.30.9**: AM004/AM005 severity documentation trust with descriptor-aligned rule docs
 - **v2.30.8**: AM030 null-guard fixer precision without invasive `using System` edits
 - **v2.30.7**: AM022 recursion boundary precision for nested-map chains and explicit recursion controls

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -44,7 +44,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | AM030 | Custom type converter issues | Custom Conversions | Error/Warning/Info | 3 | 4 | 4 | 4 | 4 | 3 | Low | Nullable-source converter fixes now insert fully qualified null guards without adding or reordering `using System`, with coverage for existing/global usings, file-scoped namespaces, expression-bodied converters, and multi-diagnostic fixes. Remaining opportunities are mostly external DI/service-provider wiring and the mixed-concept shape of the single AM030 ID. |
 | AM031 | Performance warnings in mapping expressions | Performance | Warning/Info | 4 | 4 | 4 | 5 | 4 | 4 | Low | Multiple-enumeration diagnostics now normalize source-rooted collection paths, cache rewrites support nested source collections, unsafe captured-collection cache actions are suppressed, and Task-valued source-property `.Result` is covered. Remaining risk is mainly the intentionally heuristic nature of broad performance smells. |
 | AM041 | Duplicate mapping registration | Configuration | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | Strong compilation-wide registry, reverse-map awareness, cross-profile duplicate detection, and removal fixer coverage. Remaining risk is mainly nuanced intentional override/configuration ordering cases. |
-| AM050 | Redundant MapFrom configuration | Configuration | Info | 3 | 3 | 4 | 3 | 3 | 2 | Low | Safe cleanup rule with idempotent fixer tests, but product importance is low and analyzer semantics are intentionally narrow around direct same-name property lambdas. |
+| AM050 | Redundant MapFrom configuration | Configuration | Info | 4 | 4 | 4 | 4 | 4 | 2 | Low | Safe cleanup rule now requires proven source/destination type compatibility, including string-based `ForMember` members resolved through the `CreateMap` destination type; product importance remains low. |
 
 ## Planning Shortlist
 
@@ -59,6 +59,7 @@ The next improvement batch should focus on rules where user impact and health ga
 ## Cross-Cutting Findings
 
 - Public docs are useful and now have a severity drift guard for rule documentation. `AM004`, `AM005`, and `AM031` rule-doc severity text matches shipped descriptor metadata, while README/package version references remain covered by existing trust tests.
+- AM050 now treats redundant cleanup as a proven safe rewrite: string-based destination members are resolved through `CreateMap<TSource, TDestination>()`, mismatched same-name types are suppressed, and fixer titles retain the destination member name.
 - Analyzer ownership is a real strength. The conflict tests and shared helpers make `AM001`/`AM002`/`AM003`/`AM020`/`AM021` boundaries much healthier than a file-count audit would suggest.
 - The project now has a checked-in `RuleCatalog` health contract plus generated `docs/RULE_CATALOG.md` and sample diagnostic snapshots that tie rule IDs to descriptors, fixers, docs anchors, sample paths, and fixer trust levels.
 - Diagnostic placement is generally at the mapping invocation or mapping lambda, not always the precise property/member token. That is acceptable for many AutoMapper configuration rules, but high-volume rules benefit from tighter placement when practical.
@@ -70,6 +71,7 @@ Architecture-style coverage currently comes from analyzer/fixer tests, conflict 
 
 Current local verification:
 
-- `/opt/homebrew/bin/dotnet test automapper-analyser.sln --no-restore --framework net10.0` passed: 672 passed, 0 skipped, 0 failed.
+- `/usr/local/share/dotnet/dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter AM050` passed: 20 passed, 0 skipped, 0 failed.
+- `/usr/local/share/dotnet/dotnet test automapper-analyser.sln --no-restore --framework net10.0` passed: 675 passed, 0 skipped, 0 failed.
 - The trust-first pass removed active skipped tests, added drift validation, and moved intentional analyzer-test warnings into an explicit test-project warning baseline.
 - `/opt/homebrew/bin/dotnet --list-runtimes` shows only .NET 10 runtimes in this local environment, so broader runtime verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/docs/ANALYZER_REVIEW_TRACKER.md
+++ b/docs/ANALYZER_REVIEW_TRACKER.md
@@ -35,6 +35,7 @@ Tracks analyzer-by-analyzer improvement passes focused on false positives, contr
 | AM022 (3rd pass) | Complex Mappings | main | v2.30.7 | Required configured nested `CreateMap` chains before indirect recursion diagnostics, suppressed semantic `PreserveReferences` and `ConvertUsing`, and expanded boundary regression coverage. |
 | AM030 (3rd pass) | Complex Mappings | main | v2.30.8 | Generated fully qualified null guards without adding `using System`, preserving existing/global usings, file-scoped namespaces, expression-bodied converters, and multi-diagnostic fixer behavior. |
 | AM004/AM005 docs trust | Data Integrity | main | v2.30.9 | Aligned rule docs with shipped Warning severity/category metadata and added catalog trust coverage that keeps documented severity lines descriptor-accurate. |
+| AM050 (2nd pass) | Configuration | main | v2.30.10 | Required proven source/destination type compatibility before reporting redundant `MapFrom`, including string-based `ForMember` destination members resolved from `CreateMap`. |
 
 ## In Progress
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -724,7 +724,7 @@ dotnet pack --configuration Release
 
 # Test package locally
 cd test-install/NetCoreTest
-dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.9-local
+dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.10-local
 ```
 
 ---
@@ -908,4 +908,4 @@ dotnet build
 
 **Last Updated**: 2025-11-19
 **Maintainer**: George Wall
-**Version**: 2.30.9
+**Version**: 2.30.10

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -57,7 +57,7 @@ The AutoMapper Roslyn Analyzer project uses GitHub Actions for continuous integr
 
 **Triggers:**
 
-- Semantic version tags such as `v2.30.9`
+- Semantic version tags such as `v2.30.10`
 
 **Features:**
 
@@ -112,8 +112,8 @@ The AutoMapper Roslyn Analyzer project uses GitHub Actions for continuous integr
 ### Package Versioning
 
 - **Format**: Major.Minor.Patch (SemVer)
-- **Current**: 2.30.9
-- **Pre-release**: 2.30.9-preview, 2.30.9-beta
+- **Current**: 2.30.10
+- **Pre-release**: 2.30.10-preview, 2.30.10-beta
 
 ## 🔧 Configuration
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -43,7 +43,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.9">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -67,7 +67,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.9">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -86,7 +86,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="14.0.0" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.9">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -218,7 +218,7 @@ public class Destination
 
 2. **Verify Package Installation**
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.9">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.10">
      <PrivateAssets>all</PrivateAssets>
      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -280,4 +280,4 @@ This guide ensures smooth installation and usage across all supported .NET frame
 ---
 
 **Last Updated**: November 19, 2025
-**Version**: 2.30.9
+**Version**: 2.30.10

--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -1163,6 +1163,8 @@ dotnet_diagnostic.AM041.severity = warning
 
 Detects explicit `MapFrom` calls where the source and destination properties have the same name. AutoMapper maps these automatically by default.
 
+AM050 only reports when it can prove the source and destination members have the same type, including string-based destination member names such as `ForMember("Name", ...)`. It stays quiet when the destination member cannot be resolved or the same-name members have different types.
+
 #### Problem
 
 ```csharp
@@ -1284,7 +1286,7 @@ using System.Diagnostics.CodeAnalysis;
 
 1. **Check package reference**:
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.9">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.10">
        <PrivateAssets>all</PrivateAssets>
        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>

--- a/docs/RULE_CATALOG.md
+++ b/docs/RULE_CATALOG.md
@@ -2,7 +2,7 @@
 
 This file is generated from `RuleCatalog`.
 
-Package version: `2.30.9`
+Package version: `2.30.10`
 
 | Rule ID | Descriptor Title | Severity | Category | Analyzer | Code Fix | Trust | Sample | Docs |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,4 +1,4 @@
-## Release 2.30.9
+## Release 2.30.10
 
 ### New Rules
 

--- a/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
+++ b/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
@@ -17,7 +17,7 @@
         <!-- Fallback for local builds: 2.0.YYYYMMDD-local -->
         <MajorVersion>2</MajorVersion>
         <MinorVersion>30</MinorVersion>
-        <PatchVersion>9</PatchVersion>
+        <PatchVersion>10</PatchVersion>
         <BuildNumber Condition="'$(BuildNumber)' == ''"
         >$([System.DateTime]::Now.ToString('yyyyMMdd'))
         </BuildNumber
@@ -32,18 +32,18 @@
         <RepositoryUrl>https://github.com/georgepwall1991/automapper-analyser</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <PackageReleaseNotes>Version 2.30.9 - AM004/AM005 severity documentation trust
+        <PackageReleaseNotes>Version 2.30.10 - AM050 proven redundant MapFrom cleanup
 
             Changed:
-            - Aligned AM004 and AM005 rule docs with shipped Warning severity and descriptor categories
-            - Documented AM031's mixed Warning/Info descriptor severity in the rule docs
-            - Added rule-catalog trust coverage for documented severity drift
+            - Hardened AM050 so redundant MapFrom cleanup is reported only when source and destination property types are proven compatible
+            - Added AM050 coverage for string-based ForMember property names with matching and mismatched destination types
+            - Preserved property-specific code action titles for string-based destination members
 
             Validation:
-            - Full solution test suite passing on net10.0 with targeted rule catalog trust coverage
+            - Full solution test suite passing on net10.0 with targeted AM050 coverage
             - git diff --check clean
 
-            Previous Release: v2.30.8 - AM030 null-guard fixer precision
+            Previous Release: v2.30.9 - AM004/AM005 severity documentation trust
         </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>

--- a/src/AutoMapperAnalyzer.Analyzers/Configuration/AM050_RedundantMapFromAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Configuration/AM050_RedundantMapFromAnalyzer.cs
@@ -107,7 +107,7 @@ public class AM050_RedundantMapFromAnalyzer : DiagnosticAnalyzer
 
         if (sourceType == null || destType == null)
         {
-            return true; // Can't determine, assume compatible
+            return false;
         }
 
         // Check if types are exactly the same (including nullability)
@@ -139,6 +139,29 @@ public class AM050_RedundantMapFromAnalyzer : DiagnosticAnalyzer
         return null;
     }
 
+    private InvocationExpressionSyntax? FindCreateMapInvocation(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel)
+    {
+        ExpressionSyntax? currentExpression = invocation.Expression is MemberAccessExpressionSyntax memberAccess
+            ? memberAccess.Expression
+            : null;
+
+        while (currentExpression is InvocationExpressionSyntax currentInvocation)
+        {
+            if (MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(currentInvocation, semanticModel, "CreateMap"))
+            {
+                return currentInvocation;
+            }
+
+            currentExpression = currentInvocation.Expression is MemberAccessExpressionSyntax currentMemberAccess
+                ? currentMemberAccess.Expression
+                : null;
+        }
+
+        return null;
+    }
+
     private ITypeSymbol? GetDestinationPropertyType(
         InvocationExpressionSyntax forMemberInvocation,
         SyntaxNodeAnalysisContext context)
@@ -161,7 +184,26 @@ public class AM050_RedundantMapFromAnalyzer : DiagnosticAnalyzer
             }
         }
 
-        return null;
+        string? destinationPropertyName = GetStringLiteralValue(arg);
+        if (destinationPropertyName == null)
+        {
+            return null;
+        }
+
+        InvocationExpressionSyntax? createMapInvocation = FindCreateMapInvocation(forMemberInvocation, context.SemanticModel);
+        if (createMapInvocation == null)
+        {
+            return null;
+        }
+
+        (_, ITypeSymbol? destinationType) =
+            MappingChainAnalysisHelper.GetCreateMapTypeArguments(createMapInvocation, context.SemanticModel);
+
+        return destinationType == null
+            ? null
+            : AutoMapperAnalysisHelpers.GetMappableProperties(destinationType)
+                .FirstOrDefault(property => property.Name == destinationPropertyName)
+                ?.Type;
     }
 
     private string? GetDestinationPropertyName(InvocationExpressionSyntax forMemberInvocation)
@@ -183,10 +225,10 @@ public class AM050_RedundantMapFromAnalyzer : DiagnosticAnalyzer
         }
 
         // Handle quoted string "Name"
-        if (arg is LiteralExpressionSyntax literal &&
-            literal.IsKind(SyntaxKind.StringLiteralExpression))
+        string? literalValue = GetStringLiteralValue(arg);
+        if (literalValue != null)
         {
-            return literal.Token.ValueText;
+            return literalValue;
         }
 
         return null;
@@ -211,6 +253,14 @@ public class AM050_RedundantMapFromAnalyzer : DiagnosticAnalyzer
         }
 
         return null;
+    }
+
+    private static string? GetStringLiteralValue(ExpressionSyntax expression)
+    {
+        return expression is LiteralExpressionSyntax literal &&
+               literal.IsKind(SyntaxKind.StringLiteralExpression)
+            ? literal.Token.ValueText
+            : null;
     }
 
 }

--- a/src/AutoMapperAnalyzer.Analyzers/Configuration/AM050_RedundantMapFromCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Configuration/AM050_RedundantMapFromCodeFixProvider.cs
@@ -4,6 +4,7 @@ using AutoMapperAnalyzer.Analyzers.Helpers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace AutoMapperAnalyzer.Analyzers.Configuration;
@@ -74,8 +75,15 @@ public class AM050_RedundantMapFromCodeFixProvider : AutoMapperCodeFixProviderBa
         }
 
         SyntaxNode? lambdaBody = AutoMapperAnalysisHelpers.GetLambdaBody(forMemberInvocation.ArgumentList.Arguments[0].Expression);
-        return lambdaBody is MemberAccessExpressionSyntax memberAccess
-            ? memberAccess.Name.Identifier.ValueText
+        if (lambdaBody is MemberAccessExpressionSyntax memberAccess)
+        {
+            return memberAccess.Name.Identifier.ValueText;
+        }
+
+        ExpressionSyntax expression = forMemberInvocation.ArgumentList.Arguments[0].Expression;
+        return expression is LiteralExpressionSyntax literal &&
+               literal.IsKind(SyntaxKind.StringLiteralExpression)
+            ? literal.Token.ValueText
             : null;
     }
 }

--- a/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
@@ -99,7 +99,7 @@ public static class RuleCatalog
     /// <summary>
     ///     Current package version used by docs/package drift tests.
     /// </summary>
-    public const string CurrentPackageVersion = "2.30.9";
+    public const string CurrentPackageVersion = "2.30.10";
 
     /// <summary>
     ///     Implemented rules, grouped by public diagnostic ID.

--- a/tests/AutoMapperAnalyzer.Tests/Configuration/AM050_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Configuration/AM050_CodeFixTests.cs
@@ -234,6 +234,48 @@ public class AM050_CodeFixTests
     }
 
     [Fact]
+    public async Task Should_Remove_RedundantMapping_WithStringDestinationMember()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                public class Source { public string Name { get; set; } }
+                                public class Destination { public string Name { get; set; } }
+
+                                public class MyProfile : Profile
+                                {
+                                    public MyProfile()
+                                    {
+                                        CreateMap<Source, Destination>()
+                                            .ForMember("Name", o => o.MapFrom(s => s.Name));
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 using AutoMapper;
+
+                                 public class Source { public string Name { get; set; } }
+                                 public class Destination { public string Name { get; set; } }
+
+                                 public class MyProfile : Profile
+                                 {
+                                     public MyProfile()
+                                     {
+                                         CreateMap<Source, Destination>();
+                                     }
+                                 }
+                                 """;
+
+        DiagnosticResult expected = new DiagnosticResult(AM050_RedundantMapFromAnalyzer.RedundantMapFromRule)
+            .WithLocation(11, 37)
+            .WithArguments("Name");
+
+        await CodeFixVerifier<AM050_RedundantMapFromAnalyzer, AM050_RedundantMapFromCodeFixProvider>
+            .VerifyFixAsync(testCode, expected, fixedCode);
+    }
+
+    [Fact]
     public async Task Should_Remove_RedundantMapping_NumericTypes()
     {
         const string testCode = """

--- a/tests/AutoMapperAnalyzer.Tests/Configuration/AM050_RedundantMapFromTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Configuration/AM050_RedundantMapFromTests.cs
@@ -55,6 +55,54 @@ public class AM050_RedundantMapFromTests
     }
 
     [Fact]
+    public async Task Should_ReportDiagnostic_When_StringDestinationMemberTypeMatches()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                public class Source { public string Name { get; set; } }
+                                public class Destination { public string Name { get; set; } }
+
+                                public class MyProfile : Profile
+                                {
+                                    public MyProfile()
+                                    {
+                                        CreateMap<Source, Destination>()
+                                            .ForMember("Name", o => o.MapFrom(s => s.Name));
+                                    }
+                                }
+                                """;
+
+        DiagnosticResult expected = new DiagnosticResult(AM050_RedundantMapFromAnalyzer.RedundantMapFromRule)
+            .WithLocation(11, 37)
+            .WithArguments("Name");
+
+        await AnalyzerVerifier<AM050_RedundantMapFromAnalyzer>.VerifyAnalyzerAsync(testCode, expected);
+    }
+
+    [Fact]
+    public async Task Should_NotReportDiagnostic_When_StringDestinationMemberTypeDiffers()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                public class Source { public string Name { get; set; } }
+                                public class Destination { public int Name { get; set; } }
+
+                                public class MyProfile : Profile
+                                {
+                                    public MyProfile()
+                                    {
+                                        CreateMap<Source, Destination>()
+                                            .ForMember("Name", o => o.MapFrom(s => s.Name));
+                                    }
+                                }
+                                """;
+
+        await AnalyzerVerifier<AM050_RedundantMapFromAnalyzer>.VerifyAnalyzerAsync(testCode);
+    }
+
+    [Fact]
     public async Task Should_NotReportDiagnostic_When_MappingExpression()
     {
         const string testCode = """


### PR DESCRIPTION
## Summary
- harden AM050 so redundant `MapFrom` cleanup requires proven source/destination type compatibility
- add string-based `ForMember` coverage for compatible and incompatible same-name destination members
- update analyzer health, trust metadata, docs, changelog, and bump v2.30.10

## Impact
This improves AM050 precision by preserving safe cleanup diagnostics while suppressing same-name mappings when the destination type cannot safely be treated as redundant.

## Validation
- local `net10.0` AM050 test slice passed: 20 passed
- local `net10.0` solution test run passed: 675 passed
- rule catalog and sample diagnostics snapshot checks passed
- `git diff --check` clean
- CI covers the hosted build/package workflow and package smoke checks