### PR TITLE
Support ImmutableArray containers in AM003

### DIFF
--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -267,15 +267,15 @@ automatic conversions. For unsupported custom collection destination types, AM00
 speculative constructor rewrites and offers only the manual-review ignore action. Known BCL collection destinations with
 safe collection constructors, such as `SortedSet<T>` and `LinkedList<T>`, still receive constructor-based mapping actions.
 Immutable/frozen destination containers use fully qualified `ImmutableList.CreateRange(...)`,
-`ImmutableHashSet.CreateRange(...)`, or `FrozenSet.ToFrozenSet(...)` factory calls so generated mappings remain
-executable without depending on user imports.
+`ImmutableArray.CreateRange(...)`, `ImmutableHashSet.CreateRange(...)`, or `FrozenSet.ToFrozenSet(...)` factory calls so
+generated mappings remain executable without depending on user imports.
 
 #### Detected Incompatibilities
 
 - ✅ `HashSet` ↔ `List`/`Array`
 - ✅ `Queue` ↔ other collections
 - ✅ `Stack` ↔ other collections
-- ✅ Mutable collections → `ImmutableList<T>`, `ImmutableHashSet<T>`, or `FrozenSet<T>`
+- ✅ Mutable collections → `ImmutableList<T>`, `ImmutableArray<T>`, `ImmutableHashSet<T>`, or `FrozenSet<T>`
 - ❌ Element type mismatches (owned by `AM021`)
 - ❌ `List` → `Array` (AutoMapper handles this)
 - ❌ Source collections already assignable to the destination contract, such as `T[]` → `IEnumerable<T>` or `HashSet<T>` → `IReadOnlyCollection<T>`

--- a/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM003_CollectionTypeIncompatibilityAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM003_CollectionTypeIncompatibilityAnalyzer.cs
@@ -223,6 +223,10 @@ public class AM003_CollectionTypeIncompatibilityAnalyzer : DiagnosticAnalyzer
             IsConstructedFromType(sourceType, "System.Collections.Immutable.ImmutableList<T>");
         bool destIsImmutableList =
             IsConstructedFromType(destType, "System.Collections.Immutable.ImmutableList<T>");
+        bool sourceIsImmutableArray =
+            IsConstructedFromType(sourceType, "System.Collections.Immutable.ImmutableArray<T>");
+        bool destIsImmutableArray =
+            IsConstructedFromType(destType, "System.Collections.Immutable.ImmutableArray<T>");
         bool sourceIsImmutableHashSet =
             IsConstructedFromType(sourceType, "System.Collections.Immutable.ImmutableHashSet<T>");
         bool destIsImmutableHashSet =
@@ -270,6 +274,16 @@ public class AM003_CollectionTypeIncompatibilityAnalyzer : DiagnosticAnalyzer
         }
 
         if (!sourceIsImmutableList && destIsImmutableList)
+        {
+            return true;
+        }
+
+        if (sourceIsImmutableArray && !destIsImmutableArray)
+        {
+            return true;
+        }
+
+        if (!sourceIsImmutableArray && destIsImmutableArray)
         {
             return true;
         }

--- a/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM003_CollectionTypeIncompatibilityCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM003_CollectionTypeIncompatibilityCodeFixProvider.cs
@@ -411,6 +411,16 @@ public class AM003_CollectionTypeIncompatibilityCodeFixProvider : AutoMapperCode
             return true;
         }
 
+        if (IsKnownConcreteCollectionType(destinationType, "ImmutableArray", "System.Collections.Immutable."))
+        {
+            fix = (
+                $"Convert {propertyName} using ImmutableArray.CreateRange()",
+                $"global::System.Collections.Immutable.ImmutableArray.CreateRange({sourceExpression})",
+                needsElementConversion,
+                $"AM003_ImmutableArray_{propertyName}");
+            return true;
+        }
+
         if (IsKnownConcreteCollectionType(destinationType, "ImmutableHashSet", "System.Collections.Immutable."))
         {
             fix = (

--- a/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM003_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM003_CodeFixTests.cs
@@ -988,6 +988,146 @@ public class AM003_CodeFixTests
     }
 
     [Fact]
+    public async Task AM003_ShouldFixListToImmutableArrayWithCreateRange()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Collections.Generic;
+                                using System.Collections.Immutable;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public List<string> Tags { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public ImmutableArray<string> Tags { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string expectedFixedCode = """
+                                         using AutoMapper;
+                                         using System.Collections.Generic;
+                                         using System.Collections.Immutable;
+
+                                         namespace TestNamespace
+                                         {
+                                             public class Source
+                                             {
+                                                 public List<string> Tags { get; set; }
+                                             }
+
+                                             public class Destination
+                                             {
+                                                 public ImmutableArray<string> Tags { get; set; }
+                                             }
+
+                                             public class TestProfile : Profile
+                                             {
+                                                 public TestProfile()
+                                                 {
+                                                     CreateMap<Source, Destination>().ForMember(dest => dest.Tags, opt => opt.MapFrom(src => global::System.Collections.Immutable.ImmutableArray.CreateRange(src.Tags)));
+                                                 }
+                                             }
+                                         }
+                                         """;
+
+        await VerifyFixAsync(
+            testCode,
+            AM003_CollectionTypeIncompatibilityAnalyzer.CollectionTypeIncompatibilityRule,
+            21,
+            13,
+            expectedFixedCode,
+            "Tags",
+            "Source",
+            "System.Collections.Generic.List<string>",
+            "Destination",
+            "System.Collections.Immutable.ImmutableArray<string>");
+    }
+
+    [Fact]
+    public async Task AM003_ShouldFixImmutableArrayToListWithConstructor()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Collections.Generic;
+                                using System.Collections.Immutable;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public ImmutableArray<string> Tags { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public List<string> Tags { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string expectedFixedCode = """
+                                         using AutoMapper;
+                                         using System.Collections.Generic;
+                                         using System.Collections.Immutable;
+
+                                         namespace TestNamespace
+                                         {
+                                             public class Source
+                                             {
+                                                 public ImmutableArray<string> Tags { get; set; }
+                                             }
+
+                                             public class Destination
+                                             {
+                                                 public List<string> Tags { get; set; }
+                                             }
+
+                                             public class TestProfile : Profile
+                                             {
+                                                 public TestProfile()
+                                                 {
+                                                     CreateMap<Source, Destination>().ForMember(dest => dest.Tags, opt => opt.MapFrom(src => new List<string>(src.Tags)));
+                                                 }
+                                             }
+                                         }
+                                         """;
+
+        await VerifyFixAsync(
+            testCode,
+            AM003_CollectionTypeIncompatibilityAnalyzer.CollectionTypeIncompatibilityRule,
+            21,
+            13,
+            expectedFixedCode,
+            "Tags",
+            "Source",
+            "System.Collections.Immutable.ImmutableArray<string>",
+            "Destination",
+            "System.Collections.Generic.List<string>");
+    }
+
+    [Fact]
     public async Task AM003_ShouldFixListToImmutableHashSetWithCreateRange()
     {
         const string testCode = """

--- a/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM003_CollectionTypeIncompatibilityTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM003_CollectionTypeIncompatibilityTests.cs
@@ -265,6 +265,82 @@ public class AM003_CollectionTypeIncompatibilityTests
     }
 
     [Fact]
+    public async Task AM003_ShouldReportDiagnostic_WhenListToImmutableArray()
+    {
+        const string testCode = """
+
+                                using AutoMapper;
+                                using System.Collections.Generic;
+                                using System.Collections.Immutable;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public List<string> Tags { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public ImmutableArray<string> Tags { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await AnalyzerVerifier<AM003_CollectionTypeIncompatibilityAnalyzer>.VerifyAnalyzerAsync(
+            testCode,
+            Diagnostic(AM003_CollectionTypeIncompatibilityAnalyzer.CollectionTypeIncompatibilityRule, 22, 13,
+                "Tags", "Source", "System.Collections.Generic.List<string>", "Destination",
+                "System.Collections.Immutable.ImmutableArray<string>"));
+    }
+
+    [Fact]
+    public async Task AM003_ShouldReportDiagnostic_WhenImmutableArrayToList()
+    {
+        const string testCode = """
+
+                                using AutoMapper;
+                                using System.Collections.Generic;
+                                using System.Collections.Immutable;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public ImmutableArray<string> Tags { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public List<string> Tags { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await AnalyzerVerifier<AM003_CollectionTypeIncompatibilityAnalyzer>.VerifyAnalyzerAsync(
+            testCode,
+            Diagnostic(AM003_CollectionTypeIncompatibilityAnalyzer.CollectionTypeIncompatibilityRule, 22, 13,
+                "Tags", "Source", "System.Collections.Immutable.ImmutableArray<string>", "Destination",
+                "System.Collections.Generic.List<string>"));
+    }
+
+    [Fact]
     public async Task AM003_ShouldReportDiagnostic_WhenQueueToFrozenSet()
     {
         const string testCode = """


### PR DESCRIPTION
## Summary
- Teach AM003 to treat `ImmutableArray<T>` as an immutable collection container mismatch when the other side is a different collection container.
- Add the safe `ImmutableArray.CreateRange(...)` code fix for destination `ImmutableArray<T>` mappings.
- Update AM003 docs and add analyzer/code-fix regression coverage.

## Validation
- `dotnet test tests\AutoMapperAnalyzer.Tests\AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter AM003` (expected pre-fix failure for the new tests, then passing after implementation)
- `dotnet test tests\AutoMapperAnalyzer.Tests\AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter "AM003|RuleCatalogTests"`
- `dotnet format whitespace automapper-analyser.sln --include src\AutoMapperAnalyzer.Analyzers\TypeSafety\AM003_CollectionTypeIncompatibilityAnalyzer.cs src\AutoMapperAnalyzer.Analyzers\TypeSafety\AM003_CollectionTypeIncompatibilityCodeFixProvider.cs tests\AutoMapperAnalyzer.Tests\TypeSafety\AM003_CollectionTypeIncompatibilityTests.cs tests\AutoMapperAnalyzer.Tests\TypeSafety\AM003_CodeFixTests.cs --verify-no-changes`
- `dotnet test automapper-analyser.sln --no-restore --framework net10.0`
- `dotnet run --project tools\AnalyzerVerifier\AnalyzerVerifier.csproj --configuration Debug -- --check-catalog --check-snapshots`
- `git diff --check`