### PR TITLE
Harden AM021 dictionary code fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,23 @@
 
 ### Changed
 
+### Validation
+
+## [2.30.12] - 2026-05-03
+
+### Changed
+
 - Hardened AM030 unused-converter analysis so simple `ITypeConverter<TSource, TDestination>` locals, fields, and properties initialized with concrete converters count as `ConvertUsing` usage.
 - Added AM030 regression coverage for interface-typed local, field, and property converter usage.
 - Updated AM030 docs and analyzer health status to describe the supported interface-typed converter usage boundary.
+- Hardened AM021 dictionary element mismatch code fixes so `KeyValuePair<TKey, TValue>` diagnostics no longer offer unsafe element `CreateMap` suggestions.
+- Added AM021 regression coverage proving dictionary mismatch diagnostics keep only the manual ignore action.
+- Updated AM021 docs and analyzer health status to describe the dictionary fixer safety boundary.
 
 ### Validation
 
 - Targeted AM030 analyzer tests.
+- Targeted AM021 analyzer and code fix tests.
 - Full `net10.0` solution test suite.
 - Rule catalog and sample diagnostics snapshot checks.
 - `git diff --check`.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet Version](https://img.shields.io/nuget/v/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=NuGet)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=Downloads)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/georgepwall1991/automapper-analyser/ci.yml?style=flat-square&logo=github&label=Build)](https://github.com/georgepwall1991/automapper-analyser/actions)
-[![Tests](https://img.shields.io/badge/Tests-675%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
+[![Tests](https://img.shields.io/badge/Tests-683%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
 [![.NET](https://img.shields.io/badge/.NET-4.8+%20%7C%206.0+%20%7C%208.0+%20%7C%209.0+%20%7C%2010.0+-512BD4?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 [![Coverage](https://img.shields.io/codecov/c/github/georgepwall1991/automapper-analyser?style=flat-square&logo=codecov&label=Coverage)](https://codecov.io/gh/georgepwall1991/automapper-analyser)
@@ -14,24 +14,25 @@ prevention*
 
 ---
 
-## 🎉 Latest Release: v2.30.11
+## 🎉 Latest Release: v2.30.12
 
-**AM001 Enum Conversion Fixes — direct enum/string mapping actions**
+**AM030 and AM021 Precision Hardening — safer converter usage and dictionary fixes**
 
 ✅ **Highlights**
 
-- Adds AM001 enum-to-string fixes using `ToString()`.
-- Adds AM001 string-to-enum fixes using null-guarded, fully qualified `Enum.Parse<TEnum>()`.
-- Keeps manual-review ignore actions available for domain-specific conversion policies.
+- Recognises interface-typed AM030 converter locals, fields, and properties when they are passed to `ConvertUsing`.
+- Keeps AM021 dictionary `KeyValuePair<TKey, TValue>` mismatch diagnostics on the manual-review path instead of offering unsafe element `CreateMap` scaffolding.
+- Keeps existing AM021 collection conversion fixes for safer list/array/queue/stack cases.
 
 🧪 **Validation**
 
 - Full solution test validation passed on `net10.0`.
-- Full test suite passed with `679` passing and `0` skipped.
-- Release validation covered targeted AM001 code fix tests plus full solution verification before tagging.
+- Full test suite passed with `683` passing and `0` skipped.
+- Release validation covered targeted AM021 tests, AnalyzerVerifier catalog/snapshot checks, and full solution verification before tagging.
 
 ### Recent Releases
 
+- **v2.30.12**: AM030 interface-typed converter usage and AM021 dictionary fixer safety.
 - **v2.30.11**: AM001 enum/string conversion fixes for direct property mismatch remediation.
 - **v2.30.10**: AM050 proven redundant `MapFrom` cleanup for string-based members and type-safe suppressions.
 - **v2.30.9**: AM004/AM005 severity documentation trust with descriptor-aligned rule docs.
@@ -179,7 +180,7 @@ Install-Package AutoMapperAnalyzer.Analyzers
 ### Project File (For CI/CD)
 
 ```xml
-<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.11">
+<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.12">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 </PackageReference>
@@ -373,6 +374,7 @@ This isn't just another analyzer—it's built for **enterprise-grade reliability
 
 ### Recently Completed ✅
 
+- **v2.30.12**: AM030 interface-typed converter usage and AM021 dictionary fixer safety
 - **v2.30.11**: AM001 enum/string conversion fixes for direct property mismatch remediation
 - **v2.30.10**: AM050 proven redundant `MapFrom` cleanup for string-based members and type-safe suppressions
 - **v2.30.9**: AM004/AM005 severity documentation trust with descriptor-aligned rule docs

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -1,6 +1,6 @@
 # Analyzer Health
 
-Reviewed: 2026-04-27
+Reviewed: 2026-05-03
 
 This is a deliberately harsh health audit for the 14 implemented AutoMapper analyzer rule IDs in this repository. Several rule IDs expose multiple diagnostic descriptors, especially `AM002`, `AM022`, `AM030`, and `AM031`; the scorecard rates the public rule ID as the user experiences it.
 
@@ -39,7 +39,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | AM006 | Destination property is not mapped | Data Integrity | Info | 4 | 4 | 4 | 4 | 4 | 4 | Low | Solid non-required counterpart to AM011 with flattening, reverse-map, ForPath, lookalike API, fuzzy-match, and bulk-ignore coverage; analyzer test count is lighter than AM004 but the risk is lower. |
 | AM011 | Required destination property is not mapped | Data Integrity | Error | 4 | 5 | 3 | 5 | 5 | 5 | Low | Important runtime-failure guardrail with required-member, reverse-map, constructor, custom-construction, and direct/nested ForPath coverage; fixer default/ignore actions are now documented as manual-review scaffolds. |
 | AM020 | Nested object mapping configuration missing | Complex Mappings | Warning | 4 | 4 | 4 | 5 | 5 | 5 | Low | The reference example in this repo: broad tests cover separate profiles, reverse maps, inheritance, records, interfaces, internal members, ForPath/string paths, and construction/conversion suppression. |
-| AM021 | Collection element type incompatibility | Complex Mappings | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | Good AM003 boundary discipline and recent fixer hardening for case-only names plus queue/stack output shape; keep expanding dictionary/custom-collection and reverse-map edge cases. |
+| AM021 | Collection element type incompatibility | Complex Mappings | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | Good AM003 boundary discipline and fixer hardening for case-only names plus queue/stack output shape; dictionary `KeyValuePair<,>` diagnostics now avoid unsafe element-`CreateMap` suggestions and keep only the manual ignore action. Remaining opportunities are custom-collection and reverse-map edge cases. |
 | AM022 | Infinite recursion risk | Complex Mappings | Warning | 4 | 4 | 4 | 5 | 5 | 4 | Low | Recursion diagnostics now require convention-mapped paths plus configured nested `CreateMap` chains for indirect cycles, and suppress forward `MaxDepth`, `PreserveReferences`, `ConvertUsing`, ignores, collections, and reverse-map boundaries. Remaining risk is the intentionally heuristic nature of graph analysis. |
 | AM030 | Custom type converter issues | Custom Conversions | Error/Warning/Info | 3 | 4 | 4 | 4 | 4 | 3 | Low | Unused-converter analysis now recognizes simple interface-typed converter locals, fields, and properties initialized with concrete converters and passed to `ConvertUsing(converter)`, alongside existing nullable-source fixer coverage. Remaining opportunities are mostly external DI/service-provider wiring and the mixed-concept shape of the single AM030 ID. |
 | AM031 | Performance warnings in mapping expressions | Performance | Warning/Info | 4 | 4 | 4 | 5 | 4 | 4 | Low | Multiple-enumeration diagnostics now normalize source-rooted collection paths, cache rewrites support nested source collections, unsafe captured-collection cache actions are suppressed, and Task-valued source-property `.Result` is covered. Remaining risk is mainly the intentionally heuristic nature of broad performance smells. |
@@ -62,6 +62,7 @@ The next improvement batch should focus on rules where user impact and health ga
 - AM001 fixer coverage now includes enum-to-string and null-guarded string-to-enum property mismatches, so the documented enum conversion scenario has an executable code action instead of only an ignore fallback.
 - AM050 now treats redundant cleanup as a proven safe rewrite: string-based destination members are resolved through `CreateMap<TSource, TDestination>()`, mismatched same-name types are suppressed, and fixer titles retain the destination member name.
 - AM030 now avoids unused-converter false positives when a converter is deliberately stored behind `ITypeConverter<TSource, TDestination>` before being passed to AutoMapper.
+- AM021 now reports dictionary key/value element mismatches without offering a misleading `CreateMap<KeyValuePair<...>, KeyValuePair<...>>()` fixer; dictionary diagnostics stay on the manual ignore/review path.
 - Analyzer ownership is a real strength. The conflict tests and shared helpers make `AM001`/`AM002`/`AM003`/`AM020`/`AM021` boundaries much healthier than a file-count audit would suggest.
 - The project now has a checked-in `RuleCatalog` health contract plus generated `docs/RULE_CATALOG.md` and sample diagnostic snapshots that tie rule IDs to descriptors, fixers, docs anchors, sample paths, and fixer trust levels.
 - Diagnostic placement is generally at the mapping invocation or mapping lambda, not always the precise property/member token. That is acceptable for many AutoMapper configuration rules, but high-volume rules benefit from tighter placement when practical.
@@ -73,9 +74,9 @@ Architecture-style coverage currently comes from analyzer/fixer tests, conflict 
 
 Current local verification:
 
-- `/usr/local/share/dotnet/dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter AM001_CodeFixTests` passed: 11 passed, 0 skipped, 0 failed.
-- `/usr/local/share/dotnet/dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter AM050` passed: 20 passed, 0 skipped, 0 failed.
-- `/usr/local/share/dotnet/dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter AM030_CustomTypeConverterTests` passed: 11 passed, 0 skipped, 0 failed.
-- `/usr/local/share/dotnet/dotnet test automapper-analyser.sln --no-restore --framework net10.0` passed: 682 passed, 0 skipped, 0 failed.
+- `/usr/local/share/dotnet/dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter AM021` passed: 38 passed, 0 skipped, 0 failed.
+- `/usr/local/share/dotnet/dotnet test automapper-analyser.sln --no-restore --framework net10.0` passed: 683 passed, 0 skipped, 0 failed.
+- `/usr/local/share/dotnet/dotnet run --project tools/AnalyzerVerifier/AnalyzerVerifier.csproj --configuration Release -- --check-catalog --check-snapshots` passed: rule catalog and sample diagnostics snapshot are up to date.
+- `git diff --check` passed.
 - The trust-first pass removed active skipped tests, added drift validation, and moved intentional analyzer-test warnings into an explicit test-project warning baseline.
 - `/opt/homebrew/bin/dotnet --list-runtimes` shows only .NET 10 runtimes in this local environment, so broader runtime verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/docs/ANALYZER_REVIEW_TRACKER.md
+++ b/docs/ANALYZER_REVIEW_TRACKER.md
@@ -37,6 +37,7 @@ Tracks analyzer-by-analyzer improvement passes focused on false positives, contr
 | AM004/AM005 docs trust | Data Integrity | main | v2.30.9 | Aligned rule docs with shipped Warning severity/category metadata and added catalog trust coverage that keeps documented severity lines descriptor-accurate. |
 | AM050 (2nd pass) | Configuration | main | v2.30.10 | Required proven source/destination type compatibility before reporting redundant `MapFrom`, including string-based `ForMember` destination members resolved from `CreateMap`. |
 | AM001 (2nd pass) | Type Safety | main | v2.30.11 | Added direct enum-to-string and string-to-enum conversion fixes for documented AM001 enum mismatch scenarios. |
+| AM030 + AM021 follow-up | Complex Mappings | main | v2.30.12 | Recognized interface-typed converter usage for AM030 and kept AM021 dictionary `KeyValuePair<,>` mismatch diagnostics on the manual-review fixer path. |
 
 ## In Progress
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -724,7 +724,7 @@ dotnet pack --configuration Release
 
 # Test package locally
 cd test-install/NetCoreTest
-dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.11-local
+dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.12-local
 ```
 
 ---
@@ -908,4 +908,4 @@ dotnet build
 
 **Last Updated**: 2025-11-19
 **Maintainer**: George Wall
-**Version**: 2.30.11
+**Version**: 2.30.12

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -57,7 +57,7 @@ The AutoMapper Roslyn Analyzer project uses GitHub Actions for continuous integr
 
 **Triggers:**
 
-- Semantic version tags such as `v2.30.11`
+- Semantic version tags such as `v2.30.12`
 
 **Features:**
 
@@ -112,8 +112,8 @@ The AutoMapper Roslyn Analyzer project uses GitHub Actions for continuous integr
 ### Package Versioning
 
 - **Format**: Major.Minor.Patch (SemVer)
-- **Current**: 2.30.11
-- **Pre-release**: 2.30.11-preview, 2.30.11-beta
+- **Current**: 2.30.12
+- **Pre-release**: 2.30.12-preview, 2.30.12-beta
 
 ## 🔧 Configuration
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -43,7 +43,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.11">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.12">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -67,7 +67,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.11">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.12">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -86,7 +86,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="14.0.0" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.11">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.12">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -218,7 +218,7 @@ public class Destination
 
 2. **Verify Package Installation**
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.11">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.12">
      <PrivateAssets>all</PrivateAssets>
      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -280,4 +280,4 @@ This guide ensures smooth installation and usage across all supported .NET frame
 ---
 
 **Last Updated**: November 19, 2025
-**Version**: 2.30.11
+**Version**: 2.30.12

--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -1298,7 +1298,7 @@ using System.Diagnostics.CodeAnalysis;
 
 1. **Check package reference**:
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.11">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.12">
        <PrivateAssets>all</PrivateAssets>
        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>

--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -742,6 +742,8 @@ public class MappingProfile : Profile
 
 If collection containers are incompatible (`HashSet<T>` vs `List<T>`, `Queue<T>` vs `Stack<T>`, etc.), `AM003` owns the diagnostic. AM003 stays quiet when the source collection is already assignable to the destination collection contract.
 
+Dictionary value/key mismatches are treated as `KeyValuePair<TKey, TValue>` element mismatches. For those diagnostics the fixer intentionally offers only the manual ignore action, because adding a `CreateMap<KeyValuePair<...>, KeyValuePair<...>>()` registration is not a reliable executable rewrite.
+
 #### Solution
 
 **Code Fix: Add CreateMap for Element Types**

--- a/docs/RULE_CATALOG.md
+++ b/docs/RULE_CATALOG.md
@@ -2,7 +2,7 @@
 
 This file is generated from `RuleCatalog`.
 
-Package version: `2.30.11`
+Package version: `2.30.12`
 
 | Rule ID | Descriptor Title | Severity | Category | Analyzer | Code Fix | Trust | Sample | Docs |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,3 +1,15 @@
+## Release 2.30.12
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
+### Removed Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
 ## Release 2.30.11
 
 ### New Rules

--- a/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
+++ b/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
@@ -17,7 +17,7 @@
         <!-- Fallback for local builds: 2.0.YYYYMMDD-local -->
         <MajorVersion>2</MajorVersion>
         <MinorVersion>30</MinorVersion>
-        <PatchVersion>11</PatchVersion>
+        <PatchVersion>12</PatchVersion>
         <BuildNumber Condition="'$(BuildNumber)' == ''"
         >$([System.DateTime]::Now.ToString('yyyyMMdd'))
         </BuildNumber
@@ -32,18 +32,19 @@
         <RepositoryUrl>https://github.com/georgepwall1991/automapper-analyser</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <PackageReleaseNotes>Version 2.30.11 - AM001 enum conversion fixer
+        <PackageReleaseNotes>Version 2.30.12 - AM030 and AM021 precision hardening
 
             Changed:
-            - Added AM001 code fixes for enum-to-string mappings using ToString()
-            - Added AM001 code fixes for string-to-enum mappings using null-guarded, fully qualified Enum.Parse&lt;TEnum&gt;()
-            - Added focused AM001 fixer coverage for both enum conversion directions
+            - Hardened AM030 unused-converter analysis for interface-typed converter locals, fields, and properties
+            - Hardened AM021 dictionary diagnostics so KeyValuePair element mismatches do not offer unsafe element CreateMap suggestions
+            - Updated docs, health notes, and release metadata for the safer AM030/AM021 boundaries
 
             Validation:
-            - Full solution test suite passing on net10.0 with targeted AM001 coverage
+            - Full solution test suite passing on net10.0 with targeted AM021 coverage
+            - Rule catalog and sample diagnostics snapshot checks passing
             - git diff --check clean
 
-            Previous Release: v2.30.10 - AM050 proven redundant MapFrom cleanup
+            Previous Release: v2.30.11 - AM001 enum conversion fixer
         </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>

--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM021_CollectionElementMismatchCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM021_CollectionElementMismatchCodeFixProvider.cs
@@ -108,8 +108,11 @@ public class AM021_CollectionElementMismatchCodeFixProvider : AutoMapperCodeFixP
             }
             else
             {
-                RegisterComplexMappingFix(context, operationContext.Root, invocation, destinationPropertyNameValue, sourceElementType!,
-                    destElementType!, diagnostic, operationContext.SemanticModel);
+                if (!IsKeyValuePairType(sourceElementType!) && !IsKeyValuePairType(destElementType!))
+                {
+                    RegisterComplexMappingFix(context, operationContext.Root, invocation, destinationPropertyNameValue, sourceElementType!,
+                        destElementType!, diagnostic, operationContext.SemanticModel);
+                }
             }
 
             context.RegisterCodeFix(
@@ -351,6 +354,14 @@ public class AM021_CollectionElementMismatchCodeFixProvider : AutoMapperCodeFixP
     private static bool IsSimpleTypeConversion(string sourceElementType, string destElementType)
     {
         return IsSimpleConversionType(sourceElementType) && IsSimpleConversionType(destElementType);
+    }
+
+    private static bool IsKeyValuePairType(string typeName)
+    {
+        string normalizedType = typeName.Trim();
+        return normalizedType.StartsWith("System.Collections.Generic.KeyValuePair<", StringComparison.Ordinal) ||
+               normalizedType.StartsWith("global::System.Collections.Generic.KeyValuePair<", StringComparison.Ordinal) ||
+               normalizedType.StartsWith("KeyValuePair<", StringComparison.Ordinal);
     }
 
     private static string GetConversionMethod(string destElementType)

--- a/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
@@ -99,7 +99,7 @@ public static class RuleCatalog
     /// <summary>
     ///     Current package version used by docs/package drift tests.
     /// </summary>
-    public const string CurrentPackageVersion = "2.30.11";
+    public const string CurrentPackageVersion = "2.30.12";
 
     /// <summary>
     ///     Implemented rules, grouped by public diagnostic ID.

--- a/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM021_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM021_CodeFixTests.cs
@@ -1,5 +1,14 @@
+using System.Collections.Immutable;
+using System.IO;
+using AutoMapper;
 using AutoMapperAnalyzer.Analyzers.ComplexMappings;
 using AutoMapperAnalyzer.Tests.Infrastructure;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Testing;
 
 namespace AutoMapperAnalyzer.Tests.ComplexMappings;
@@ -509,6 +518,46 @@ public class AM021_CodeFixTests
     }
 
     [Fact]
+    public async Task AM021_ShouldOnlyOfferIgnore_WhenDictionaryValueTypesMismatch()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Collections.Generic;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public Dictionary<string, int> Data { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public Dictionary<string, string> Data { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        Document document = CreateDocument(testCode);
+        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(document);
+        Diagnostic diagnostic = Assert.Single(diagnostics);
+        List<CodeAction> actions = await RegisterActionsAsync(document, diagnostic);
+
+        CodeAction action = Assert.Single(actions);
+        Assert.Equal("Ignore property 'Data' (manual review)", action.Title);
+        Assert.DoesNotContain(actions, codeAction =>
+            codeAction.Title.StartsWith("Add CreateMap<", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task AM021_ShouldFixCaseOnlyPropertyMismatch_UsingSourceAndDestinationNamesSeparately()
     {
         const string testCode = """
@@ -682,5 +731,59 @@ public class AM021_CodeFixTests
 
         await AnalyzerVerifier<AM021_CollectionElementMismatchAnalyzer>
             .VerifyAnalyzerAsync(testCode);
+    }
+
+    private static Document CreateDocument(string source)
+    {
+        var workspace = new AdhocWorkspace();
+        ProjectId projectId = ProjectId.CreateNewId();
+        DocumentId documentId = DocumentId.CreateNewId(projectId);
+
+        Solution solution = workspace.CurrentSolution
+            .AddProject(projectId, "AM021Tests", "AM021Tests", LanguageNames.CSharp)
+            .WithProjectCompilationOptions(projectId, new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+            .WithProjectParseOptions(projectId, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+
+        string trustedPlatformAssemblies = (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") ?? string.Empty;
+        foreach (string assemblyPath in trustedPlatformAssemblies.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(assemblyPath))
+            {
+                solution = solution.AddMetadataReference(projectId, MetadataReference.CreateFromFile(assemblyPath));
+            }
+        }
+
+        solution = solution
+            .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(Profile).Assembly.Location))
+            .AddDocument(documentId, "Test0.cs", SourceText.From(source));
+
+        return solution.GetDocument(documentId)!;
+    }
+
+    private static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(Document document)
+    {
+        Compilation compilation = (await document.Project.GetCompilationAsync())!;
+        return (await compilation.WithAnalyzers(
+                ImmutableArray.Create<DiagnosticAnalyzer>(new AM021_CollectionElementMismatchAnalyzer()))
+            .GetAnalyzerDiagnosticsAsync())
+            .OrderBy(diagnostic => diagnostic.Location.SourceSpan.Start)
+            .ThenBy(diagnostic => diagnostic.GetMessage(), StringComparer.Ordinal)
+            .ToImmutableArray();
+    }
+
+    private static async Task<List<CodeAction>> RegisterActionsAsync(Document document, params Diagnostic[] diagnostics)
+    {
+        var actions = new List<CodeAction>();
+        var provider = new AM021_CollectionElementMismatchCodeFixProvider();
+
+        var context = new CodeFixContext(
+            document,
+            diagnostics[0].Location.SourceSpan,
+            diagnostics.ToImmutableArray(),
+            (action, _) => actions.Add(action),
+            CancellationToken.None);
+
+        await provider.RegisterCodeFixesAsync(context);
+        return actions;
     }
 }


### PR DESCRIPTION
## Summary
- harden AM021 code-fix routing so dictionary KeyValuePair element mismatches do not offer unsafe element CreateMap suggestions
- add regression coverage proving dictionary mismatch diagnostics keep only the manual ignore action
- prepare v2.30.12 release metadata across package, changelog, README, catalog docs, and tracker files

## Impact
This keeps AM021 diagnostics useful while preventing a misleading dictionary fixer path from generating unreliable KeyValuePair mapping registrations. The release also includes the already-unreleased AM030 interface-typed converter usage hardening in v2.30.12 metadata.

## Validation
- /usr/local/share/dotnet/dotnet restore automapper-analyser.sln
- /usr/local/share/dotnet/dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter AM021
- /usr/local/share/dotnet/dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter "AM021|RuleCatalogTests"
- /usr/local/share/dotnet/dotnet test automapper-analyser.sln --no-restore --framework net10.0
- /usr/local/share/dotnet/dotnet run --project tools/AnalyzerVerifier/AnalyzerVerifier.csproj --configuration Release -- --check-catalog --check-snapshots
- git diff --check
- PR CI/CD Pipeline run 275 passed