### PR TITLE
test: lock AM050 sibling-config withhold behavior with PreCondition/UseDestinationValue/Ignore tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+## [2.30.26] - 2026-05-14
+
+### Changed
+
+- Added direct AM050 code-fix test coverage for the three sibling member-options previously only covered by the generic `ForMemberLambdaContainsOnlyTheMapFrom` structural check: `PreCondition`, `UseDestinationValue`, and `Ignore`. The structural check already withholds the automatic `ForMember`-removal action whenever the options lambda contains anything besides the redundant `MapFrom`; the new tests lock that contract directly so a future refactor narrowing the structural check to a known-sibling list would fail tests.
+
+### Validation
+
+- Targeted AM050 code-fix tests (5 sibling-config cases now green: Condition, NullSubstitute, PreCondition, UseDestinationValue, Ignore).
+- Full solution test suite (`net10.0`) green.
+- AnalyzerVerifier `--check-catalog --check-snapshots` green.
+
 ## [2.30.25] - 2026-05-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -14,14 +14,13 @@ prevention*
 
 ---
 
-## 🎉 Latest Release: v2.30.25
+## 🎉 Latest Release: v2.30.26
 
-**Fix rule documentation category drift and add a category drift guard**
+**Lock AM050 sibling-config withhold behavior with direct `PreCondition`/`UseDestinationValue`/`Ignore` tests**
 
 ✅ **Highlights**
 
-- Corrected six rule documentation `**Category**:` lines in `docs/DIAGNOSTIC_RULES.md` to match the descriptor categories actually shipped: AM002 (`TypeSafety` → `NullSafety`), AM011 (`DataIntegrity` → `RequiredProperties`), AM020 (`ComplexMappings` → `NestedObjects`), AM021 (`ComplexMappings` → `Collections`), AM022 (`ComplexMappings` → `Recursion`), AM030 (`CustomConversions` → `Converters`). The descriptors themselves were unchanged; only the docs had drifted.
-- Added `RuleCatalogTests.RuleDocs_ShouldDocumentDescriptorCategories` as a trust drift guard that asserts the `**Category**:` line in each rule's documentation section names every distinct `descriptor.Category` for that rule. This mirrors the existing severity drift guard and prevents future drift in either direction.
+- Added direct AM050 code-fix test coverage for three sibling member-options previously only covered by the generic structural check: `PreCondition`, `UseDestinationValue`, and `Ignore`. The check still withholds the automatic `ForMember`-removal whenever the options lambda contains anything besides the redundant `MapFrom`; the new tests lock that contract directly so a future refactor narrowing the check to a known-sibling list would fail tests.
 
 🧪 **Validation**
 
@@ -30,6 +29,7 @@ prevention*
 
 ### Recent Releases
 
+- **v2.30.26**: Locked AM050 sibling-config withhold behavior with direct `PreCondition`/`UseDestinationValue`/`Ignore` regression tests alongside the existing `Condition`/`NullSubstitute` cases.
 - **v2.30.25**: Corrected six AM002/AM011/AM020/AM021/AM022/AM030 rule-docs category lines to match the shipped descriptor categories and added a category drift guard that prevents future doc/descriptor drift.
 - **v2.30.24**: Marked unwired AM003/AM030 `DiagnosticDescriptor` relics `[Obsolete]` (binary compatibility preserved) and added a trust drift guard that fails when any shipped analyzer declares a `DiagnosticDescriptor` field outside its `SupportedDiagnostics` without an explicit Obsolete attribute.
 - **v2.30.23**: AM050 code fix is withheld when the redundant-`MapFrom` `ForMember` lambda contains sibling configuration (`Condition`, `NullSubstitute`, …) that would otherwise be dropped.
@@ -191,7 +191,7 @@ Install-Package AutoMapperAnalyzer.Analyzers
 ### Project File (For CI/CD)
 
 ```xml
-<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.25">
+<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.26">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 </PackageReference>

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -70,7 +70,7 @@ The Planning Shortlist above summarises overall rule priority; this backlog is t
 
 ### P2 — Opportunistic, when adjacent work is open
 
-- **AM050 sibling-config direct coverage.** The Notes name `Condition`, `NullSubstitute`, `PreCondition`, `UseDestinationValue`, and `Ignore` as withhold cases. The generic structural check in `AM050_RedundantMapFromCodeFixProvider.cs:64-89` does cover all five, but dedicated tests exist only for `Condition` and `NullSubstitute` (`tests/.../AM050_CodeFixTests.cs:606, 642, 678`). Adding direct tests for `PreCondition`, `UseDestinationValue`, and `Ignore` would lock the behavior against future refactors.
+- _AM050 sibling-config direct coverage — resolved in 2.30.26._ Direct tests for `PreCondition`, `UseDestinationValue`, and `Ignore` now sit alongside the pre-existing `Condition`/`NullSubstitute` cases, so the generic structural check is locked against future narrowing.
 - **AM041 `ForPath` chained-config test.** The Notes and cross-cutting findings claim chained `ForPath` configuration also withholds the duplicate-removal fix. The generic algorithm in `IsCreateMapWithUnsafeChainedConfiguration` covers it, but `AM041_CodeFixTests.cs` has no `ForPath`-specific case. Add at least one to make the claim directly test-backed.
 - **Tighten diagnostic placement** for high-volume rules (AM004 / AM006) where the diagnostic currently lands on the mapping invocation rather than the offending property token. The cross-cutting note already calls this out as acceptable but improvable when practical — no owner yet.
 
@@ -132,9 +132,9 @@ Current local verification:
 - `/usr/local/share/dotnet/dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter AM030` passed: 32 passed, 0 skipped, 0 failed.
 - `/usr/local/share/dotnet/dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter AM031` passed: 49 passed, 0 skipped, 0 failed.
 - `/usr/local/share/dotnet/dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter AM041` passed: 25 passed, 0 skipped, 0 failed.
-- `/usr/local/share/dotnet/dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter AM050` passed: 27 passed, 0 skipped, 0 failed.
+- `/usr/local/share/dotnet/dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter AM050` passed: 30 passed, 0 skipped, 0 failed.
 - `/usr/local/share/dotnet/dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter RuleCatalogTests` passed: 10 passed, 0 skipped, 0 failed.
-- `/usr/local/share/dotnet/dotnet test automapper-analyser.sln --no-restore --framework net10.0` passed: 780 passed, 0 skipped, 0 failed.
+- `/usr/local/share/dotnet/dotnet test automapper-analyser.sln --no-restore --framework net10.0` passed: 783 passed, 0 skipped, 0 failed.
 - `/usr/local/share/dotnet/dotnet run --project tools/AnalyzerVerifier/AnalyzerVerifier.csproj --configuration Release -- --check-catalog --check-snapshots` passed: rule catalog and sample diagnostics snapshot are up to date.
 - `git diff --check` passed.
 - The trust-first pass removed active skipped tests, added drift validation, and moved intentional analyzer-test warnings into an explicit test-project warning baseline.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -725,7 +725,7 @@ dotnet pack --configuration Release
 
 # Test package locally
 cd test-install/NetCoreTest
-dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.25-local
+dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.26-local
 ```
 
 ---
@@ -909,4 +909,4 @@ dotnet build
 
 **Last Updated**: 2026-05-14
 **Maintainer**: George Wall
-**Version**: 2.30.25
+**Version**: 2.30.26

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -112,8 +112,8 @@ The AutoMapper Roslyn Analyzer project uses GitHub Actions for continuous integr
 ### Package Versioning
 
 - **Format**: Major.Minor.Patch (SemVer)
-- **Current**: 2.30.25
-- **Pre-release**: 2.30.25-preview, 2.30.25-beta
+- **Current**: 2.30.26
+- **Pre-release**: 2.30.26-preview, 2.30.26-beta
 
 ## 🔧 Configuration
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -43,7 +43,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.25">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.26">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -67,7 +67,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.25">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.26">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -86,7 +86,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="14.0.0" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.25">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.26">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -218,7 +218,7 @@ public class Destination
 
 2. **Verify Package Installation**
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.25">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.26">
      <PrivateAssets>all</PrivateAssets>
      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -280,4 +280,4 @@ This guide ensures smooth installation and usage across all supported .NET frame
 ---
 
 **Last Updated**: 2026-05-14
-**Version**: 2.30.25
+**Version**: 2.30.26

--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -1343,7 +1343,7 @@ using System.Diagnostics.CodeAnalysis;
 
 1. **Check package reference**:
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.25">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.26">
        <PrivateAssets>all</PrivateAssets>
        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -1382,5 +1382,5 @@ If analyzer slows down builds:
 ---
 
 **Last Updated**: 2026-05-14
-**Version**: 2.30.25
+**Version**: 2.30.26
 **Maintainer**: George Wall

--- a/docs/RULE_CATALOG.md
+++ b/docs/RULE_CATALOG.md
@@ -2,7 +2,7 @@
 
 This file is generated from `RuleCatalog`.
 
-Package version: `2.30.25`
+Package version: `2.30.26`
 
 | Rule ID | Descriptor Title | Severity | Category | Analyzer | Code Fix | Trust | Sample | Docs |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,3 +1,15 @@
+## Release 2.30.26
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
+### Removed Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
 ## Release 2.30.25
 
 ### New Rules

--- a/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
+++ b/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
@@ -17,7 +17,7 @@
         <!-- Fallback for local builds: 2.0.YYYYMMDD-local -->
         <MajorVersion>2</MajorVersion>
         <MinorVersion>30</MinorVersion>
-        <PatchVersion>25</PatchVersion>
+        <PatchVersion>26</PatchVersion>
         <BuildNumber Condition="'$(BuildNumber)' == ''"
         >$([System.DateTime]::Now.ToString('yyyyMMdd'))
         </BuildNumber
@@ -32,18 +32,18 @@
         <RepositoryUrl>https://github.com/georgepwall1991/automapper-analyser</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <PackageReleaseNotes>Version 2.30.25 - Fix rule documentation category drift and add a category drift guard
+        <PackageReleaseNotes>Version 2.30.26 - Lock AM050 sibling-config withhold behavior with direct PreCondition/UseDestinationValue/Ignore tests
 
             Changed:
-            - Corrected six rule documentation `**Category**:` lines in `docs/DIAGNOSTIC_RULES.md` to match the descriptor categories actually shipped: AM002 (TypeSafety -> NullSafety), AM011 (DataIntegrity -> RequiredProperties), AM020 (ComplexMappings -> NestedObjects), AM021 (ComplexMappings -> Collections), AM022 (ComplexMappings -> Recursion), AM030 (CustomConversions -> Converters). The descriptors themselves were unchanged; the docs had drifted away from the shipped categories
-            - Added a new `RuleCatalogTests.RuleDocs_ShouldDocumentDescriptorCategories` drift guard that asserts the `**Category**:` line in each rule's documentation section names every distinct `descriptor.Category` for that rule. This mirrors the existing severity drift guard and prevents future drift in either direction (docs ahead of descriptors or descriptors ahead of docs)
+            - Added direct AM050 code-fix test coverage for the three sibling member-options previously only covered by the generic `ForMemberLambdaContainsOnlyTheMapFrom` structural check: `PreCondition`, `UseDestinationValue`, and `Ignore`. The structural check already withholds the automatic `ForMember`-removal action whenever the options lambda contains anything besides the redundant `MapFrom`, so the diagnostic still fires while the unsafe automatic action stays suppressed
+            - The new tests lock the sibling-config withhold contract directly so a future refactor narrowing the structural check to a known-sibling list would now fail tests
 
             Validation:
-            - Full solution test suite passing on net10.0 with targeted RuleCatalog coverage
+            - Full solution test suite passing on net10.0 with targeted AM050 code-fix coverage
             - Rule catalog and sample diagnostics snapshot checks passing
             - git diff --check clean
 
-            Previous Release: v2.30.24 - Mark unwired AM003/AM030 DiagnosticDescriptor relics Obsolete
+            Previous Release: v2.30.25 - Fix rule documentation category drift and add a category drift guard
         </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>

--- a/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
@@ -130,7 +130,7 @@ public static class RuleCatalog
     /// <summary>
     ///     Current package version used by docs/package drift tests.
     /// </summary>
-    public const string CurrentPackageVersion = "2.30.25";
+    public const string CurrentPackageVersion = "2.30.26";
 
     /// <summary>
     ///     Implemented rules, grouped by public diagnostic ID.

--- a/tests/AutoMapperAnalyzer.Tests/Configuration/AM050_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Configuration/AM050_CodeFixTests.cs
@@ -676,6 +676,114 @@ public class AM050_CodeFixTests
     }
 
     [Fact]
+    public async Task Should_NotOfferFix_WhenForMemberLambdaHasSiblingPreCondition()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                public class Source { public string Name { get; set; } }
+                                public class Destination { public string Name { get; set; } }
+
+                                public class MyProfile : Profile
+                                {
+                                    public MyProfile()
+                                    {
+                                        CreateMap<Source, Destination>()
+                                            .ForMember(d => d.Name, o =>
+                                            {
+                                                o.MapFrom(s => s.Name);
+                                                o.PreCondition((src, ctx) => src.Name != null);
+                                            });
+                                    }
+                                }
+                                """;
+
+        Document document = CreateDocument(testCode);
+        Compilation compilation = (await document.Project.GetCompilationAsync())!;
+        Diagnostic diagnostic = (await compilation.WithAnalyzers(
+                ImmutableArray.Create<DiagnosticAnalyzer>(new AM050_RedundantMapFromAnalyzer()))
+            .GetAnalyzerDiagnosticsAsync())
+            .Single();
+
+        Assert.Equal("AM050", diagnostic.Id);
+
+        List<CodeAction> actions = await RegisterActionsAsync(document, diagnostic);
+        Assert.Empty(actions);
+    }
+
+    [Fact]
+    public async Task Should_NotOfferFix_WhenForMemberLambdaHasSiblingUseDestinationValue()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                public class Source { public string Name { get; set; } }
+                                public class Destination { public string Name { get; set; } }
+
+                                public class MyProfile : Profile
+                                {
+                                    public MyProfile()
+                                    {
+                                        CreateMap<Source, Destination>()
+                                            .ForMember(d => d.Name, o =>
+                                            {
+                                                o.MapFrom(s => s.Name);
+                                                o.UseDestinationValue();
+                                            });
+                                    }
+                                }
+                                """;
+
+        Document document = CreateDocument(testCode);
+        Compilation compilation = (await document.Project.GetCompilationAsync())!;
+        Diagnostic diagnostic = (await compilation.WithAnalyzers(
+                ImmutableArray.Create<DiagnosticAnalyzer>(new AM050_RedundantMapFromAnalyzer()))
+            .GetAnalyzerDiagnosticsAsync())
+            .Single();
+
+        Assert.Equal("AM050", diagnostic.Id);
+
+        List<CodeAction> actions = await RegisterActionsAsync(document, diagnostic);
+        Assert.Empty(actions);
+    }
+
+    [Fact]
+    public async Task Should_NotOfferFix_WhenForMemberLambdaHasSiblingIgnore()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                public class Source { public string Name { get; set; } }
+                                public class Destination { public string Name { get; set; } }
+
+                                public class MyProfile : Profile
+                                {
+                                    public MyProfile()
+                                    {
+                                        CreateMap<Source, Destination>()
+                                            .ForMember(d => d.Name, o =>
+                                            {
+                                                o.MapFrom(s => s.Name);
+                                                o.Ignore();
+                                            });
+                                    }
+                                }
+                                """;
+
+        Document document = CreateDocument(testCode);
+        Compilation compilation = (await document.Project.GetCompilationAsync())!;
+        Diagnostic diagnostic = (await compilation.WithAnalyzers(
+                ImmutableArray.Create<DiagnosticAnalyzer>(new AM050_RedundantMapFromAnalyzer()))
+            .GetAnalyzerDiagnosticsAsync())
+            .Single();
+
+        Assert.Equal("AM050", diagnostic.Id);
+
+        List<CodeAction> actions = await RegisterActionsAsync(document, diagnostic);
+        Assert.Empty(actions);
+    }
+
+    [Fact]
     public async Task Should_NotOfferFix_WhenParenthesizedOptionsLambdaHasSiblingConfiguration()
     {
         const string testCode = """


### PR DESCRIPTION
## Summary

- AM050's automatic `ForMember`-removal code action is gated by a structural check (`ForMemberLambdaContainsOnlyTheMapFrom`) that only offers the fix when the options lambda body is exactly the redundant `MapFrom` invocation. Every other sibling member-option (recognized or not) makes the check return false and suppresses the action.
- Until now, only `Condition` and `NullSubstitute` had direct test coverage of that contract. The remaining three known siblings — `PreCondition`, `UseDestinationValue`, `Ignore` — relied implicitly on the generic structural check.
- Added three new code-fix tests that assert AM050 still **reports** the redundant `MapFrom` for each of those siblings while the automatic action is **suppressed**. The tests pass on day 1 (algorithm already correct) — their value is locking the contract so a future refactor narrowing the check to a known-sibling list would fail tests instead of silently allowing an unsafe rewrite.

## Impact

- No diagnostic or code-fix behaviour change.
- Resolves the AM050 sibling-config P2 entry from `analyzer-health.md`.
- Patch bump (`2.30.25` → `2.30.26`): pure regression coverage; no analyzer/fixer code change, no public surface change.

## Test plan

- [x] Targeted: `dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --framework net10.0 --filter "Should_NotOfferFix_WhenForMemberLambdaHasSibling"` (5 sibling-config cases now green: Condition, NullSubstitute, PreCondition, UseDestinationValue, Ignore).
- [x] Full suite: `dotnet test automapper-analyser.sln --configuration Release --framework net10.0` (783 passed, 0 skipped, 0 failed).
- [x] Verifier: `dotnet run --project tools/AnalyzerVerifier/AnalyzerVerifier.csproj --configuration Release -- --check-catalog --check-snapshots` green.
- [x] Codex `codex review --uncommitted` — no actionable findings; explicit "Yes, meaningful improvement" judgment confirming the locking value of the new direct coverage.