### PR TITLE
fix: respect implicit nested conversions in AM020

### DIFF
--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM020_NestedObjectMappingAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM020_NestedObjectMappingAnalyzer.cs
@@ -95,7 +95,7 @@ public class AM020_NestedObjectMappingAnalyzer : DiagnosticAnalyzer
             }
 
             // Check if this property requires nested object mapping
-            if (RequiresNestedObjectMapping(sourceProperty.Type, destinationProperty.Type))
+            if (RequiresNestedObjectMapping(context.Compilation, sourceProperty.Type, destinationProperty.Type))
             {
                 ITypeSymbol sourceNestedType = AutoMapperAnalysisHelpers.GetUnderlyingType(sourceProperty.Type);
                 ITypeSymbol destNestedType = AutoMapperAnalysisHelpers.GetUnderlyingType(destinationProperty.Type);
@@ -128,7 +128,7 @@ public class AM020_NestedObjectMappingAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    private static bool RequiresNestedObjectMapping(ITypeSymbol sourceType, ITypeSymbol destinationType)
+    private static bool RequiresNestedObjectMapping(Compilation compilation, ITypeSymbol sourceType, ITypeSymbol destinationType)
     {
         // Get the underlying types (remove nullable wrappers)
         ITypeSymbol sourceUnderlyingType = AutoMapperAnalysisHelpers.GetUnderlyingType(sourceType);
@@ -150,6 +150,12 @@ public class AM020_NestedObjectMappingAnalyzer : DiagnosticAnalyzer
         // Collections should be handled by AM021, not AM020
         if (AutoMapperAnalysisHelpers.IsCollectionType(sourceUnderlyingType) ||
             AutoMapperAnalysisHelpers.IsCollectionType(destUnderlyingType))
+        {
+            return false;
+        }
+
+        Conversion conversion = compilation.ClassifyConversion(sourceUnderlyingType, destUnderlyingType);
+        if (conversion.Exists && conversion.IsImplicit)
         {
             return false;
         }

--- a/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM020_NestedObjectMappingTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM020_NestedObjectMappingTests.cs
@@ -369,6 +369,110 @@ public class AM020_NestedObjectMappingTests
     }
 
     [Fact]
+    public async Task AM020_ShouldNotReportDiagnostic_WhenUserDefinedImplicitNestedConversionExists()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class SourceAddress
+                                    {
+                                        public string Street { get; set; }
+
+                                        public static implicit operator DestAddress(SourceAddress address)
+                                        {
+                                            return new DestAddress { Street = address.Street };
+                                        }
+                                    }
+
+                                    public class DestAddress
+                                    {
+                                        public string Street { get; set; }
+                                    }
+
+                                    public class Source
+                                    {
+                                        public string Name { get; set; }
+                                        public SourceAddress Address { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public string Name { get; set; }
+                                        public DestAddress Address { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM020_NestedObjectMappingAnalyzer>()
+            .WithSource(testCode)
+            .RunWithNoDiagnosticsAsync();
+    }
+
+    [Fact]
+    public async Task AM020_ShouldReportDiagnostic_WhenOnlyUserDefinedExplicitNestedConversionExists()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class SourceAddress
+                                    {
+                                        public string Street { get; set; }
+
+                                        public static explicit operator DestAddress(SourceAddress address)
+                                        {
+                                            return new DestAddress { Street = address.Street };
+                                        }
+                                    }
+
+                                    public class DestAddress
+                                    {
+                                        public string Street { get; set; }
+                                    }
+
+                                    public class Source
+                                    {
+                                        public string Name { get; set; }
+                                        public SourceAddress Address { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public string Name { get; set; }
+                                        public DestAddress Address { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM020_NestedObjectMappingAnalyzer>()
+            .WithSource(testCode)
+            .ExpectDiagnostic(AM020_NestedObjectMappingAnalyzer.NestedObjectMappingMissingRule, 36, 13, "Address",
+                "SourceAddress", "DestAddress")
+            .RunAsync();
+    }
+
+    [Fact]
     public async Task AM020_ShouldIgnoreValueTypes()
     {
         const string testCode = """


### PR DESCRIPTION
## Summary
- Treat compiler-known implicit nested object conversions as compatible in AM020 analysis
- Add regressions for user-defined implicit versus explicit-only nested conversions

## Verification
- dotnet test tests\AutoMapperAnalyzer.Tests\AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter AM020
- dotnet test tests\AutoMapperAnalyzer.Tests\AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter "AM001|AM020|AM021|AnalyzerOwnershipConflictTests"
- git diff --check