### PR TITLE
Detect GetAwaiter().GetResult() in AM031

### DIFF
--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -1160,13 +1160,13 @@ CreateMap<Source, Destination>()
 
 **Issue**: Mapping same object twice produces different results, breaks unit tests, and causes caching issues.
 
-#### Problem 4: Task.Result Deadlock Risk
+#### Problem 4: Sync-over-async Deadlock Risk
 
 ```csharp
 CreateMap<Source, Destination>()
     .ForMember(dest => dest.Data, opt => opt.MapFrom(src =>
         _service.GetDataAsync(src.Id).Result));  // ❌ Synchronous access
-// ⚠️ AM031: Task.Result can cause deadlocks
+// ⚠️ AM031: Synchronously waiting on async work can cause deadlocks
 ```
 
 Task-valued source members are also detected:
@@ -1176,6 +1176,8 @@ CreateMap<Source, Destination>()
     .ForMember(dest => dest.Data, opt => opt.MapFrom(src =>
         src.DataTask.Result));  // ❌ Synchronous access
 ```
+
+`Task.Wait()` and `GetAwaiter().GetResult()` are reported through the same descriptor.
 
 #### Solutions
 
@@ -1214,7 +1216,7 @@ manual-review action only so the fixer does not change runtime mapping policy.
 - ✅ Reflection operations
 - ✅ Multiple collection enumerations
 - ✅ `DateTime.Now`, `Random`, `Guid.NewGuid()`
-- ✅ `Task.Result`, `Task.Wait()`, including Task-valued source properties
+- ✅ `Task.Result`, `Task.Wait()`, `GetAwaiter().GetResult()`, including Task-valued source properties
 - ✅ Complex LINQ (SelectMany chains)
 
 #### Configuration
@@ -1225,7 +1227,7 @@ dotnet_diagnostic.AM031.severity = warning
 # Specific sub-rules
 dotnet_diagnostic.AM031.001.severity = error  # Expensive operations
 dotnet_diagnostic.AM031.002.severity = warning  # Multiple enumerations
-dotnet_diagnostic.AM031.003.severity = error  # Task.Result deadlock
+dotnet_diagnostic.AM031.003.severity = error  # Sync-over-async deadlock
 dotnet_diagnostic.AM031.004.severity = warning  # Non-deterministic
 ```
 

--- a/samples/AutoMapperAnalyzer.Samples/Performance/AM031_PerformanceExamples.cs
+++ b/samples/AutoMapperAnalyzer.Samples/Performance/AM031_PerformanceExamples.cs
@@ -132,7 +132,7 @@ public class AM031_PerformanceExamples
     }
 
     /// <summary>
-    ///     AM031: Task.Result Synchronous Access
+    ///     AM031: Sync-over-async Access
     ///     This should trigger AM031 diagnostic
     /// </summary>
     public void TaskResultExample()
@@ -142,7 +142,7 @@ public class AM031_PerformanceExamples
         var config = new MapperConfiguration(cfg =>
         {
             cfg.CreateMap<AM031Customer, AM031CustomerDto>()
-                // ❌ AM031: Task.Result can cause deadlocks
+                // ❌ AM031: synchronously waiting on async work can cause deadlocks
                 .ForMember(dest => dest.ExternalData,
                     opt => opt.MapFrom(src => asyncService.GetDataAsync(src.Id).Result));
         });
@@ -150,7 +150,7 @@ public class AM031_PerformanceExamples
         var mapper = config.CreateMapper();
         var customer = new AM031Customer { Id = 1, Name = "Jane Smith" };
 
-        Console.WriteLine("❌ Task.Result usage detected - await async operations before mapping!");
+        Console.WriteLine("❌ Sync-over-async usage detected - await async operations before mapping!");
 
         // ✅ CORRECT WAY:
         // var externalData = await asyncService.GetDataAsync(customer.Id);

--- a/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningAnalyzer.cs
@@ -63,16 +63,16 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
         "Complex computations in mapping expressions can impact performance. Consider computing values before mapping.");
 
     /// <summary>
-    ///     Diagnostic rule for synchronous access of Task.Result.
+    ///     Diagnostic rule for synchronous access of async operations.
     /// </summary>
     public static readonly DiagnosticDescriptor TaskResultSynchronousAccessRule = new(
         "AM031",
         "Synchronous access of async operation in mapping",
-        "Property '{0}' mapping uses Task.Result which can cause deadlocks. Perform async operations before mapping.",
+        "Property '{0}' mapping synchronously waits on an async operation, which can cause deadlocks. Perform async operations before mapping.",
         "AutoMapper.Performance",
         DiagnosticSeverity.Warning,
         true,
-        "Using Task.Result or Task.Wait() in mapping can cause deadlocks and performance issues. Await async operations before mapping.");
+        "Using Task.Result, Task.Wait(), or GetAwaiter().GetResult() in mapping can cause deadlocks and performance issues. Await async operations before mapping.");
 
     /// <summary>
     ///     Diagnostic rule for complex LINQ operations.
@@ -374,6 +374,16 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
 
             // Check for Task.Result
             if (IsTaskResultAccess(invocation, context.SemanticModel))
+            {
+                if (reportedIssueTypes.Add(TaskResultIssueType))
+                {
+                    ReportTaskResultDiagnostic(context, lambda, propertyName);
+                }
+
+                continue;
+            }
+
+            if (IsTaskAwaiterGetResultAccess(containingType, methodName))
             {
                 if (reportedIssueTypes.Add(TaskResultIssueType))
                 {
@@ -707,6 +717,15 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
     {
         return methodName == "Wait" &&
                containingType.StartsWith("System.Threading.Tasks.Task", StringComparison.Ordinal);
+    }
+
+    private static bool IsTaskAwaiterGetResultAccess(string containingType, string methodName)
+    {
+        return methodName == "GetResult" &&
+               (containingType.StartsWith("System.Runtime.CompilerServices.TaskAwaiter", StringComparison.Ordinal) ||
+                containingType.StartsWith("System.Runtime.CompilerServices.ValueTaskAwaiter", StringComparison.Ordinal) ||
+                containingType.StartsWith("System.Runtime.CompilerServices.ConfiguredTaskAwaitable", StringComparison.Ordinal) ||
+                containingType.StartsWith("System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable", StringComparison.Ordinal));
     }
 
     private static bool IsNonDeterministicOperation(string containingType, string methodName, out string operationType)

--- a/tests/AutoMapperAnalyzer.Tests/Performance/AM031_PerformanceWarningTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Performance/AM031_PerformanceWarningTests.cs
@@ -1584,6 +1584,168 @@ public class AM031_PerformanceWarningTests
     }
 
     [Fact]
+    public async Task AM031_ShouldReportDiagnostic_WhenGetAwaiterGetResultUsedInMapFrom()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Threading.Tasks;
+
+                                namespace TestNamespace
+                                {
+                                    public static class DataService
+                                    {
+                                        public static Task<string> GetDataAsync(int id) => Task.FromResult("data");
+                                    }
+
+                                    public class Source
+                                    {
+                                        public int Id { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public string Data { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>()
+                                                .ForMember(dest => dest.Data, opt => opt.MapFrom(src => DataService.GetDataAsync(src.Id).GetAwaiter().GetResult()));
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM031_PerformanceWarningAnalyzer>()
+            .WithSource(testCode)
+            .ExpectDiagnostic(AM031_PerformanceWarningAnalyzer.TaskResultSynchronousAccessRule, 26, 66,
+                "Data")
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM031_ShouldReportDiagnostic_WhenConfiguredTaskGetResultUsedInMapFrom()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Threading.Tasks;
+
+                                namespace TestNamespace
+                                {
+                                    public static class DataService
+                                    {
+                                        public static Task<string> GetDataAsync(int id) => Task.FromResult("data");
+                                    }
+
+                                    public class Source
+                                    {
+                                        public int Id { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public string Data { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>()
+                                                .ForMember(dest => dest.Data, opt => opt.MapFrom(src => DataService.GetDataAsync(src.Id).ConfigureAwait(false).GetAwaiter().GetResult()));
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM031_PerformanceWarningAnalyzer>()
+            .WithSource(testCode)
+            .ExpectDiagnostic(AM031_PerformanceWarningAnalyzer.TaskResultSynchronousAccessRule, 26, 66,
+                "Data")
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM031_ShouldReportDiagnostic_WhenValueTaskGetAwaiterGetResultUsedInMapFrom()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Threading.Tasks;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public ValueTask<string> DataTask { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public string Data { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>()
+                                                .ForMember(dest => dest.Data, opt => opt.MapFrom(src => src.DataTask.GetAwaiter().GetResult()));
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM031_PerformanceWarningAnalyzer>()
+            .WithSource(testCode)
+            .ExpectDiagnostic(AM031_PerformanceWarningAnalyzer.TaskResultSynchronousAccessRule, 21, 66,
+                "Data")
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM031_ShouldReportDiagnostic_WhenConfiguredValueTaskGetResultUsedInMapFrom()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Threading.Tasks;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public ValueTask<string> DataTask { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public string Data { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>()
+                                                .ForMember(dest => dest.Data, opt => opt.MapFrom(src => src.DataTask.ConfigureAwait(false).GetAwaiter().GetResult()));
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM031_PerformanceWarningAnalyzer>()
+            .WithSource(testCode)
+            .ExpectDiagnostic(AM031_PerformanceWarningAnalyzer.TaskResultSynchronousAccessRule, 21, 66,
+                "Data")
+            .RunAsync();
+    }
+
+    [Fact]
     public async Task AM031_ShouldReportDiagnostic_WhenTaskWaitUsedInMapFrom()
     {
         const string testCode = """

--- a/tests/AutoMapperAnalyzer.Tests/Snapshots/sample-diagnostics.json
+++ b/tests/AutoMapperAnalyzer.Tests/Snapshots/sample-diagnostics.json
@@ -920,7 +920,7 @@
     "filePath": "samples/AutoMapperAnalyzer.Samples/Performance/AM031_PerformanceExamples.cs",
     "line": 147,
     "column": 40,
-    "message": "Property 'ExternalData' mapping uses Task.Result which can cause deadlocks. Perform async operations before mapping.",
+    "message": "Property 'ExternalData' mapping synchronously waits on an async operation, which can cause deadlocks. Perform async operations before mapping.",
     "fixTrustLevel": "Scaffold"
   },
   {


### PR DESCRIPTION
## Summary
- Detect `GetAwaiter().GetResult()` sync-over-async calls in AM031 MapFrom expressions using framework task awaiter symbols.
- Broaden the AM031 sync-over-async descriptor wording beyond `Task.Result`.
- Add regression coverage and refresh AM031 docs/sample diagnostics snapshot.

## Verification
- `dotnet test tests\AutoMapperAnalyzer.Tests\AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter AM031`
- `dotnet test tests\AutoMapperAnalyzer.Tests\AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter "AM031|RuleCatalogTests"`
- `dotnet run --project tools\AnalyzerVerifier\AnalyzerVerifier.csproj --configuration Debug -- --check-catalog --check-snapshots`
- `dotnet format whitespace automapper-analyser.sln --include src\AutoMapperAnalyzer.Analyzers\Performance\AM031_PerformanceWarningAnalyzer.cs tests\AutoMapperAnalyzer.Tests\Performance\AM031_PerformanceWarningTests.cs --verify-no-changes`
- `dotnet test automapper-analyser.sln --no-restore --framework net10.0`
- `git diff --check`

Note: the Release-config verifier DLL was blocked locally by Windows Application Control, so the catalog/snapshot verifier was run in Debug config.