### PR TITLE
fix: respect implicit element conversions in AM021

### DIFF
--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM021_CollectionElementMismatchAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM021_CollectionElementMismatchAnalyzer.cs
@@ -154,7 +154,7 @@ public class AM021_CollectionElementMismatchAnalyzer : DiagnosticAnalyzer
         }
 
         // Check if element types are compatible
-        if (!AutoMapperAnalysisHelpers.AreTypesCompatible(sourceElementType, destElementType))
+        if (!AreElementTypesCompatible(context.Compilation, sourceElementType, destElementType))
         {
             // Check if there's an explicit CreateMap for the element types
             var registry = CreateMapRegistry.FromCompilation(context.Compilation);
@@ -241,6 +241,17 @@ public class AM021_CollectionElementMismatchAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
+    }
+
+    private static bool AreElementTypesCompatible(Compilation compilation, ITypeSymbol sourceType, ITypeSymbol destinationType)
+    {
+        if (AutoMapperAnalysisHelpers.AreTypesCompatible(sourceType, destinationType))
+        {
+            return true;
+        }
+
+        Conversion conversion = compilation.ClassifyConversion(sourceType, destinationType);
+        return conversion.Exists && conversion.IsImplicit;
     }
 
     private static bool IsGenericCollection(ITypeSymbol type)

--- a/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM021_CollectionElementMismatchTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM021_CollectionElementMismatchTests.cs
@@ -245,6 +245,103 @@ public class AM021_CollectionElementMismatchTests
     }
 
     [Fact]
+    public async Task AM021_ShouldNotReportDiagnostic_WhenUserDefinedImplicitElementConversionExists()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Collections.Generic;
+
+                                namespace TestNamespace
+                                {
+                                    public readonly struct Money
+                                    {
+                                        public Money(decimal value)
+                                        {
+                                            Value = value;
+                                        }
+
+                                        public decimal Value { get; }
+
+                                        public static implicit operator decimal(Money money) => money.Value;
+                                    }
+
+                                    public class Source
+                                    {
+                                        public List<Money> Amounts { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public List<decimal> Amounts { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM021_CollectionElementMismatchAnalyzer>()
+            .WithSource(testCode)
+            .ExpectNoDiagnostics()
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM021_ShouldReportDiagnostic_WhenOnlyUserDefinedExplicitElementConversionExists()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Collections.Generic;
+
+                                namespace TestNamespace
+                                {
+                                    public readonly struct Money
+                                    {
+                                        public Money(decimal value)
+                                        {
+                                            Value = value;
+                                        }
+
+                                        public decimal Value { get; }
+
+                                        public static explicit operator decimal(Money money) => money.Value;
+                                    }
+
+                                    public class Source
+                                    {
+                                        public List<Money> Amounts { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public List<decimal> Amounts { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM021_CollectionElementMismatchAnalyzer>()
+            .WithSource(testCode)
+            .ExpectDiagnostic(AM021_CollectionElementMismatchAnalyzer.CollectionElementIncompatibilityRule, 32, 13,
+                "Amounts", "Source", "TestNamespace.Money", "Destination", "Amounts", "decimal")
+            .RunAsync();
+    }
+
+    [Fact]
     public async Task AM021_ShouldNotReportDiagnostic_WhenExplicitElementMappingProvided()
     {
         const string testCode = """


### PR DESCRIPTION
## Summary
- Treat compiler-known implicit element conversions as compatible in AM021 collection element analysis
- Add regressions for user-defined implicit versus explicit-only element conversions

## Verification
- dotnet test tests\AutoMapperAnalyzer.Tests\AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter AM021
- dotnet test tests\AutoMapperAnalyzer.Tests\AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter "AM003|AM021|AnalyzerOwnershipConflictTests"
- git diff --check