### PR TITLE
Harden AM001 enum conversion fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+## [2.30.11] - 2026-04-27
+
+### Changed
+
+- Added AM001 code fixes for enum-to-string property mappings using `ToString()`.
+- Added AM001 code fixes for string-to-enum property mappings using null-guarded, fully qualified `Enum.Parse<TEnum>()`.
+- Updated analyzer health status to record the AM001 enum conversion fixer hardening pass.
+
+### Validation
+
+- Targeted AM001 code fix tests.
+- Full `net10.0` solution test suite.
+- `git diff --check`.
+
 ## [2.30.10] - 2026-04-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -14,24 +14,25 @@ prevention*
 
 ---
 
-## 🎉 Latest Release: v2.30.10
+## 🎉 Latest Release: v2.30.11
 
-**AM050 Proven Redundant MapFrom Cleanup — safe rewrite only when types match**
+**AM001 Enum Conversion Fixes — direct enum/string mapping actions**
 
 ✅ **Highlights**
 
-- Requires AM050 cleanup diagnostics to prove same-name source and destination member types are compatible.
-- Supports string-based `ForMember("Name", ...)` when the destination property resolves through `CreateMap`.
-- Suppresses same-name string-member cleanup when source and destination types differ.
+- Adds AM001 enum-to-string fixes using `ToString()`.
+- Adds AM001 string-to-enum fixes using null-guarded, fully qualified `Enum.Parse<TEnum>()`.
+- Keeps manual-review ignore actions available for domain-specific conversion policies.
 
 🧪 **Validation**
 
 - Full solution test validation passed on `net10.0`.
-- Full test suite passed with `675` passing and `0` skipped.
-- Release validation covered targeted AM050 analyzer/code fix tests plus full solution verification before tagging.
+- Full test suite passed with `679` passing and `0` skipped.
+- Release validation covered targeted AM001 code fix tests plus full solution verification before tagging.
 
 ### Recent Releases
 
+- **v2.30.11**: AM001 enum/string conversion fixes for direct property mismatch remediation.
 - **v2.30.10**: AM050 proven redundant `MapFrom` cleanup for string-based members and type-safe suppressions.
 - **v2.30.9**: AM004/AM005 severity documentation trust with descriptor-aligned rule docs.
 - **v2.30.8**: AM030 null-guard fixer precision without invasive `using System` edits.
@@ -178,7 +179,7 @@ Install-Package AutoMapperAnalyzer.Analyzers
 ### Project File (For CI/CD)
 
 ```xml
-<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.10">
+<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.11">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 </PackageReference>
@@ -372,6 +373,7 @@ This isn't just another analyzer—it's built for **enterprise-grade reliability
 
 ### Recently Completed ✅
 
+- **v2.30.11**: AM001 enum/string conversion fixes for direct property mismatch remediation
 - **v2.30.10**: AM050 proven redundant `MapFrom` cleanup for string-based members and type-safe suppressions
 - **v2.30.9**: AM004/AM005 severity documentation trust with descriptor-aligned rule docs
 - **v2.30.8**: AM030 null-guard fixer precision without invasive `using System` edits

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -1,6 +1,6 @@
 # Analyzer Health
 
-Reviewed: 2026-04-26
+Reviewed: 2026-04-27
 
 This is a deliberately harsh health audit for the 14 implemented AutoMapper analyzer rule IDs in this repository. Several rule IDs expose multiple diagnostic descriptors, especially `AM002`, `AM022`, `AM030`, and `AM031`; the scorecard rates the public rule ID as the user experiences it.
 
@@ -31,7 +31,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 
 | Rule | Title | Domain | Severity | Analyzer | False Positives | Fix Strategy | Tests | Docs/Samples | Importance | Priority | Notes |
 | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |
-| AM001 | Property type mismatch | Type Safety | Error | 4 | 4 | 4 | 4 | 4 | 5 | Low | Strong semantic AutoMapper gating, ownership handoff to AM002/AM020/AM021, and solid fixer coverage; remaining gaps are mostly advanced conversion semantics and richer compile-time conversion modeling. |
+| AM001 | Property type mismatch | Type Safety | Error | 4 | 4 | 4 | 4 | 4 | 5 | Low | Strong semantic AutoMapper gating, ownership handoff to AM002/AM020/AM021, and solid fixer coverage; enum/string mismatches now get direct conversion fixes. Remaining gaps are mostly advanced conversion semantics and richer compile-time conversion modeling. |
 | AM002 | Nullable compatibility issue | Type Safety | Error/Info | 4 | 4 | 4 | 5 | 4 | 5 | Low | Descriptor-accurate docs now call out the Error/Info split, and regression tests cover oblivious reference nullability plus nullable value types in disabled nullable contexts. Remaining opportunities are advanced generic/nullability-flow semantics. |
 | AM003 | Collection type incompatibility | Type Safety | Error | 4 | 4 | 4 | 5 | 4 | 4 | Low | Now suppresses container diagnostics when the source collection is implicitly assignable to the destination contract, with regression coverage for array/interface and set/read-only interface shapes. Remaining opportunities are broader custom/immutable collection semantics. |
 | AM004 | Source property has no corresponding destination property | Data Integrity | Warning | 4 | 4 | 4 | 5 | 5 | 5 | Low | One of the strongest rules: reverse maps, records, inheritance, flattening, ctor params, custom construction, and fixer behavior have extensive coverage. Rule docs now match shipped Warning severity/category metadata and are protected by catalog severity drift tests. |
@@ -59,6 +59,7 @@ The next improvement batch should focus on rules where user impact and health ga
 ## Cross-Cutting Findings
 
 - Public docs are useful and now have a severity drift guard for rule documentation. `AM004`, `AM005`, and `AM031` rule-doc severity text matches shipped descriptor metadata, while README/package version references remain covered by existing trust tests.
+- AM001 fixer coverage now includes enum-to-string and null-guarded string-to-enum property mismatches, so the documented enum conversion scenario has an executable code action instead of only an ignore fallback.
 - AM050 now treats redundant cleanup as a proven safe rewrite: string-based destination members are resolved through `CreateMap<TSource, TDestination>()`, mismatched same-name types are suppressed, and fixer titles retain the destination member name.
 - Analyzer ownership is a real strength. The conflict tests and shared helpers make `AM001`/`AM002`/`AM003`/`AM020`/`AM021` boundaries much healthier than a file-count audit would suggest.
 - The project now has a checked-in `RuleCatalog` health contract plus generated `docs/RULE_CATALOG.md` and sample diagnostic snapshots that tie rule IDs to descriptors, fixers, docs anchors, sample paths, and fixer trust levels.
@@ -71,6 +72,7 @@ Architecture-style coverage currently comes from analyzer/fixer tests, conflict 
 
 Current local verification:
 
+- `/usr/local/share/dotnet/dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter AM001_CodeFixTests` passed: 11 passed, 0 skipped, 0 failed.
 - `/usr/local/share/dotnet/dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter AM050` passed: 20 passed, 0 skipped, 0 failed.
 - `/usr/local/share/dotnet/dotnet test automapper-analyser.sln --no-restore --framework net10.0` passed: 675 passed, 0 skipped, 0 failed.
 - The trust-first pass removed active skipped tests, added drift validation, and moved intentional analyzer-test warnings into an explicit test-project warning baseline.

--- a/docs/ANALYZER_REVIEW_TRACKER.md
+++ b/docs/ANALYZER_REVIEW_TRACKER.md
@@ -36,6 +36,7 @@ Tracks analyzer-by-analyzer improvement passes focused on false positives, contr
 | AM030 (3rd pass) | Complex Mappings | main | v2.30.8 | Generated fully qualified null guards without adding `using System`, preserving existing/global usings, file-scoped namespaces, expression-bodied converters, and multi-diagnostic fixer behavior. |
 | AM004/AM005 docs trust | Data Integrity | main | v2.30.9 | Aligned rule docs with shipped Warning severity/category metadata and added catalog trust coverage that keeps documented severity lines descriptor-accurate. |
 | AM050 (2nd pass) | Configuration | main | v2.30.10 | Required proven source/destination type compatibility before reporting redundant `MapFrom`, including string-based `ForMember` destination members resolved from `CreateMap`. |
+| AM001 (2nd pass) | Type Safety | main | v2.30.11 | Added direct enum-to-string and string-to-enum conversion fixes for documented AM001 enum mismatch scenarios. |
 
 ## In Progress
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -724,7 +724,7 @@ dotnet pack --configuration Release
 
 # Test package locally
 cd test-install/NetCoreTest
-dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.10-local
+dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.11-local
 ```
 
 ---
@@ -908,4 +908,4 @@ dotnet build
 
 **Last Updated**: 2025-11-19
 **Maintainer**: George Wall
-**Version**: 2.30.10
+**Version**: 2.30.11

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -57,7 +57,7 @@ The AutoMapper Roslyn Analyzer project uses GitHub Actions for continuous integr
 
 **Triggers:**
 
-- Semantic version tags such as `v2.30.10`
+- Semantic version tags such as `v2.30.11`
 
 **Features:**
 
@@ -112,8 +112,8 @@ The AutoMapper Roslyn Analyzer project uses GitHub Actions for continuous integr
 ### Package Versioning
 
 - **Format**: Major.Minor.Patch (SemVer)
-- **Current**: 2.30.10
-- **Pre-release**: 2.30.10-preview, 2.30.10-beta
+- **Current**: 2.30.11
+- **Pre-release**: 2.30.11-preview, 2.30.11-beta
 
 ## 🔧 Configuration
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -43,7 +43,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.10">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -67,7 +67,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.10">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -86,7 +86,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="14.0.0" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.10">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -218,7 +218,7 @@ public class Destination
 
 2. **Verify Package Installation**
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.10">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.11">
      <PrivateAssets>all</PrivateAssets>
      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -280,4 +280,4 @@ This guide ensures smooth installation and usage across all supported .NET frame
 ---
 
 **Last Updated**: November 19, 2025
-**Version**: 2.30.10
+**Version**: 2.30.11

--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -110,10 +110,14 @@ CreateMap<Source, Destination>()
         int.TryParse(src.Age, out var age) ? age : 0));
 ```
 
+For enum/string mismatches, AM001 offers direct conversion fixes such as `src.Status.ToString()` and
+`src.Status != null ? global::System.Enum.Parse<global::MyApp.OrderStatus>(src.Status) : default`.
+
 #### When to Use
 
 - ✅ String → numeric conversions
 - ✅ Enum → string conversions
+- ✅ String → enum conversions
 - ✅ Custom type conversions
 - ❌ Compatible types (no warning needed)
 
@@ -1286,7 +1290,7 @@ using System.Diagnostics.CodeAnalysis;
 
 1. **Check package reference**:
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.10">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.11">
        <PrivateAssets>all</PrivateAssets>
        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>

--- a/docs/RULE_CATALOG.md
+++ b/docs/RULE_CATALOG.md
@@ -2,7 +2,7 @@
 
 This file is generated from `RuleCatalog`.
 
-Package version: `2.30.10`
+Package version: `2.30.11`
 
 | Rule ID | Descriptor Title | Severity | Category | Analyzer | Code Fix | Trust | Sample | Docs |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,4 +1,4 @@
-## Release 2.30.10
+## Release 2.30.11
 
 ### New Rules
 

--- a/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
+++ b/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
@@ -17,7 +17,7 @@
         <!-- Fallback for local builds: 2.0.YYYYMMDD-local -->
         <MajorVersion>2</MajorVersion>
         <MinorVersion>30</MinorVersion>
-        <PatchVersion>10</PatchVersion>
+        <PatchVersion>11</PatchVersion>
         <BuildNumber Condition="'$(BuildNumber)' == ''"
         >$([System.DateTime]::Now.ToString('yyyyMMdd'))
         </BuildNumber
@@ -32,18 +32,18 @@
         <RepositoryUrl>https://github.com/georgepwall1991/automapper-analyser</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <PackageReleaseNotes>Version 2.30.10 - AM050 proven redundant MapFrom cleanup
+        <PackageReleaseNotes>Version 2.30.11 - AM001 enum conversion fixer
 
             Changed:
-            - Hardened AM050 so redundant MapFrom cleanup is reported only when source and destination property types are proven compatible
-            - Added AM050 coverage for string-based ForMember property names with matching and mismatched destination types
-            - Preserved property-specific code action titles for string-based destination members
+            - Added AM001 code fixes for enum-to-string mappings using ToString()
+            - Added AM001 code fixes for string-to-enum mappings using null-guarded, fully qualified Enum.Parse&lt;TEnum&gt;()
+            - Added focused AM001 fixer coverage for both enum conversion directions
 
             Validation:
-            - Full solution test suite passing on net10.0 with targeted AM050 coverage
+            - Full solution test suite passing on net10.0 with targeted AM001 coverage
             - git diff --check clean
 
-            Previous Release: v2.30.9 - AM004/AM005 severity documentation trust
+            Previous Release: v2.30.10 - AM050 proven redundant MapFrom cleanup
         </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>

--- a/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
@@ -99,7 +99,7 @@ public static class RuleCatalog
     /// <summary>
     ///     Current package version used by docs/package drift tests.
     /// </summary>
-    public const string CurrentPackageVersion = "2.30.10";
+    public const string CurrentPackageVersion = "2.30.11";
 
     /// <summary>
     ///     Implemented rules, grouped by public diagnostic ID.

--- a/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM001_PropertyTypeMismatchCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM001_PropertyTypeMismatchCodeFixProvider.cs
@@ -200,6 +200,19 @@ public class AM001_PropertyTypeMismatchCodeFixProvider : AutoMapperCodeFixProvid
             return $"src.{propertyName}.ToString()";
         }
 
+        if (sourceType.TypeKind == TypeKind.Enum && IsString(destinationType))
+        {
+            return $"src.{propertyName}.ToString()";
+        }
+
+        if (IsString(sourceType) && destinationType.TypeKind == TypeKind.Enum)
+        {
+            string fullyQualifiedDestinationTypeName =
+                destinationType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+            return
+                $"src.{propertyName} != null ? global::System.Enum.Parse<{fullyQualifiedDestinationTypeName}>(src.{propertyName}) : default";
+        }
+
         // Nullable source to non-nullable destination where underlying types are compatible.
         ITypeSymbol sourceUnderlyingType = AutoMapperAnalysisHelpers.GetUnderlyingType(sourceType);
         if (IsNullableType(sourceType) &&

--- a/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM001_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM001_CodeFixTests.cs
@@ -431,6 +431,269 @@ public class AM001_CodeFixTests
                 expectedFixedCode);
     }
 
+    [Fact]
+    public async Task AM001_ShouldFixEnumToStringWithToString()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public enum OrderStatus
+                                    {
+                                        Draft,
+                                        Submitted
+                                    }
+
+                                    public class Source
+                                    {
+                                        public OrderStatus Status { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public string Status { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string expectedFixedCode = """
+                                         using AutoMapper;
+
+                                         namespace TestNamespace
+                                         {
+                                             public enum OrderStatus
+                                             {
+                                                 Draft,
+                                                 Submitted
+                                             }
+
+                                             public class Source
+                                             {
+                                                 public OrderStatus Status { get; set; }
+                                             }
+
+                                             public class Destination
+                                             {
+                                                 public string Status { get; set; }
+                                             }
+
+                                             public class TestProfile : Profile
+                                             {
+                                                 public TestProfile()
+                                                 {
+                                                     CreateMap<Source, Destination>().ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.Status.ToString()));
+                                                 }
+                                             }
+                                         }
+                                         """;
+
+        await CodeFixVerifier<AM001_PropertyTypeMismatchAnalyzer, AM001_PropertyTypeMismatchCodeFixProvider>
+            .VerifyFixAsync(
+                testCode,
+                Diagnostic(AM001_PropertyTypeMismatchAnalyzer.PropertyTypeMismatchRule, 25, 13,
+                    "Status", "Source", "TestNamespace.OrderStatus", "Destination", "string"),
+                expectedFixedCode);
+    }
+
+    [Fact]
+    public async Task AM001_ShouldFixStringToEnumWithParse()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public enum OrderStatus
+                                    {
+                                        Draft,
+                                        Submitted
+                                    }
+
+                                    public class Source
+                                    {
+                                        public string Status { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public OrderStatus Status { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string expectedFixedCode = """
+                                         using AutoMapper;
+
+                                         namespace TestNamespace
+                                         {
+                                             public enum OrderStatus
+                                             {
+                                                 Draft,
+                                                 Submitted
+                                             }
+
+                                             public class Source
+                                             {
+                                                 public string Status { get; set; }
+                                             }
+
+                                             public class Destination
+                                             {
+                                                 public OrderStatus Status { get; set; }
+                                             }
+
+                                             public class TestProfile : Profile
+                                             {
+                                                 public TestProfile()
+                                                 {
+                                                     CreateMap<Source, Destination>().ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.Status != null ? global::System.Enum.Parse<global::TestNamespace.OrderStatus>(src.Status) : default));
+                                                 }
+                                             }
+                                         }
+                                         """;
+
+        await CodeFixVerifier<AM001_PropertyTypeMismatchAnalyzer, AM001_PropertyTypeMismatchCodeFixProvider>
+            .VerifyFixAsync(
+                testCode,
+                Diagnostic(AM001_PropertyTypeMismatchAnalyzer.PropertyTypeMismatchRule, 25, 13,
+                    "Status", "Source", "string", "Destination", "TestNamespace.OrderStatus"),
+                expectedFixedCode);
+    }
+
+    [Fact]
+    public async Task AM001_ShouldFixNullableStringToEnumWithParseFallback()
+    {
+        const string testCode = """
+                                #nullable enable
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public enum OrderStatus
+                                    {
+                                        Draft,
+                                        Submitted
+                                    }
+
+                                    public class Source
+                                    {
+                                        public string? Status { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public OrderStatus Status { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string expectedFixedCode = """
+                                         #nullable enable
+                                         using AutoMapper;
+
+                                         namespace TestNamespace
+                                         {
+                                             public enum OrderStatus
+                                             {
+                                                 Draft,
+                                                 Submitted
+                                             }
+
+                                             public class Source
+                                             {
+                                                 public string? Status { get; set; }
+                                             }
+
+                                             public class Destination
+                                             {
+                                                 public OrderStatus Status { get; set; }
+                                             }
+
+                                             public class TestProfile : Profile
+                                             {
+                                                 public TestProfile()
+                                                 {
+                                                     CreateMap<Source, Destination>().ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.Status != null ? global::System.Enum.Parse<global::TestNamespace.OrderStatus>(src.Status) : default));
+                                                 }
+                                             }
+                                         }
+                                         """;
+
+        await CodeFixVerifier<AM001_PropertyTypeMismatchAnalyzer, AM001_PropertyTypeMismatchCodeFixProvider>
+            .VerifyFixAsync(
+                testCode,
+                Diagnostic(AM001_PropertyTypeMismatchAnalyzer.PropertyTypeMismatchRule, 26, 13,
+                    "Status", "Source", "string?", "Destination", "TestNamespace.OrderStatus"),
+                expectedFixedCode);
+    }
+
+    [Fact]
+    public async Task AM001_ShouldOfferOnlyIgnore_WhenEnumMapsToNumericType()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public enum OrderStatus
+                                    {
+                                        Draft,
+                                        Submitted
+                                    }
+
+                                    public class Source
+                                    {
+                                        public OrderStatus Status { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public int Status { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        Document document = CreateDocument(testCode);
+        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(document);
+        List<CodeAction> actions = await RegisterActionsAsync(document, diagnostics);
+
+        CodeAction action = Assert.Single(actions);
+        Assert.Equal("Ignore property 'Status' (manual review)", action.Title);
+    }
+
     private static Document CreateDocument(string source)
     {
         var workspace = new AdhocWorkspace();


### PR DESCRIPTION
## Summary
- harden AM001 code fixes for enum-to-string and null-guarded string-to-enum property mismatches
- add focused AM001 fixer coverage for both enum conversion directions plus the conservative enum-to-numeric ignore-only path
- update docs/analyzer-health and bump v2.30.11

## Impact
This improves AM001 remediation by making the documented enum conversion scenario directly fixable while preserving manual-review ignore actions for domain-specific policies.

## Validation
- `/usr/local/share/dotnet/dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter AM001_CodeFixTests` passed with 11 tests
- `/usr/local/share/dotnet/dotnet run --project tools/AnalyzerVerifier/AnalyzerVerifier.csproj --configuration Release -- --check-catalog --check-snapshots` passed
- `/usr/local/share/dotnet/dotnet test automapper-analyser.sln --no-restore --framework net10.0` passed with 679 tests
- `git diff --check` clean
- CI covers full repository validation; local runtime has only .NET 10 available