### PR TITLE
Add AM021 ImmutableArray conversion fix

### DIFF
--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -805,9 +805,9 @@ public class MappingProfile : Profile
 
 For simple element conversions, AM021 can add a `Select(...)` mapping. List-like interface destinations use `ToList()`,
 `HashSet<T>`/`ISet<T>` destinations are wrapped in a concrete `HashSet<T>` constructor, and known immutable/frozen
-destinations use fully qualified `ImmutableList.CreateRange(...)`, `ImmutableHashSet.CreateRange(...)`, or
-`FrozenSet.ToFrozenSet(...)` calls so the generated mapping stays executable. Custom collection lookalikes remain on
-the manual-review path instead of receiving name-based rewrites.
+destinations use fully qualified `ImmutableList.CreateRange(...)`, `ImmutableArray.CreateRange(...)`,
+`ImmutableHashSet.CreateRange(...)`, or `FrozenSet.ToFrozenSet(...)` calls so the generated mapping stays executable.
+Custom collection lookalikes remain on the manual-review path instead of receiving name-based rewrites.
 
 #### Configuration
 

--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM021_CollectionElementMismatchCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM021_CollectionElementMismatchCodeFixProvider.cs
@@ -349,6 +349,11 @@ public class AM021_CollectionElementMismatchCodeFixProvider : AutoMapperCodeFixP
             return $"global::System.Collections.Immutable.ImmutableList.CreateRange({selectExpression})";
         }
 
+        if (IsConstructedFromType(destProperty.Type, "System.Collections.Immutable.ImmutableArray<T>"))
+        {
+            return $"global::System.Collections.Immutable.ImmutableArray.CreateRange({selectExpression})";
+        }
+
         if (IsConstructedFromType(destProperty.Type, "System.Collections.Immutable.ImmutableHashSet<T>"))
         {
             return $"global::System.Collections.Immutable.ImmutableHashSet.CreateRange({selectExpression})";

--- a/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM021_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM021_CodeFixTests.cs
@@ -840,6 +840,73 @@ public class AM021_CodeFixTests
     }
 
     [Fact]
+    public async Task AM021_ShouldFixListToImmutableArray_WithSelectAndCreateRange()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Collections.Generic;
+                                using System.Collections.Immutable;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public List<string> Values { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public ImmutableArray<int> Values { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string expectedFixedCode = """
+                                         using AutoMapper;
+                                         using System.Collections.Generic;
+                                         using System.Collections.Immutable;
+                                         using System.Linq;
+
+                                         namespace TestNamespace
+                                         {
+                                             public class Source
+                                             {
+                                                 public List<string> Values { get; set; }
+                                             }
+
+                                             public class Destination
+                                             {
+                                                 public ImmutableArray<int> Values { get; set; }
+                                             }
+
+                                             public class TestProfile : Profile
+                                             {
+                                                 public TestProfile()
+                                                 {
+                                                     CreateMap<Source, Destination>().ForMember(dest => dest.Values, opt => opt.MapFrom(src => global::System.Collections.Immutable.ImmutableArray.CreateRange(src.Values.Select(x => global::System.Convert.ToInt32(x)))));
+                                                 }
+                                             }
+                                         }
+                                         """;
+
+        await CodeFixVerifier<AM021_CollectionElementMismatchAnalyzer, AM021_CollectionElementMismatchCodeFixProvider>
+            .VerifyFixAsync(
+                testCode,
+                new DiagnosticResult(AM021_CollectionElementMismatchAnalyzer.CollectionElementIncompatibilityRule)
+                    .WithLocation(21, 13)
+                    .WithArguments("Values", "Source", "string", "Destination", "Values", "int"),
+                expectedFixedCode);
+    }
+
+    [Fact]
     public async Task AM021_ShouldFixListToImmutableHashSet_WithSelectAndCreateRange()
     {
         const string testCode = """


### PR DESCRIPTION
## Summary
- Add the AM021 simple-conversion code fix for destination `ImmutableArray<T>` collections using `ImmutableArray.CreateRange(...)`.
- Add regression coverage for `List<string>` to `ImmutableArray<int>` element conversion.
- Update AM021 docs to include the immutable-array factory path.

## Validation
- `dotnet test tests\AutoMapperAnalyzer.Tests\AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter AM021` (expected pre-fix failure for the new test, then passing after implementation)
- `dotnet test tests\AutoMapperAnalyzer.Tests\AutoMapperAnalyzer.Tests.csproj --no-restore --framework net10.0 --filter "AM021|RuleCatalogTests"`
- `dotnet run --project tools\AnalyzerVerifier\AnalyzerVerifier.csproj --configuration Debug -- --check-catalog --check-snapshots`
- `dotnet format whitespace automapper-analyser.sln --include src\AutoMapperAnalyzer.Analyzers\ComplexMappings\AM021_CollectionElementMismatchCodeFixProvider.cs tests\AutoMapperAnalyzer.Tests\ComplexMappings\AM021_CodeFixTests.cs --verify-no-changes`
- `dotnet test automapper-analyser.sln --no-restore --framework net10.0`
- `git diff --check`