### PR TITLE
test: lock AM041 ForPath chained-configuration withhold behavior with a direct test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+## [2.30.27] - 2026-05-14
+
+### Changed
+
+- Added direct AM041 code-fix coverage for the duplicate-`CreateMap` removal action being withheld when the duplicate carries chained `ForPath(...)` configuration. The generic `IsCreateMapWithUnsafeChainedConfiguration` algorithm in `AM041_DuplicateMappingCodeFixProvider` already covers this shape (any chained call besides bare `.ReverseMap()` is unsafe to remove); the new test locks the contract so a future refactor narrowing the structural check to a known-method list (e.g. `ForMember` only) would now fail tests.
+
+### Validation
+
+- Targeted AM041 code-fix test slice.
+- Full solution test suite (`net10.0`) green.
+- AnalyzerVerifier `--check-catalog --check-snapshots` green.
+
 ## [2.30.26] - 2026-05-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ prevention*
 
 ---
 
-## 🎉 Latest Release: v2.30.26
+## 🎉 Latest Release: v2.30.27
 
-**Lock AM050 sibling-config withhold behavior with direct `PreCondition`/`UseDestinationValue`/`Ignore` tests**
+**Lock AM041 `ForPath` chained-configuration withhold behavior with a direct test**
 
 ✅ **Highlights**
 
-- Added direct AM050 code-fix test coverage for three sibling member-options previously only covered by the generic structural check: `PreCondition`, `UseDestinationValue`, and `Ignore`. The check still withholds the automatic `ForMember`-removal whenever the options lambda contains anything besides the redundant `MapFrom`; the new tests lock that contract directly so a future refactor narrowing the check to a known-sibling list would fail tests.
+- Added a direct AM041 code-fix test asserting that the duplicate `CreateMap` removal action is withheld when the duplicate carries chained `ForPath(...)` configuration. The structural withhold algorithm already handles this shape (any chained call besides bare `.ReverseMap()` is unsafe to remove); the new test makes the documented `ForPath` claim test-backed and locks the contract against future narrowing to a known-method list.
 
 🧪 **Validation**
 
@@ -29,6 +29,7 @@ prevention*
 
 ### Recent Releases
 
+- **v2.30.27**: Added a direct AM041 test locking the `ForPath` chained-configuration withhold behavior alongside the existing `ForMember`/parenthesized/`ReverseMap()`-chained coverage.
 - **v2.30.26**: Locked AM050 sibling-config withhold behavior with direct `PreCondition`/`UseDestinationValue`/`Ignore` regression tests alongside the existing `Condition`/`NullSubstitute` cases.
 - **v2.30.25**: Corrected six AM002/AM011/AM020/AM021/AM022/AM030 rule-docs category lines to match the shipped descriptor categories and added a category drift guard that prevents future doc/descriptor drift.
 - **v2.30.24**: Marked unwired AM003/AM030 `DiagnosticDescriptor` relics `[Obsolete]` (binary compatibility preserved) and added a trust drift guard that fails when any shipped analyzer declares a `DiagnosticDescriptor` field outside its `SupportedDiagnostics` without an explicit Obsolete attribute.
@@ -191,7 +192,7 @@ Install-Package AutoMapperAnalyzer.Analyzers
 ### Project File (For CI/CD)
 
 ```xml
-<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.26">
+<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.27">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 </PackageReference>

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -71,7 +71,7 @@ The Planning Shortlist above summarises overall rule priority; this backlog is t
 ### P2 — Opportunistic, when adjacent work is open
 
 - _AM050 sibling-config direct coverage — resolved in 2.30.26._ Direct tests for `PreCondition`, `UseDestinationValue`, and `Ignore` now sit alongside the pre-existing `Condition`/`NullSubstitute` cases, so the generic structural check is locked against future narrowing.
-- **AM041 `ForPath` chained-config test.** The Notes and cross-cutting findings claim chained `ForPath` configuration also withholds the duplicate-removal fix. The generic algorithm in `IsCreateMapWithUnsafeChainedConfiguration` covers it, but `AM041_CodeFixTests.cs` has no `ForPath`-specific case. Add at least one to make the claim directly test-backed.
+- _AM041 `ForPath` chained-config test — resolved in 2.30.27._ The duplicate-removal fix withhold for `CreateMap<>().ForPath(...)` shapes now has direct test coverage alongside the pre-existing `ForMember`/parenthesized/`ReverseMap()`-chained cases.
 - **Tighten diagnostic placement** for high-volume rules (AM004 / AM006) where the diagnostic currently lands on the mapping invocation rather than the offending property token. The cross-cutting note already calls this out as acceptable but improvable when practical — no owner yet.
 
 ### P3 — Directional, longer-horizon
@@ -131,10 +131,10 @@ Current local verification:
 - `/usr/local/share/dotnet/dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter AM022` passed: 78 passed, 0 skipped, 0 failed.
 - `/usr/local/share/dotnet/dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter AM030` passed: 32 passed, 0 skipped, 0 failed.
 - `/usr/local/share/dotnet/dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter AM031` passed: 49 passed, 0 skipped, 0 failed.
-- `/usr/local/share/dotnet/dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter AM041` passed: 25 passed, 0 skipped, 0 failed.
+- `/usr/local/share/dotnet/dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter AM041` passed: 26 passed, 0 skipped, 0 failed.
 - `/usr/local/share/dotnet/dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter AM050` passed: 30 passed, 0 skipped, 0 failed.
 - `/usr/local/share/dotnet/dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter RuleCatalogTests` passed: 10 passed, 0 skipped, 0 failed.
-- `/usr/local/share/dotnet/dotnet test automapper-analyser.sln --no-restore --framework net10.0` passed: 783 passed, 0 skipped, 0 failed.
+- `/usr/local/share/dotnet/dotnet test automapper-analyser.sln --no-restore --framework net10.0` passed: 784 passed, 0 skipped, 0 failed.
 - `/usr/local/share/dotnet/dotnet run --project tools/AnalyzerVerifier/AnalyzerVerifier.csproj --configuration Release -- --check-catalog --check-snapshots` passed: rule catalog and sample diagnostics snapshot are up to date.
 - `git diff --check` passed.
 - The trust-first pass removed active skipped tests, added drift validation, and moved intentional analyzer-test warnings into an explicit test-project warning baseline.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -725,7 +725,7 @@ dotnet pack --configuration Release
 
 # Test package locally
 cd test-install/NetCoreTest
-dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.26-local
+dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.27-local
 ```
 
 ---
@@ -909,4 +909,4 @@ dotnet build
 
 **Last Updated**: 2026-05-14
 **Maintainer**: George Wall
-**Version**: 2.30.26
+**Version**: 2.30.27

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -112,8 +112,8 @@ The AutoMapper Roslyn Analyzer project uses GitHub Actions for continuous integr
 ### Package Versioning
 
 - **Format**: Major.Minor.Patch (SemVer)
-- **Current**: 2.30.26
-- **Pre-release**: 2.30.26-preview, 2.30.26-beta
+- **Current**: 2.30.27
+- **Pre-release**: 2.30.27-preview, 2.30.27-beta
 
 ## 🔧 Configuration
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -43,7 +43,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.26">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.27">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -67,7 +67,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.26">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.27">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -86,7 +86,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="14.0.0" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.26">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.27">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -218,7 +218,7 @@ public class Destination
 
 2. **Verify Package Installation**
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.26">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.27">
      <PrivateAssets>all</PrivateAssets>
      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -280,4 +280,4 @@ This guide ensures smooth installation and usage across all supported .NET frame
 ---
 
 **Last Updated**: 2026-05-14
-**Version**: 2.30.26
+**Version**: 2.30.27

--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -1343,7 +1343,7 @@ using System.Diagnostics.CodeAnalysis;
 
 1. **Check package reference**:
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.26">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.27">
        <PrivateAssets>all</PrivateAssets>
        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -1382,5 +1382,5 @@ If analyzer slows down builds:
 ---
 
 **Last Updated**: 2026-05-14
-**Version**: 2.30.26
+**Version**: 2.30.27
 **Maintainer**: George Wall

--- a/docs/RULE_CATALOG.md
+++ b/docs/RULE_CATALOG.md
@@ -2,7 +2,7 @@
 
 This file is generated from `RuleCatalog`.
 
-Package version: `2.30.26`
+Package version: `2.30.27`
 
 | Rule ID | Descriptor Title | Severity | Category | Analyzer | Code Fix | Trust | Sample | Docs |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,3 +1,15 @@
+## Release 2.30.27
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
+### Removed Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
 ## Release 2.30.26
 
 ### New Rules

--- a/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
+++ b/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
@@ -17,7 +17,7 @@
         <!-- Fallback for local builds: 2.0.YYYYMMDD-local -->
         <MajorVersion>2</MajorVersion>
         <MinorVersion>30</MinorVersion>
-        <PatchVersion>26</PatchVersion>
+        <PatchVersion>27</PatchVersion>
         <BuildNumber Condition="'$(BuildNumber)' == ''"
         >$([System.DateTime]::Now.ToString('yyyyMMdd'))
         </BuildNumber
@@ -32,18 +32,18 @@
         <RepositoryUrl>https://github.com/georgepwall1991/automapper-analyser</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <PackageReleaseNotes>Version 2.30.26 - Lock AM050 sibling-config withhold behavior with direct PreCondition/UseDestinationValue/Ignore tests
+        <PackageReleaseNotes>Version 2.30.27 - Lock AM041 ForPath chained-configuration withhold behavior with a direct test
 
             Changed:
-            - Added direct AM050 code-fix test coverage for the three sibling member-options previously only covered by the generic `ForMemberLambdaContainsOnlyTheMapFrom` structural check: `PreCondition`, `UseDestinationValue`, and `Ignore`. The structural check already withholds the automatic `ForMember`-removal action whenever the options lambda contains anything besides the redundant `MapFrom`, so the diagnostic still fires while the unsafe automatic action stays suppressed
-            - The new tests lock the sibling-config withhold contract directly so a future refactor narrowing the structural check to a known-sibling list would now fail tests
+            - Added a direct AM041 code-fix test asserting that the duplicate `CreateMap` removal action is withheld when the duplicate carries chained `ForPath(...)` configuration. Until now, the documented claim that `ForPath` chained-config was covered by the generic `IsCreateMapWithUnsafeChainedConfiguration` algorithm relied on the algorithm not caring about the chained method name; the new test makes the claim directly test-backed
+            - No production code changes; the algorithm already withholds the fix for chained `ForPath`, and the new test locks the contract so a future refactor narrowing the structural check to a known-method list would now fail tests
 
             Validation:
-            - Full solution test suite passing on net10.0 with targeted AM050 code-fix coverage
+            - Full solution test suite passing on net10.0 with targeted AM041 code-fix coverage
             - Rule catalog and sample diagnostics snapshot checks passing
             - git diff --check clean
 
-            Previous Release: v2.30.25 - Fix rule documentation category drift and add a category drift guard
+            Previous Release: v2.30.26 - Lock AM050 sibling-config withhold behavior with PreCondition/UseDestinationValue/Ignore tests
         </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>

--- a/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
@@ -130,7 +130,7 @@ public static class RuleCatalog
     /// <summary>
     ///     Current package version used by docs/package drift tests.
     /// </summary>
-    public const string CurrentPackageVersion = "2.30.26";
+    public const string CurrentPackageVersion = "2.30.27";
 
     /// <summary>
     ///     Implemented rules, grouped by public diagnostic ID.

--- a/tests/AutoMapperAnalyzer.Tests/Configuration/AM041_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Configuration/AM041_CodeFixTests.cs
@@ -362,6 +362,41 @@ public class AM041_CodeFixTests
     }
 
     [Fact]
+    public async Task Should_NotOfferFix_WhenDuplicateCreateMapHasChainedForPathConfiguration()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                public class StreetSource { public string Name { get; set; } }
+                                public class Source { public StreetSource Street { get; set; } }
+                                public class Address { public string StreetName { get; set; } }
+                                public class Destination { public Address Address { get; set; } }
+
+                                public class MyProfile : Profile
+                                {
+                                    public MyProfile()
+                                    {
+                                        CreateMap<Source, Destination>();
+                                        CreateMap<Source, Destination>()
+                                            .ForPath(d => d.Address.StreetName, opt => opt.MapFrom(s => s.Street.Name));
+                                    }
+                                }
+                                """;
+
+        Document document = CreateDocument(testCode);
+        Compilation compilation = (await document.Project.GetCompilationAsync())!;
+        Diagnostic diagnostic = (await compilation.WithAnalyzers(
+                [new AM041_DuplicateMappingAnalyzer()])
+            .GetAnalyzerDiagnosticsAsync())
+            .Single();
+
+        Assert.Equal("AM041", diagnostic.Id);
+
+        List<CodeAction> actions = await RegisterActionsAsync(document, diagnostic);
+        Assert.Empty(actions);
+    }
+
+    [Fact]
     public async Task Should_NotOfferFix_WhenParenthesizedDuplicateCreateMapHasChainedConfiguration()
     {
         const string testCode = """


### PR DESCRIPTION
## Summary

- AM041's duplicate-`CreateMap` removal action is gated by a structural check (`IsCreateMapWithUnsafeChainedConfiguration`) that withholds the fix whenever the duplicate carries any chained method call other than bare `.ReverseMap()`. The check does not enumerate known method names — chained `ForPath(...)` is already covered.
- The previous test suite had explicit cases for chained `ForMember`, parenthesized `(CreateMap<>()).ForMember(...)`, and post-`ReverseMap()` chaining, but no `ForPath`-specific case. `analyzer-health.md` called this out as a P2 gap.
- Added `Should_NotOfferFix_WhenDuplicateCreateMapHasChainedForPathConfiguration`, asserting AM041 still reports the duplicate while the automatic removal action is suppressed. The test passes on day 1 (algorithm already correct); its value is locking the documented `ForPath` claim so a future refactor narrowing the structural check to a known-method list would fail tests.

## Impact

- No analyzer/code-fix behaviour change.
- Resolves the AM041 `ForPath` chained-config P2 entry from `analyzer-health.md`.
- Patch bump (`2.30.26` → `2.30.27`): pure regression coverage; no analyzer/fixer code change, no public surface change.

## Test plan

- [x] Targeted: `dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --framework net10.0 --filter "FullyQualifiedName~Should_NotOfferFix_WhenDuplicateCreateMapHasChainedForPathConfiguration"` (1 passed).
- [x] Full suite: `dotnet test automapper-analyser.sln --configuration Release --framework net10.0` (784 passed, 0 skipped, 0 failed).
- [x] Verifier: `dotnet run --project tools/AnalyzerVerifier/AnalyzerVerifier.csproj --configuration Release -- --check-catalog --check-snapshots` green.
- [x] Codex `codex review --uncommitted` — no actionable findings; explicit "Yes, modest meaningful improvement" judgment confirming the locking value of the new direct coverage.