### PR TITLE
Track more LINQ terminal operators in AM031

### DIFF
--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -1117,7 +1117,7 @@ dotnet_diagnostic.AM033.severity = info
 #### Description
 
 Detects expensive operations inside mapping expressions that should be performed before mapping.
-AM031 analyzes both `ForMember(... MapFrom(...))` and `ForPath(... MapFrom(...))`; nested destination paths are reported as paths such as `Stats.Total`. Multiple-enumeration tracking covers the commonly used terminal LINQ operators — `ToList`, `ToArray`, `ToHashSet`, `ToDictionary`, `ToLookup`, `Sum`, `Average`, `Min`, `Max`, `Aggregate`, `Count`, `LongCount`, `First`/`FirstOrDefault`, `Last`/`LastOrDefault`, `Single`/`SingleOrDefault`, `Any`, and `All`. Lazy/intermediate operators such as `Where`, `Select`, `OrderBy`, `GroupBy`, and `Distinct` intentionally do not count toward the enumeration count.
+AM031 analyzes both `ForMember(... MapFrom(...))` and `ForPath(... MapFrom(...))`; nested destination paths are reported as paths such as `Stats.Total`. Multiple-enumeration tracking covers the commonly used terminal LINQ operators — `ToList`, `ToArray`, `ToHashSet`, `ToDictionary`, `ToLookup`, `Sum`, `Average`, `Min`, `Max`, `Aggregate`, `Count`, `LongCount`, `First`/`FirstOrDefault`, `Last`/`LastOrDefault`, `Single`/`SingleOrDefault`, `Any`, `All`, `Contains`, and `ElementAt`/`ElementAtOrDefault`. Lazy/intermediate operators such as `Where`, `Select`, `OrderBy`, `GroupBy`, and `Distinct` intentionally do not count toward the enumeration count.
 
 #### Problem 1: Database Query in Mapping
 

--- a/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningAnalyzer.cs
@@ -14,6 +14,13 @@ namespace AutoMapperAnalyzer.Analyzers.Performance;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
 {
+    private static readonly string[] LinearCollectionContainsTypes =
+    [
+        "System.Collections.Generic.List<",
+        "System.Collections.ObjectModel.Collection<",
+        "System.Collections.ObjectModel.ReadOnlyCollection<"
+    ];
+
     private const string IssueTypePropertyName = "IssueType";
     private const string PropertyNamePropertyName = "PropertyName";
     private const string OperationTypePropertyName = "OperationType";
@@ -415,7 +422,8 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
             }
 
             // Track LINQ operations for multiple enumeration detection
-            if (IsLinqEnumerationMethod(containingType, methodName))
+            if (IsLinqEnumerationMethod(containingType, methodName) ||
+                IsLinearCollectionContainsMethod(containingType, methodName))
             {
                 TrackCollectionAccess(invocation, collectionAccesses, sourceParameterName, context.SemanticModel);
             }
@@ -766,7 +774,13 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
             "Count" or "LongCount" or
             "First" or "FirstOrDefault" or "Last" or "LastOrDefault" or
             "Single" or "SingleOrDefault" or
-            "Any" or "All";
+            "Any" or "All" or "Contains" or "ElementAt" or "ElementAtOrDefault";
+    }
+
+    private static bool IsLinearCollectionContainsMethod(string containingType, string methodName)
+    {
+        return methodName == "Contains" &&
+               LinearCollectionContainsTypes.Any(prefix => containingType.StartsWith(prefix, StringComparison.Ordinal));
     }
 
     private static void TrackCollectionAccess(

--- a/tests/AutoMapperAnalyzer.Tests/Performance/AM031_PerformanceWarningTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Performance/AM031_PerformanceWarningTests.cs
@@ -543,6 +543,84 @@ public class AM031_PerformanceWarningTests
     }
 
     [Fact]
+    public async Task AM031_ShouldReportDiagnostic_WhenContainsAndElementAtEnumerateSameCollection()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Collections.Generic;
+                                using System.Linq;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public List<int> Numbers { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public bool Result { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>()
+                                                .ForMember(dest => dest.Result, opt => opt.MapFrom(src => src.Numbers.Contains(src.Numbers.ElementAt(0)) || src.Numbers.ElementAtOrDefault(1) == 0));
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM031_PerformanceWarningAnalyzer>()
+            .WithSource(testCode)
+            .ExpectDiagnostic(AM031_PerformanceWarningAnalyzer.MultipleEnumerationRule, 22, 68,
+                "Result", "Numbers")
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM031_ShouldReportDiagnostic_WhenListContainsAndSumEnumerateSameCollection()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Collections.Generic;
+                                using System.Linq;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public List<int> Numbers { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public bool Result { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>()
+                                                .ForMember(dest => dest.Result, opt => opt.MapFrom(src => src.Numbers.Contains(5) && src.Numbers.Sum() > 0));
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM031_PerformanceWarningAnalyzer>()
+            .WithSource(testCode)
+            .ExpectDiagnostic(AM031_PerformanceWarningAnalyzer.MultipleEnumerationRule, 22, 68,
+                "Result", "Numbers")
+            .RunAsync();
+    }
+
+    [Fact]
     public async Task AM031_ShouldReportDiagnostic_WhenMultipleEnumerationUsesNonSrcParameterName()
     {
         const string testCode = """


### PR DESCRIPTION
## Summary
- Add `Contains`, `ElementAt`, and `ElementAtOrDefault` to AM031's terminal LINQ enumeration tracking.
- Add regression coverage proving these terminal calls report when they enumerate the same source collection multiple times.
- Update AM031 docs to list the new terminal operators.

## Verification
- `dotnet test tests\AutoMapperAnalyzer.Tests\AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter AM031`
- `dotnet test tests\AutoMapperAnalyzer.Tests\AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter "AM031|RuleCatalogTests"`
- `dotnet run --project tools\AnalyzerVerifier\AnalyzerVerifier.csproj --configuration Debug -- --check-catalog --check-snapshots`
- `dotnet format whitespace automapper-analyser.sln --include src\AutoMapperAnalyzer.Analyzers\Performance\AM031_PerformanceWarningAnalyzer.cs tests\AutoMapperAnalyzer.Tests\Performance\AM031_PerformanceWarningTests.cs --verify-no-changes`
- `dotnet test automapper-analyser.sln --no-restore --framework net10.0`
- `git diff --check`