### PR TITLE
fix: respect implicit conversions in AM001

### DIFF
--- a/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM001_PropertyTypeMismatchAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM001_PropertyTypeMismatchAnalyzer.cs
@@ -164,7 +164,7 @@ public class AM001_PropertyTypeMismatchAnalyzer : DiagnosticAnalyzer
         }
 
         // Check for basic type incompatibilities
-        if (!AreTypesCompatible(sourceProperty.Type, destinationProperty.Type))
+        if (!AreTypesCompatible(context.Compilation, sourceProperty.Type, destinationProperty.Type))
         {
             var properties = ImmutableDictionary.CreateBuilder<string, string?>();
             properties.Add(PropertyNamePropertyName, sourceProperty.Name);
@@ -265,12 +265,15 @@ public class AM001_PropertyTypeMismatchAnalyzer : DiagnosticAnalyzer
             destinationType);
     }
 
-    private static bool AreTypesCompatible(ITypeSymbol sourceType, ITypeSymbol destinationType)
+    private static bool AreTypesCompatible(Compilation compilation, ITypeSymbol sourceType, ITypeSymbol destinationType)
     {
-        // Use the centralized helper method for comprehensive compatibility checking.
-        // This includes: exact type match, nullable compatibility, collection compatibility,
-        // and numeric type implicit conversions (using SpecialType for accuracy).
-        return AutoMapperAnalysisHelpers.AreTypesCompatible(sourceType, destinationType);
+        if (AutoMapperAnalysisHelpers.AreTypesCompatible(sourceType, destinationType))
+        {
+            return true;
+        }
+
+        Conversion conversion = compilation.ClassifyConversion(sourceType, destinationType);
+        return conversion.Exists && conversion.IsImplicit;
     }
 
     private static bool IsPrimitiveOrFrameworkType(ITypeSymbol type)

--- a/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM001_PropertyTypeMismatchTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM001_PropertyTypeMismatchTests.cs
@@ -188,6 +188,97 @@ public class AM001_PropertyTypeMismatchTests
     }
 
     [Fact]
+    public async Task AM001_ShouldNotReportDiagnostic_WhenUserDefinedImplicitConversionExists()
+    {
+        const string testCode = """
+
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public readonly struct Money
+                                    {
+                                        public Money(decimal value)
+                                        {
+                                            Value = value;
+                                        }
+
+                                        public decimal Value { get; }
+
+                                        public static implicit operator decimal(Money money) => money.Value;
+                                    }
+
+                                    public class Source
+                                    {
+                                        public Money Amount { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public decimal Amount { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await AnalyzerVerifier<AM001_PropertyTypeMismatchAnalyzer>.VerifyAnalyzerAsync(testCode);
+    }
+
+    [Fact]
+    public async Task AM001_ShouldReportDiagnostic_WhenOnlyUserDefinedExplicitConversionExists()
+    {
+        const string testCode = """
+
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public readonly struct Money
+                                    {
+                                        public Money(decimal value)
+                                        {
+                                            Value = value;
+                                        }
+
+                                        public decimal Value { get; }
+
+                                        public static explicit operator decimal(Money money) => money.Value;
+                                    }
+
+                                    public class Source
+                                    {
+                                        public Money Amount { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public decimal Amount { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await AnalyzerVerifier<AM001_PropertyTypeMismatchAnalyzer>.VerifyAnalyzerAsync(
+            testCode,
+            CreateDiagnostic(AM001_PropertyTypeMismatchAnalyzer.PropertyTypeMismatchRule, 32, 13, "Amount", "Source",
+                "TestNamespace.Money", "Destination", "decimal"));
+    }
+
+    [Fact]
     public async Task AM001_ShouldReportDiagnostic_WhenSourcePropertyIsReadOnly()
     {
         const string testCode = """


### PR DESCRIPTION
## Summary
- use Roslyn conversion classification so AM001 treats compiler-known implicit conversions as compatible
- add regression coverage for a value object with an implicit conversion to decimal
- keep explicit user-defined conversions reportable

## Validation
- dotnet format automapper-analyser.sln --no-restore --include src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM001_PropertyTypeMismatchAnalyzer.cs tests/AutoMapperAnalyzer.Tests/TypeSafety/AM001_PropertyTypeMismatchTests.cs
- dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter AM001
- git diff --check