### PR TITLE
Detect redundant top-level ForPath in AM050

### DIFF
--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -1294,7 +1294,7 @@ dotnet_diagnostic.AM041.severity = warning
 
 Detects explicit `MapFrom` calls where the source and destination properties have the same name. AutoMapper maps these automatically by default.
 
-AM050 only reports when it can prove the source and destination members have the same type, including string-based destination member names such as `ForMember("Name", ...)`. It stays quiet when the destination member cannot be resolved or the same-name members have different types. Both source and destination lambda arguments accept simple, parenthesized, and typed shapes — `s => s.Name`, `(s) => s.Name`, and `(Source s) => s.Name` are all recognised. Multi-parameter parenthesized lambdas (such as AutoMapper's `(src, ctx) => ...` `IMemberConfigurationExpression` overload) intentionally stay outside the analyzer's scope.
+AM050 only reports when it can prove the source and destination members have the same type, including string-based destination member names such as `ForMember("Name", ...)` and top-level `ForPath(dest => dest.Name, ...)` mappings. Nested `ForPath` destination paths stay outside this cleanup rule because convention mapping equivalence is not guaranteed. It stays quiet when the destination member cannot be resolved or the same-name members have different types. Both source and destination lambda arguments accept simple, parenthesized, and typed shapes — `s => s.Name`, `(s) => s.Name`, and `(Source s) => s.Name` are all recognised. Multi-parameter parenthesized lambdas (such as AutoMapper's `(src, ctx) => ...` `IMemberConfigurationExpression` overload) intentionally stay outside the analyzer's scope.
 
 #### Problem
 
@@ -1311,6 +1311,8 @@ CreateMap<Source, Destination>()
 CreateMap<Source, Destination>();
 // AutoMapper automatically maps 'Name' to 'Name'
 ```
+
+Top-level redundant `ForPath(dest => dest.Name, opt => opt.MapFrom(src => src.Name))` configurations receive the same removal action. Nested paths keep no automatic cleanup action.
 
 #### Configuration
 

--- a/src/AutoMapperAnalyzer.Analyzers/Configuration/AM050_RedundantMapFromAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Configuration/AM050_RedundantMapFromAnalyzer.cs
@@ -50,21 +50,24 @@ public class AM050_RedundantMapFromAnalyzer : DiagnosticAnalyzer
                 return;
             }
 
-            // Check if it's inside ForMember
-            InvocationExpressionSyntax? forMemberInvocation = invocation.Ancestors()
+            // Check if it's inside a destination member/path configuration.
+            InvocationExpressionSyntax? destinationConfigurationInvocation = invocation.Ancestors()
                 .OfType<InvocationExpressionSyntax>()
                 .FirstOrDefault(inv =>
                     inv.Expression is MemberAccessExpressionSyntax ma &&
-                    ma.Name.Identifier.Text == "ForMember" &&
-                    MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(inv, context.SemanticModel, "ForMember"));
+                    ma.Name.Identifier.Text is "ForMember" or "ForPath" &&
+                    MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(
+                        inv,
+                        context.SemanticModel,
+                        ma.Name.Identifier.Text));
 
-            if (forMemberInvocation == null)
+            if (destinationConfigurationInvocation == null)
             {
                 return;
             }
 
             // Get destination property name
-            string? destPropName = GetDestinationPropertyName(forMemberInvocation);
+            string? destPropName = GetDestinationPropertyName(destinationConfigurationInvocation);
             if (destPropName == null)
             {
                 return;
@@ -81,7 +84,7 @@ public class AM050_RedundantMapFromAnalyzer : DiagnosticAnalyzer
             if (string.Equals(sourcePropName, destPropName, StringComparison.Ordinal))
             {
                 // Check if types are compatible (same type including nullability)
-                if (!AreTypesCompatibleForAutoMapping(forMemberInvocation, invocation, context))
+                if (!AreTypesCompatibleForAutoMapping(destinationConfigurationInvocation, invocation, context))
                 {
                     return; // Not redundant if types differ (e.g., int? to int)
                 }
@@ -97,13 +100,13 @@ public class AM050_RedundantMapFromAnalyzer : DiagnosticAnalyzer
     }
 
     private static bool AreTypesCompatibleForAutoMapping(
-        InvocationExpressionSyntax forMemberInvocation,
+        InvocationExpressionSyntax destinationConfigurationInvocation,
         InvocationExpressionSyntax mapFromInvocation,
         SyntaxNodeAnalysisContext context)
     {
         // Get source and destination property types
         ITypeSymbol? sourceType = GetSourcePropertyType(mapFromInvocation, context);
-        ITypeSymbol? destType = GetDestinationPropertyType(forMemberInvocation, context);
+        ITypeSymbol? destType = GetDestinationPropertyType(destinationConfigurationInvocation, context);
 
         if (sourceType == null || destType == null)
         {

--- a/src/AutoMapperAnalyzer.Analyzers/Configuration/AM050_RedundantMapFromCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Configuration/AM050_RedundantMapFromCodeFixProvider.cs
@@ -32,45 +32,53 @@ public class AM050_RedundantMapFromCodeFixProvider : AutoMapperCodeFixProviderBa
         {
             SyntaxNode? node = operationContext.Root.FindNode(diagnostic.Location.SourceSpan);
 
-            // The analyzer reports on the 'MapFrom' invocation, which is inside ForMember
-            // We need to find the outer ForMember invocation
+            // The analyzer reports on the 'MapFrom' invocation, which is inside ForMember/ForPath.
+            // We need to find the outer destination configuration invocation.
             InvocationExpressionSyntax? mapFromInvocation = node?.AncestorsAndSelf()
                 .OfType<InvocationExpressionSyntax>()
                 .FirstOrDefault(inv =>
                     inv.Expression is MemberAccessExpressionSyntax ma &&
                     ma.Name.Identifier.Text == "MapFrom");
 
-            InvocationExpressionSyntax? forMemberInvocation = node?.AncestorsAndSelf()
+            InvocationExpressionSyntax? destinationConfigurationInvocation = node?.AncestorsAndSelf()
                 .OfType<InvocationExpressionSyntax>()
                 .FirstOrDefault(inv =>
                     inv.Expression is MemberAccessExpressionSyntax ma &&
-                    ma.Name.Identifier.Text == "ForMember");
+                    ma.Name.Identifier.Text is "ForMember" or "ForPath" &&
+                    MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(
+                        inv,
+                        operationContext.SemanticModel,
+                        ma.Name.Identifier.Text));
 
-            if (forMemberInvocation != null &&
+            if (destinationConfigurationInvocation != null &&
                 mapFromInvocation != null &&
-                ForMemberLambdaContainsOnlyTheMapFrom(forMemberInvocation, mapFromInvocation))
+                DestinationConfigurationLambdaContainsOnlyTheMapFrom(destinationConfigurationInvocation, mapFromInvocation))
             {
-                string propertyName = GetDestinationPropertyName(forMemberInvocation) ?? "property";
+                string configurationMethodName = GetConfigurationMethodName(destinationConfigurationInvocation) ?? "mapping";
+                string propertyName = GetDestinationPropertyName(destinationConfigurationInvocation) ?? "property";
+                string equivalenceKey = configurationMethodName == "ForMember"
+                    ? $"AM050_RemoveRedundantMapping_{propertyName}"
+                    : $"AM050_RemoveRedundant{configurationMethodName}_{propertyName}";
                 context.RegisterCodeFix(
                     CodeAction.Create(
-                        $"Remove redundant ForMember for '{propertyName}'",
-                        c => RemoveRedundantMapping(context.Document, operationContext.Root, forMemberInvocation),
-                        $"AM050_RemoveRedundantMapping_{propertyName}"),
+                        $"Remove redundant {configurationMethodName} for '{propertyName}'",
+                        c => RemoveRedundantMapping(context.Document, operationContext.Root, destinationConfigurationInvocation),
+                        equivalenceKey),
                     diagnostic);
             }
         }
     }
 
-    private static bool ForMemberLambdaContainsOnlyTheMapFrom(
-        InvocationExpressionSyntax forMemberInvocation,
+    private static bool DestinationConfigurationLambdaContainsOnlyTheMapFrom(
+        InvocationExpressionSyntax destinationConfigurationInvocation,
         InvocationExpressionSyntax mapFromInvocation)
     {
-        if (forMemberInvocation.ArgumentList.Arguments.Count < 2)
+        if (destinationConfigurationInvocation.ArgumentList.Arguments.Count < 2)
         {
             return false;
         }
 
-        ExpressionSyntax optionsArgument = forMemberInvocation.ArgumentList.Arguments[1].Expression;
+        ExpressionSyntax optionsArgument = destinationConfigurationInvocation.ArgumentList.Arguments[1].Expression;
         CSharpSyntaxNode? body = optionsArgument switch
         {
             SimpleLambdaExpressionSyntax simple => simple.Body,
@@ -93,8 +101,8 @@ public class AM050_RedundantMapFromCodeFixProvider : AutoMapperCodeFixProviderBa
     {
         if (invocation.Expression is MemberAccessExpressionSyntax memberAccess)
         {
-            // Replace the whole ForMember(...) invocation with the expression it was called on
-            // e.g. CreateMap<A,B>().ForMember(...) -> CreateMap<A,B>()
+            // Replace the whole ForMember/ForPath invocation with the expression it was called on.
+            // e.g. CreateMap<A,B>().ForMember(...) -> CreateMap<A,B>().
             return ReplaceNodeAsync(document, root, invocation,
                 memberAccess.Expression.WithTrailingTrivia(invocation.GetTrailingTrivia()));
         }
@@ -102,20 +110,27 @@ public class AM050_RedundantMapFromCodeFixProvider : AutoMapperCodeFixProviderBa
         return Task.FromResult(document);
     }
 
-    private static string? GetDestinationPropertyName(InvocationExpressionSyntax forMemberInvocation)
+    private static string? GetConfigurationMethodName(InvocationExpressionSyntax destinationConfigurationInvocation)
     {
-        if (forMemberInvocation.ArgumentList.Arguments.Count == 0)
+        return destinationConfigurationInvocation.Expression is MemberAccessExpressionSyntax memberAccess
+            ? memberAccess.Name.Identifier.ValueText
+            : null;
+    }
+
+    private static string? GetDestinationPropertyName(InvocationExpressionSyntax destinationConfigurationInvocation)
+    {
+        if (destinationConfigurationInvocation.ArgumentList.Arguments.Count == 0)
         {
             return null;
         }
 
-        SyntaxNode? lambdaBody = AutoMapperAnalysisHelpers.GetLambdaBody(forMemberInvocation.ArgumentList.Arguments[0].Expression);
+        SyntaxNode? lambdaBody = AutoMapperAnalysisHelpers.GetLambdaBody(destinationConfigurationInvocation.ArgumentList.Arguments[0].Expression);
         if (lambdaBody is MemberAccessExpressionSyntax memberAccess)
         {
             return memberAccess.Name.Identifier.ValueText;
         }
 
-        ExpressionSyntax expression = forMemberInvocation.ArgumentList.Arguments[0].Expression;
+        ExpressionSyntax expression = destinationConfigurationInvocation.ArgumentList.Arguments[0].Expression;
         return expression is LiteralExpressionSyntax literal &&
                literal.IsKind(SyntaxKind.StringLiteralExpression)
             ? literal.Token.ValueText

--- a/tests/AutoMapperAnalyzer.Tests/Configuration/AM050_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Configuration/AM050_CodeFixTests.cs
@@ -59,6 +59,48 @@ public class AM050_CodeFixTests
     }
 
     [Fact]
+    public async Task Should_Remove_RedundantTopLevelForPath_AtEndOfChain()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                public class Source { public string Name { get; set; } }
+                                public class Destination { public string Name { get; set; } }
+
+                                public class MyProfile : Profile
+                                {
+                                    public MyProfile()
+                                    {
+                                        CreateMap<Source, Destination>()
+                                            .ForPath(d => d.Name, o => o.MapFrom(s => s.Name));
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 using AutoMapper;
+
+                                 public class Source { public string Name { get; set; } }
+                                 public class Destination { public string Name { get; set; } }
+
+                                 public class MyProfile : Profile
+                                 {
+                                     public MyProfile()
+                                     {
+                                         CreateMap<Source, Destination>();
+                                     }
+                                 }
+                                 """;
+
+        DiagnosticResult expected = new DiagnosticResult(AM050_RedundantMapFromAnalyzer.RedundantMapFromRule)
+            .WithLocation(11, 40)
+            .WithArguments("Name");
+
+        await CodeFixVerifier<AM050_RedundantMapFromAnalyzer, AM050_RedundantMapFromCodeFixProvider>
+            .VerifyFixAsync(testCode, expected, fixedCode);
+    }
+
+    [Fact]
     public async Task Should_Remove_RedundantMapping_InMiddleOfChain()
     {
         const string testCode = """

--- a/tests/AutoMapperAnalyzer.Tests/Configuration/AM050_RedundantMapFromTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Configuration/AM050_RedundantMapFromTests.cs
@@ -33,6 +33,55 @@ public class AM050_RedundantMapFromTests
     }
 
     [Fact]
+    public async Task Should_ReportDiagnostic_When_TopLevelForPathMapsSamePropertyName()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                public class Source { public string Name { get; set; } }
+                                public class Destination { public string Name { get; set; } }
+
+                                public class MyProfile : Profile
+                                {
+                                    public MyProfile()
+                                    {
+                                        CreateMap<Source, Destination>()
+                                            .ForPath(d => d.Name, o => o.MapFrom(s => s.Name));
+                                    }
+                                }
+                                """;
+
+        DiagnosticResult expected = new DiagnosticResult(AM050_RedundantMapFromAnalyzer.RedundantMapFromRule)
+            .WithLocation(11, 40)
+            .WithArguments("Name");
+
+        await AnalyzerVerifier<AM050_RedundantMapFromAnalyzer>.VerifyAnalyzerAsync(testCode, expected);
+    }
+
+    [Fact]
+    public async Task Should_NotReportDiagnostic_When_ForPathMapsNestedDestinationPath()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                public class Source { public string Name { get; set; } }
+                                public class Destination { public DestinationChild Child { get; set; } }
+                                public class DestinationChild { public string Name { get; set; } }
+
+                                public class MyProfile : Profile
+                                {
+                                    public MyProfile()
+                                    {
+                                        CreateMap<Source, Destination>()
+                                            .ForPath(d => d.Child.Name, o => o.MapFrom(s => s.Name));
+                                    }
+                                }
+                                """;
+
+        await AnalyzerVerifier<AM050_RedundantMapFromAnalyzer>.VerifyAnalyzerAsync(testCode);
+    }
+
+    [Fact]
     public async Task Should_ReportDiagnostic_When_MapFromUsesParenthesizedLambda()
     {
         const string testCode = """


### PR DESCRIPTION
## Summary
- Extend AM050 redundant `MapFrom` detection from `ForMember` to top-level `ForPath(dest => dest.Member, ...)` mappings.
- Keep nested `ForPath` paths out of scope because convention equivalence is not guaranteed.
- Let the AM050 code fix remove redundant top-level `ForPath` while preserving existing `ForMember` equivalence keys.
- Update AM050 docs and add analyzer/code-fix regression coverage.

## Verification
- `dotnet format whitespace automapper-analyser.sln --include src\AutoMapperAnalyzer.Analyzers\Configuration\AM050_RedundantMapFromAnalyzer.cs src\AutoMapperAnalyzer.Analyzers\Configuration\AM050_RedundantMapFromCodeFixProvider.cs tests\AutoMapperAnalyzer.Tests\Configuration\AM050_RedundantMapFromTests.cs tests\AutoMapperAnalyzer.Tests\Configuration\AM050_CodeFixTests.cs --verify-no-changes`
- `dotnet test tests\AutoMapperAnalyzer.Tests\AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter "AM050|RuleCatalogTests"`
- `dotnet run --project tools\AnalyzerVerifier\AnalyzerVerifier.csproj --configuration Debug -- --check-catalog --check-snapshots`
- `git diff --check`
- `dotnet test automapper-analyser.sln --no-restore --framework net10.0`