### PR TITLE
Track SequenceEqual enumeration in AM031

### DIFF
--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -1117,7 +1117,7 @@ dotnet_diagnostic.AM033.severity = info
 #### Description
 
 Detects expensive operations inside mapping expressions that should be performed before mapping.
-AM031 analyzes both `ForMember(... MapFrom(...))` and `ForPath(... MapFrom(...))`; nested destination paths are reported as paths such as `Stats.Total`. Multiple-enumeration tracking covers the commonly used terminal LINQ operators — `ToList`, `ToArray`, `ToHashSet`, `ToDictionary`, `ToLookup`, `Sum`, `Average`, `Min`, `Max`, `Aggregate`, `Count`, `LongCount`, `First`/`FirstOrDefault`, `Last`/`LastOrDefault`, `Single`/`SingleOrDefault`, `Any`, `All`, `Contains`, and `ElementAt`/`ElementAtOrDefault`. Lazy/intermediate operators such as `Where`, `Select`, `OrderBy`, `GroupBy`, and `Distinct` intentionally do not count toward the enumeration count.
+AM031 analyzes both `ForMember(... MapFrom(...))` and `ForPath(... MapFrom(...))`; nested destination paths are reported as paths such as `Stats.Total`. Multiple-enumeration tracking covers the commonly used terminal LINQ operators — `ToList`, `ToArray`, `ToHashSet`, `ToDictionary`, `ToLookup`, `Sum`, `Average`, `Min`, `Max`, `Aggregate`, `Count`, `LongCount`, `First`/`FirstOrDefault`, `Last`/`LastOrDefault`, `Single`/`SingleOrDefault`, `Any`, `All`, `Contains`, `ElementAt`/`ElementAtOrDefault`, and `SequenceEqual`. Static `Enumerable`/`Queryable` terminal calls are keyed to their source sequence arguments instead of the `Enumerable`/`Queryable` type name. Lazy/intermediate operators such as `Where`, `Select`, `OrderBy`, `GroupBy`, and `Distinct` intentionally do not count toward the enumeration count.
 
 #### Problem 1: Database Query in Mapping
 

--- a/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningAnalyzer.cs
@@ -422,10 +422,17 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
             }
 
             // Track LINQ operations for multiple enumeration detection
-            if (IsLinqEnumerationMethod(containingType, methodName) ||
+            bool isLinqEnumerationMethod = IsLinqEnumerationMethod(containingType, methodName);
+            if (isLinqEnumerationMethod ||
                 IsLinearCollectionContainsMethod(containingType, methodName))
             {
-                TrackCollectionAccess(invocation, collectionAccesses, sourceParameterName, context.SemanticModel);
+                TrackCollectionAccess(
+                    invocation,
+                    collectionAccesses,
+                    sourceParameterName,
+                    context.SemanticModel,
+                    isLinqEnumerationMethod,
+                    methodName);
             }
 
             // Check for complex LINQ operations
@@ -774,7 +781,8 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
             "Count" or "LongCount" or
             "First" or "FirstOrDefault" or "Last" or "LastOrDefault" or
             "Single" or "SingleOrDefault" or
-            "Any" or "All" or "Contains" or "ElementAt" or "ElementAtOrDefault";
+            "Any" or "All" or "Contains" or "ElementAt" or "ElementAtOrDefault" or
+            "SequenceEqual";
     }
 
     private static bool IsLinearCollectionContainsMethod(string containingType, string methodName)
@@ -787,29 +795,92 @@ public class AM031_PerformanceWarningAnalyzer : DiagnosticAnalyzer
         InvocationExpressionSyntax invocation,
         Dictionary<string, int> collectionAccesses,
         string? sourceParameterName,
-        SemanticModel semanticModel)
+        SemanticModel semanticModel,
+        bool isLinqEnumerationMethod,
+        string methodName)
     {
+        if (isLinqEnumerationMethod &&
+            TryTrackStaticLinqSourceArguments(invocation, collectionAccesses, sourceParameterName, semanticModel, methodName))
+        {
+            return;
+        }
+
         if (invocation.Expression is MemberAccessExpressionSyntax memberAccess)
         {
-            ExpressionSyntax collectionRoot = UnwrapChainedLinqReceiver(
+            TrackCollectionExpression(
                 memberAccess.Expression,
+                collectionAccesses,
                 sourceParameterName,
                 semanticModel);
-
-            string collectionName = TryGetSourceCollectionPath(
-                collectionRoot,
-                sourceParameterName,
-                out string sourceCollectionPath)
-                ? sourceCollectionPath
-                : collectionRoot.ToString();
-
-            if (!collectionAccesses.ContainsKey(collectionName))
-            {
-                collectionAccesses[collectionName] = 0;
-            }
-
-            collectionAccesses[collectionName]++;
         }
+
+        if (isLinqEnumerationMethod && methodName == "SequenceEqual")
+        {
+            TrackSequenceEqualArgumentAccess(invocation, collectionAccesses, sourceParameterName, semanticModel);
+        }
+    }
+
+    private static bool TryTrackStaticLinqSourceArguments(
+        InvocationExpressionSyntax invocation,
+        Dictionary<string, int> collectionAccesses,
+        string? sourceParameterName,
+        SemanticModel semanticModel,
+        string methodName)
+    {
+        if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess ||
+            semanticModel.GetSymbolInfo(memberAccess.Expression).Symbol is not INamedTypeSymbol)
+        {
+            return false;
+        }
+
+        int sourceArgumentCount = methodName == "SequenceEqual" ? 2 : 1;
+        int argumentsToTrack = Math.Min(sourceArgumentCount, invocation.ArgumentList.Arguments.Count);
+        for (int index = 0; index < argumentsToTrack; index++)
+        {
+            TrackCollectionExpression(
+                invocation.ArgumentList.Arguments[index].Expression,
+                collectionAccesses,
+                sourceParameterName,
+                semanticModel);
+        }
+
+        return true;
+    }
+
+    private static void TrackSequenceEqualArgumentAccess(
+        InvocationExpressionSyntax invocation,
+        Dictionary<string, int> collectionAccesses,
+        string? sourceParameterName,
+        SemanticModel semanticModel)
+    {
+        TrackCollectionExpression(
+            invocation.ArgumentList.Arguments[0].Expression,
+            collectionAccesses,
+            sourceParameterName,
+            semanticModel);
+    }
+
+    private static void TrackCollectionExpression(
+        ExpressionSyntax expression,
+        Dictionary<string, int> collectionAccesses,
+        string? sourceParameterName,
+        SemanticModel semanticModel)
+    {
+        ExpressionSyntax collectionRoot = UnwrapChainedLinqReceiver(
+            expression,
+            sourceParameterName,
+            semanticModel);
+
+        string collectionName = TryGetSourceCollectionPath(collectionRoot, sourceParameterName, out string sourceCollectionPath)
+            ? sourceCollectionPath
+            : collectionRoot.ToString();
+
+        if (!collectionAccesses.ContainsKey(collectionName))
+        {
+            collectionAccesses[collectionName] = 0;
+        }
+
+        collectionAccesses[collectionName]++;
     }
 
     private static ExpressionSyntax UnwrapChainedLinqReceiver(

--- a/tests/AutoMapperAnalyzer.Tests/Performance/AM031_PerformanceWarningTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Performance/AM031_PerformanceWarningTests.cs
@@ -621,6 +621,246 @@ public class AM031_PerformanceWarningTests
     }
 
     [Fact]
+    public async Task AM031_ShouldReportDiagnostic_WhenSequenceEqualAndAnyEnumerateSameCollection()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Collections.Generic;
+                                using System.Linq;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public List<int> Numbers { get; set; }
+                                        public List<int> OtherNumbers { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public bool Result { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>()
+                                                .ForMember(dest => dest.Result, opt => opt.MapFrom(src => src.Numbers.SequenceEqual(src.OtherNumbers) && src.Numbers.Any()));
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM031_PerformanceWarningAnalyzer>()
+            .WithSource(testCode)
+            .ExpectDiagnostic(AM031_PerformanceWarningAnalyzer.MultipleEnumerationRule, 23, 68,
+                "Result", "Numbers")
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM031_ShouldReportDiagnostic_WhenSequenceEqualArgumentAndAnyEnumerateSameCollection()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Collections.Generic;
+                                using System.Linq;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public List<int> Numbers { get; set; }
+                                        public List<int> OtherNumbers { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public bool Result { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>()
+                                                .ForMember(dest => dest.Result, opt => opt.MapFrom(src => src.OtherNumbers.SequenceEqual(src.Numbers) && src.Numbers.Any()));
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM031_PerformanceWarningAnalyzer>()
+            .WithSource(testCode)
+            .ExpectDiagnostic(AM031_PerformanceWarningAnalyzer.MultipleEnumerationRule, 23, 68,
+                "Result", "Numbers")
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM031_ShouldReportDiagnostic_WhenSequenceEqualArgumentEnumeratesCapturedCollection()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Collections.Generic;
+                                using System.Linq;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public List<int> Numbers { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public bool Result { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            var numbers = new List<int> { 1, 2, 3 };
+
+                                            CreateMap<Source, Destination>()
+                                                .ForMember(dest => dest.Result, opt => opt.MapFrom(src => src.Numbers.SequenceEqual(numbers) && numbers.Any()));
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM031_PerformanceWarningAnalyzer>()
+            .WithSource(testCode)
+            .ExpectDiagnostic(AM031_PerformanceWarningAnalyzer.MultipleEnumerationRule, 24, 68,
+                "Result", "numbers")
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM031_ShouldReportDiagnostic_WhenStaticSequenceEqualArgumentAndAnyEnumerateSameCollection()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Collections.Generic;
+                                using System.Linq;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public List<int> Numbers { get; set; }
+                                        public List<int> OtherNumbers { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public bool Result { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>()
+                                                .ForMember(dest => dest.Result, opt => opt.MapFrom(src => Enumerable.SequenceEqual(src.OtherNumbers, src.Numbers) && src.Numbers.Any()));
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM031_PerformanceWarningAnalyzer>()
+            .WithSource(testCode)
+            .ExpectDiagnostic(AM031_PerformanceWarningAnalyzer.MultipleEnumerationRule, 23, 68,
+                "Result", "Numbers")
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM031_ShouldNotReportDiagnostic_WhenStaticLinqTerminalsEnumerateDifferentCollections()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Collections.Generic;
+                                using System.Linq;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public List<int> Numbers { get; set; }
+                                        public List<int> OtherNumbers { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public double Result { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>()
+                                                .ForMember(dest => dest.Result, opt => opt.MapFrom(src => Enumerable.Sum(src.Numbers) + Enumerable.Average(src.OtherNumbers)));
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM031_PerformanceWarningAnalyzer>()
+            .WithSource(testCode)
+            .RunWithNoDiagnosticsAsync();
+    }
+
+    [Fact]
+    public async Task AM031_ShouldReportDiagnostic_WhenStaticLinqTerminalsEnumerateCapturedCollection()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Collections.Generic;
+                                using System.Linq;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public int Id { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public double Result { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            var numbers = new List<int> { 1, 2, 3 };
+
+                                            CreateMap<Source, Destination>()
+                                                .ForMember(dest => dest.Result, opt => opt.MapFrom(src => Enumerable.Sum(numbers) + Enumerable.Average(numbers)));
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM031_PerformanceWarningAnalyzer>()
+            .WithSource(testCode)
+            .ExpectDiagnostic(AM031_PerformanceWarningAnalyzer.MultipleEnumerationRule, 24, 68,
+                "Result", "numbers")
+            .RunAsync();
+    }
+
+    [Fact]
     public async Task AM031_ShouldReportDiagnostic_WhenMultipleEnumerationUsesNonSrcParameterName()
     {
         const string testCode = """


### PR DESCRIPTION
## Summary
- Track LINQ `SequenceEqual` as an AM031 terminal enumeration method.
- Count both `SequenceEqual` sequence inputs so repeated source collections report even when the repeated collection is the argument.
- Key static `Enumerable`/`Queryable` terminal calls to their source sequence arguments instead of the static type name.
- Update AM031 docs and add regression coverage for receiver, argument, static, distinct-source, and captured static LINQ cases.

## Verification
- `dotnet test tests\AutoMapperAnalyzer.Tests\AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter "SequenceEqual|StaticLinq"`
- `dotnet test tests\AutoMapperAnalyzer.Tests\AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter "AM031|RuleCatalogTests"`
- `dotnet run --project tools\AnalyzerVerifier\AnalyzerVerifier.csproj --configuration Debug -- --check-catalog --check-snapshots`
- `dotnet format whitespace automapper-analyser.sln --include src\AutoMapperAnalyzer.Analyzers\Performance\AM031_PerformanceWarningAnalyzer.cs tests\AutoMapperAnalyzer.Tests\Performance\AM031_PerformanceWarningTests.cs --verify-no-changes`
- `dotnet test automapper-analyser.sln --no-restore --framework net10.0`
- `git diff --check`