### PR TITLE
release: 2.30.49 — AM021 dictionary mapping + AM002 collection element nullability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+## [2.30.49] - 2026-06-07
+
+Two new detection capabilities. Both premises and the generated fixes were verified against a real AutoMapper 14 runtime probe.
+
+### Added
+
+- **AM021**: Decomposes dictionary `KeyValuePair<TKey, TValue>` element types into independent key/value axes. Removes a false positive on idiomatic dictionary mappings (`Dictionary<K, Foo>` → `Dictionary<K, FooDto>` maps correctly when `CreateMap<Foo, FooDto>` is registered — previously reported because the analyzer looked for a non-existent `CreateMap<KeyValuePair<…>, KeyValuePair<…>>`) and adds executable fixes where only manual-ignore existed: a `ToDictionary(…)` projection for simple primitive key/value conversions (gated so `DateTime`/`Guid` `Parse` targets require a string source) and a decomposed `CreateMap<TValueSource, TValueDest>()` for a complex value with a pass-through key (never a `KeyValuePair` map). Generic-collection axes (e.g. `List<int>` vs `List<string>`) and both-axes-incompatible dictionaries keep the manual-review ignore action only.
+- **AM002**: Detects collection element nullability loss — a nullable reference-type element mapped to a non-nullable element of the same type (e.g. `List<string?>` → `List<string>`, `string?[]` → `string[]`). Scoped to convention-based mappings and reference-type elements of the same underlying type; element-type mismatches and value-type nullables stay with `AM021`/`AM001`. The diagnostic offers only the manual-review ignore action (a `?? default` scaffold cannot fix element-level nullability).
+
+### Validation
+
+- Full solution test suite (`net10.0`) green.
+- AnalyzerVerifier `--check-catalog --check-snapshots` green.
+- `dotnet build -warnaserror` clean.
+
 ## [2.30.48] - 2026-06-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -14,24 +14,24 @@ prevention*
 
 ---
 
-## 🎉 Latest Release: v2.30.48
+## 🎉 Latest Release: v2.30.49
 
-**AM021 ImmutableArray element conversion fix**
+**AM021 dictionary mapping and AM002 collection element nullability**
 
 ✅ **Highlights**
 
-- AM021 simple element-conversion fixes now cover destination `ImmutableArray<T>` collections.
-- Generated mappings use fully qualified `ImmutableArray.CreateRange(...)` plus the existing `global::System.Convert` element conversions.
-- Added regression coverage for `List<string>` to `ImmutableArray<int>` collection element mismatches.
+- AM021 decomposes dictionary `KeyValuePair` element types into key/value axes: no longer false-positives on `Dictionary<K, Foo>` → `Dictionary<K, FooDto>` when a `CreateMap<Foo, FooDto>` is registered, and offers executable `ToDictionary` / decomposed element-`CreateMap` fixes instead of manual-ignore only.
+- AM002 detects collection element nullability loss (e.g. `List<string?>` → `List<string>`, `string?[]` → `string[]`), scoped to reference-type elements of the same underlying type.
 
 🧪 **Validation**
 
-- Full solution test validation passed on `net10.0` with 859 tests.
+- Full solution test validation passed on `net10.0`.
 - AnalyzerVerifier `--check-catalog --check-snapshots` green.
-- PR #123 CI/package smoke checks green.
+- Premises and generated fixes verified against an AutoMapper 14 runtime probe.
 
 ### Recent Releases
 
+- **v2.30.49**: AM021 dictionary key/value decomposition (removes a false positive, adds `ToDictionary`/element-`CreateMap` fixes) and AM002 collection element nullability detection.
 - **v2.30.48**: AM021 simple element-conversion fixes now cover destination `ImmutableArray<T>` collections with fully qualified `ImmutableArray.CreateRange(...)` mappings.
 - **v2.30.47**: AM003 now covers `ImmutableArray<T>` container mismatches and offers `ImmutableArray.CreateRange(...)` for destination immutable arrays.
 - **v2.30.46**: AM050 now covers redundant top-level `ForPath` `MapFrom` mappings and removes them with the same safe single-call rewrite guard as `ForMember`.
@@ -216,7 +216,7 @@ Install-Package AutoMapperAnalyzer.Analyzers
 ### Project File (For CI/CD)
 
 ```xml
-<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.48">
+<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.49">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 </PackageReference>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -725,7 +725,7 @@ dotnet pack --configuration Release
 
 # Test package locally
 cd test-install/NetCoreTest
-dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.48-local
+dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.49-local
 ```
 
 ---
@@ -909,4 +909,4 @@ dotnet build
 
 **Last Updated**: 2026-05-14
 **Maintainer**: George Wall
-**Version**: 2.30.48
+**Version**: 2.30.49

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -112,8 +112,8 @@ The AutoMapper Roslyn Analyzer project uses GitHub Actions for continuous integr
 ### Package Versioning
 
 - **Format**: Major.Minor.Patch (SemVer)
-- **Current**: 2.30.48
-- **Pre-release**: 2.30.48-preview, 2.30.48-beta
+- **Current**: 2.30.49
+- **Pre-release**: 2.30.49-preview, 2.30.49-beta
 
 ## 🔧 Configuration
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -43,7 +43,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.48">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.49">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -67,7 +67,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.48">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.49">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -86,7 +86,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="14.0.0" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.48">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.49">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -218,7 +218,7 @@ public class Destination
 
 2. **Verify Package Installation**
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.48">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.49">
      <PrivateAssets>all</PrivateAssets>
      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -280,4 +280,4 @@ This guide ensures smooth installation and usage across all supported .NET frame
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.48
+**Version**: 2.30.49

--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -1421,7 +1421,7 @@ using System.Diagnostics.CodeAnalysis;
 
 1. **Check package reference**:
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.48">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.49">
        <PrivateAssets>all</PrivateAssets>
        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -1460,5 +1460,5 @@ If analyzer slows down builds:
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.48
+**Version**: 2.30.49
 **Maintainer**: George Wall

--- a/docs/RULE_CATALOG.md
+++ b/docs/RULE_CATALOG.md
@@ -2,7 +2,7 @@
 
 This file is generated from `RuleCatalog`.
 
-Package version: `2.30.48`
+Package version: `2.30.49`
 
 | Rule ID | Descriptor Title | Severity | Category | Analyzer | Code Fix | Trust | Sample | Docs |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,3 +1,15 @@
+## Release 2.30.49
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
+### Removed Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
 ## Release 2.30.48
 
 ### New Rules

--- a/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
+++ b/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
@@ -17,7 +17,7 @@
         <!-- Fallback for local builds: 2.0.YYYYMMDD-local -->
         <MajorVersion>2</MajorVersion>
         <MinorVersion>30</MinorVersion>
-        <PatchVersion>48</PatchVersion>
+        <PatchVersion>49</PatchVersion>
         <BuildNumber Condition="'$(BuildNumber)' == ''"
         >$([System.DateTime]::Now.ToString('yyyyMMdd'))
         </BuildNumber
@@ -32,20 +32,18 @@
         <RepositoryUrl>https://github.com/georgepwall1991/automapper-analyser</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <PackageReleaseNotes>Version 2.30.48 - AM021 ImmutableArray element conversion fix
+        <PackageReleaseNotes>Version 2.30.49 - AM021 dictionary mapping and AM002 collection element nullability
 
-            Changed:
-            - AM021 simple element-conversion fixes now cover destination ImmutableArray collections
-            - Generated mappings use fully qualified ImmutableArray.CreateRange factory calls
-            - Added regression coverage for List&lt;string&gt; to ImmutableArray&lt;int&gt; mappings
+            Added:
+            - AM021 decomposes dictionary KeyValuePair element types into key/value axes: it no longer false-positives on Dictionary&lt;K, Foo&gt; to Dictionary&lt;K, FooDto&gt; when a CreateMap&lt;Foo, FooDto&gt; is registered, and offers executable ToDictionary / decomposed element-CreateMap fixes instead of manual-ignore only
+            - AM002 detects collection element nullability loss (e.g. List&lt;string?&gt; to List&lt;string&gt;), scoped to reference-type elements of the same underlying type
 
             Validation:
-            - Full solution test suite passing on net10.0 (859 tests)
+            - Full solution test suite passing on net10.0
             - Rule catalog and sample diagnostics snapshot checks passing
-            - PR #123 CI/package smoke checks passing
             - git diff --check clean
 
-            Previous Release: v2.30.47 - AM003 ImmutableArray container support
+            Previous Release: v2.30.48 - AM021 ImmutableArray element conversion fix
         </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>

--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM021_CollectionElementMismatchAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM021_CollectionElementMismatchAnalyzer.cs
@@ -153,40 +153,124 @@ public class AM021_CollectionElementMismatchAnalyzer : DiagnosticAnalyzer
             return;
         }
 
+        var registry = CreateMapRegistry.FromCompilation(context.Compilation);
+
+        // Dictionary destinations surface as KeyValuePair<TKey, TValue> element types. Decompose into
+        // key/value axes: AutoMapper maps Dictionary<K, Foo> -> Dictionary<K, FooDto> correctly when a
+        // CreateMap<Foo, FooDto> is registered, so the previous "is there a CreateMap<KeyValuePair<..>,
+        // KeyValuePair<..>>?" check reported a false positive. Decomposing also lets the fixer offer a
+        // ToDictionary / element-CreateMap rewrite instead of a manual-ignore dead end.
+        if (TryGetKeyValuePairTypes(sourceElementType, out ITypeSymbol? keySource, out ITypeSymbol? valueSource) &&
+            TryGetKeyValuePairTypes(destElementType, out ITypeSymbol? keyDest, out ITypeSymbol? valueDest))
+        {
+            bool keyMappable = IsElementAxisMappable(context.Compilation, keySource!, keyDest!, registry);
+            bool valueMappable = IsElementAxisMappable(context.Compilation, valueSource!, valueDest!, registry);
+            if (keyMappable && valueMappable)
+            {
+                // Both axes are individually mappable; AutoMapper can map this dictionary.
+                return;
+            }
+
+            ImmutableDictionary<string, string?>.Builder dictionaryProperties =
+                ImmutableDictionary.CreateBuilder<string, string?>();
+            dictionaryProperties.Add("IsDictionary", "true");
+            dictionaryProperties.Add("KeySourceType", keySource!.ToDisplayString());
+            dictionaryProperties.Add("KeyDestType", keyDest!.ToDisplayString());
+            dictionaryProperties.Add("ValueSourceType", valueSource!.ToDisplayString());
+            dictionaryProperties.Add("ValueDestType", valueDest!.ToDisplayString());
+
+            ReportElementMismatch(context, invocation, sourceProperty, destinationProperty, sourceType,
+                destinationType, sourceElementType, destElementType, reportedProperties, dictionaryProperties);
+            return;
+        }
+
         // Check if element types are compatible
         if (!AreElementTypesCompatible(context.Compilation, sourceElementType, destElementType))
         {
             // Check if there's an explicit CreateMap for the element types
-            var registry = CreateMapRegistry.FromCompilation(context.Compilation);
             if (registry.Contains(sourceElementType, destElementType))
             {
                 // Element mapping exists, so AutoMapper can handle this collection mapping
                 return;
             }
 
-            ImmutableDictionary<string, string?>.Builder properties =
-                ImmutableDictionary.CreateBuilder<string, string?>();
-            properties.Add("PropertyName", destinationProperty.Name);
-            properties.Add("SourcePropertyName", sourceProperty.Name);
-            properties.Add("DestinationPropertyName", destinationProperty.Name);
-            properties.Add("SourceElementType", sourceElementType.ToDisplayString());
-            properties.Add("DestElementType", destElementType.ToDisplayString());
-
-            var diagnostic = Diagnostic.Create(
-                CollectionElementIncompatibilityRule,
-                invocation.GetLocation(),
-                properties.ToImmutable(),
-                sourceProperty.Name,
-                AutoMapperAnalysisHelpers.GetTypeName(sourceType),
-                sourceElementType.ToDisplayString(),
-                AutoMapperAnalysisHelpers.GetTypeName(destinationType),
-                destinationProperty.Name,
-                destElementType.ToDisplayString());
-
-            context.ReportDiagnostic(diagnostic);
-            reportedProperties.Add(sourceProperty.Name);
-            reportedProperties.Add(destinationProperty.Name);
+            ReportElementMismatch(context, invocation, sourceProperty, destinationProperty, sourceType,
+                destinationType, sourceElementType, destElementType, reportedProperties, extraProperties: null);
         }
+    }
+
+    private static void ReportElementMismatch(SyntaxNodeAnalysisContext context,
+        InvocationExpressionSyntax invocation,
+        IPropertySymbol sourceProperty,
+        IPropertySymbol destinationProperty,
+        ITypeSymbol sourceType,
+        ITypeSymbol destinationType,
+        ITypeSymbol sourceElementType,
+        ITypeSymbol destElementType,
+        HashSet<string> reportedProperties,
+        ImmutableDictionary<string, string?>.Builder? extraProperties)
+    {
+        ImmutableDictionary<string, string?>.Builder properties =
+            ImmutableDictionary.CreateBuilder<string, string?>();
+        properties.Add("PropertyName", destinationProperty.Name);
+        properties.Add("SourcePropertyName", sourceProperty.Name);
+        properties.Add("DestinationPropertyName", destinationProperty.Name);
+        properties.Add("SourceElementType", sourceElementType.ToDisplayString());
+        properties.Add("DestElementType", destElementType.ToDisplayString());
+        if (extraProperties != null)
+        {
+            foreach (KeyValuePair<string, string?> entry in extraProperties)
+            {
+                properties[entry.Key] = entry.Value;
+            }
+        }
+
+        var diagnostic = Diagnostic.Create(
+            CollectionElementIncompatibilityRule,
+            invocation.GetLocation(),
+            properties.ToImmutable(),
+            sourceProperty.Name,
+            AutoMapperAnalysisHelpers.GetTypeName(sourceType),
+            sourceElementType.ToDisplayString(),
+            AutoMapperAnalysisHelpers.GetTypeName(destinationType),
+            destinationProperty.Name,
+            destElementType.ToDisplayString());
+
+        context.ReportDiagnostic(diagnostic);
+        reportedProperties.Add(sourceProperty.Name);
+        reportedProperties.Add(destinationProperty.Name);
+    }
+
+    /// <summary>
+    ///     Decomposes a <c>KeyValuePair&lt;TKey, TValue&gt;</c> element type into its key and value type
+    ///     arguments. Used to analyze dictionary destinations per axis.
+    /// </summary>
+    private static bool TryGetKeyValuePairTypes(ITypeSymbol elementType, out ITypeSymbol? keyType,
+        out ITypeSymbol? valueType)
+    {
+        keyType = null;
+        valueType = null;
+        if (elementType is INamedTypeSymbol named &&
+            named.OriginalDefinition.ToDisplayString() == "System.Collections.Generic.KeyValuePair<TKey, TValue>" &&
+            named.TypeArguments.Length == 2)
+        {
+            keyType = named.TypeArguments[0];
+            valueType = named.TypeArguments[1];
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///     A dictionary key/value axis is mappable when the types are directly compatible (including
+    ///     compiler-known implicit conversions) or a CreateMap is registered for them.
+    /// </summary>
+    private static bool IsElementAxisMappable(Compilation compilation, ITypeSymbol sourceType, ITypeSymbol destType,
+        CreateMapRegistry registry)
+    {
+        return AreElementTypesCompatible(compilation, sourceType, destType) ||
+               registry.Contains(sourceType, destType);
     }
 
     private static bool AreCollectionTypesIncompatible(ITypeSymbol sourceType, ITypeSymbol destType)

--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM021_CollectionElementMismatchCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM021_CollectionElementMismatchCodeFixProvider.cs
@@ -97,6 +97,16 @@ public class AM021_CollectionElementMismatchCodeFixProvider : AutoMapperCodeFixP
                 continue;
             }
 
+            // Dictionary destinations carry decomposed key/value axes; offer a ToDictionary rewrite (simple
+            // axes) or a decomposed element CreateMap (complex value), instead of the previous ignore-only
+            // dead end. The KeyValuePair-guarded simple/complex paths below remain no-ops for dictionaries.
+            if (diagnostic.Properties.TryGetValue("IsDictionary", out string? isDictionary) &&
+                string.Equals(isDictionary, "true", StringComparison.Ordinal))
+            {
+                RegisterDictionaryFixes(context, operationContext.Root, invocation, sourcePropertyName,
+                    destinationPropertyNameValue, diagnostic, operationContext.SemanticModel);
+            }
+
             // Determine if this is a simple type conversion or complex mapping
             bool isSimpleConversion = IsSimpleTypeConversion(sourceElementType!, destElementType!);
 
@@ -155,6 +165,120 @@ public class AM021_CollectionElementMismatchCodeFixProvider : AutoMapperCodeFixP
                     AddMapFromWithLinqAsync(context.Document, root, invocation, destinationPropertyName, mapFromExpression),
                 $"AM021_SimpleConversion_{destinationPropertyName}"),
             diagnostic);
+    }
+
+    private void RegisterDictionaryFixes(
+        CodeFixContext context,
+        SyntaxNode root,
+        InvocationExpressionSyntax invocation,
+        string sourcePropertyName,
+        string destinationPropertyName,
+        Diagnostic diagnostic,
+        SemanticModel semanticModel)
+    {
+        if (!diagnostic.Properties.TryGetValue("KeySourceType", out string? keySource) ||
+            !diagnostic.Properties.TryGetValue("KeyDestType", out string? keyDest) ||
+            !diagnostic.Properties.TryGetValue("ValueSourceType", out string? valueSource) ||
+            !diagnostic.Properties.TryGetValue("ValueDestType", out string? valueDest) ||
+            string.IsNullOrEmpty(keySource) || string.IsNullOrEmpty(keyDest) ||
+            string.IsNullOrEmpty(valueSource) || string.IsNullOrEmpty(valueDest))
+        {
+            return;
+        }
+
+        bool keyNeedsConversion = !TypeNamesEquivalent(keySource!, keyDest!);
+        bool valueNeedsConversion = !TypeNamesEquivalent(valueSource!, valueDest!);
+        bool keyAxisSimple = !keyNeedsConversion || IsSafeAxisConversion(keySource!, keyDest!);
+        bool valueAxisSimple = !valueNeedsConversion || IsSafeAxisConversion(valueSource!, valueDest!);
+
+        // Both axes are pass-through or simple primitive conversions -> executable ToDictionary rewrite.
+        if ((keyNeedsConversion || valueNeedsConversion) && keyAxisSimple && valueAxisSimple)
+        {
+            string keySelector = keyNeedsConversion
+                ? $"{GetConversionMethod(keyDest!)}(kvp.Key)"
+                : "kvp.Key";
+            string valueSelector = valueNeedsConversion
+                ? $"{GetConversionMethod(valueDest!)}(kvp.Value)"
+                : "kvp.Value";
+            string mapFromExpression =
+                $"src.{sourcePropertyName}.ToDictionary(kvp => {keySelector}, kvp => {valueSelector})";
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    $"Convert {destinationPropertyName} entries using ToDictionary()",
+                    cancellationToken =>
+                        AddMapFromWithLinqAsync(context.Document, root, invocation, destinationPropertyName,
+                            mapFromExpression),
+                    $"AM021_DictionaryConversion_{destinationPropertyName}"),
+                diagnostic);
+            return;
+        }
+
+        // The value axis is a complex object type with no registered CreateMap -> offer the element map.
+        // Restricted to plain named types (generic collections/arrays such as List<int> vs List<string> are
+        // not a CreateMap target) AND a pass-through key axis: when the key also needs conversion (e.g.
+        // Dictionary<string, Foo> -> Dictionary<int, FooDto>), a value-only CreateMap would leave the key
+        // mismatch unresolved, so the diagnostic falls through to the manual-review ignore action only.
+        if (valueNeedsConversion && !valueAxisSimple && !keyNeedsConversion &&
+            IsPlainNamedTypeName(valueSource!) && IsPlainNamedTypeName(valueDest!))
+        {
+            RegisterComplexMappingFix(context, root, invocation, destinationPropertyName, valueSource!, valueDest!,
+                diagnostic, semanticModel);
+        }
+    }
+
+    /// <summary>
+    ///     Determines whether a dictionary key/value axis conversion is one the generated ToDictionary
+    ///     selector can actually compile. Both sides must be simple types, and a <c>DateTime</c>/<c>Guid</c>
+    ///     destination (which only exposes a <c>Parse(string)</c> conversion) requires a string source —
+    ///     otherwise a call such as <c>DateTime.Parse(intValue)</c> would not compile.
+    /// </summary>
+    private static bool IsSafeAxisConversion(string sourceType, string destType)
+    {
+        if (!IsSimpleConversionType(sourceType) || !IsSimpleConversionType(destType))
+        {
+            return false;
+        }
+
+        if (GetConversionMethod(destType).EndsWith(".Parse", StringComparison.Ordinal))
+        {
+            string normalizedSource = NormalizeTypeName(sourceType);
+            return normalizedSource is "string" or "System.String";
+        }
+
+        return true;
+    }
+
+    private static bool TypeNamesEquivalent(string left, string right)
+    {
+        // Preserve generic arguments here: List<int> and List<string> must be treated as DIFFERENT axes so a
+        // ToDictionary pass-through is not generated for a genuine inner-element mismatch. NormalizeTypeName
+        // intentionally strips generics for the simple-primitive check, which is the wrong comparison for
+        // deciding whether an axis needs conversion.
+        return string.Equals(StripTypeQualifiers(left), StripTypeQualifiers(right), StringComparison.Ordinal);
+    }
+
+    private static string StripTypeQualifiers(string typeName)
+    {
+        string value = typeName.Trim();
+        if (value.StartsWith("global::", StringComparison.Ordinal))
+        {
+            value = value.Substring("global::".Length);
+        }
+
+        return value;
+    }
+
+    /// <summary>
+    ///     A plain named type is a candidate for a decomposed element <c>CreateMap</c>: not a generic type,
+    ///     array, or simple primitive (those are handled by ToDictionary or left to manual review).
+    /// </summary>
+    private static bool IsPlainNamedTypeName(string typeName)
+    {
+        string value = typeName.Trim();
+        return !value.Contains('<') &&
+               !value.Contains('[') &&
+               !IsSimpleConversionType(value);
     }
 
     private void RegisterComplexMappingFix(

--- a/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
@@ -130,7 +130,7 @@ public static class RuleCatalog
     /// <summary>
     ///     Current package version used by docs/package drift tests.
     /// </summary>
-    public const string CurrentPackageVersion = "2.30.48";
+    public const string CurrentPackageVersion = "2.30.49";
 
     /// <summary>
     ///     Implemented rules, grouped by public diagnostic ID.

--- a/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM002_NullableCompatibilityAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM002_NullableCompatibilityAnalyzer.cs
@@ -19,6 +19,14 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
     internal const string DestinationPropertyTypePropertyName = "DestinationPropertyType";
 
     /// <summary>
+    ///     Marker property set when the diagnostic is a collection-element nullability mismatch
+    ///     (e.g. <c>List&lt;string?&gt;</c> → <c>List&lt;string&gt;</c>) rather than a top-level one. The
+    ///     code-fix provider uses it to withhold the <c>?? default</c> scaffold (which cannot fix element
+    ///     nullability) and offer only the manual-review ignore action.
+    /// </summary>
+    internal const string ElementNullabilityPropertyName = "ElementNullability";
+
+    /// <summary>
     ///     AM002: Nullable to non-nullable assignment without proper handling.
     /// </summary>
     public static readonly DiagnosticDescriptor NullableToNonNullableRule = new(
@@ -788,6 +796,59 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
                 context.ReportDiagnostic(diagnostic);
             }
         }
+        // Case 3: Collection whose element nullability is lost (e.g. List<string?> -> List<string>).
+        // The container is non-nullable on both sides (so Cases 1/2 do not apply), but a nullable source
+        // element flows into a non-nullable destination element — the same NRE risk one level down.
+        else if (HasNullableElementMismatch(sourceProperty.Type, destinationProperty.Type))
+        {
+            ReportNullableToNonNullableDiagnostic(
+                context,
+                invocation,
+                sourceProperty.Name,
+                sourceProperty.Name,
+                sourceProperty.Type,
+                sourceType,
+                destinationType,
+                destinationProperty.Type,
+                isElementNullability: true);
+        }
+    }
+
+    /// <summary>
+    ///     Determines whether the source collection's reference-type element is nullable while the
+    ///     destination collection's element of the same underlying type is non-nullable. Value-type nullable
+    ///     elements and genuine element-type mismatches are intentionally excluded — those stay with
+    ///     AM001/AM021 so the rules never double-report.
+    /// </summary>
+    private static bool HasNullableElementMismatch(ITypeSymbol sourceType, ITypeSymbol destType)
+    {
+        if (!AutoMapperAnalysisHelpers.IsCollectionType(sourceType) ||
+            !AutoMapperAnalysisHelpers.IsCollectionType(destType))
+        {
+            return false;
+        }
+
+        ITypeSymbol? sourceElement = AutoMapperAnalysisHelpers.GetCollectionElementType(sourceType);
+        ITypeSymbol? destElement = AutoMapperAnalysisHelpers.GetCollectionElementType(destType);
+        if (sourceElement == null || destElement == null)
+        {
+            return false;
+        }
+
+        if (!sourceElement.IsReferenceType || !destElement.IsReferenceType)
+        {
+            return false;
+        }
+
+        if (!IsNullableType(sourceElement) || IsNullableType(destElement))
+        {
+            return false;
+        }
+
+        // Same underlying reference type, differing only in nullability annotation (e.g. string? vs string).
+        return SymbolEqualityComparer.Default.Equals(
+            sourceElement.WithNullableAnnotation(NullableAnnotation.NotAnnotated),
+            destElement.WithNullableAnnotation(NullableAnnotation.NotAnnotated));
     }
 
     private static void ReportNullableToNonNullableDiagnostic(
@@ -798,7 +859,8 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
         ITypeSymbol sourcePropertyType,
         ITypeSymbol sourceType,
         ITypeSymbol destinationType,
-        ITypeSymbol destinationPropertyType)
+        ITypeSymbol destinationPropertyType,
+        bool isElementNullability = false)
     {
         string sourceTypeName = sourcePropertyType.ToDisplayString();
         string destTypeName = destinationPropertyType.ToDisplayString();
@@ -808,6 +870,10 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
         properties.Add(SourcePropertyNamePropertyName, sourcePropertyName);
         properties.Add(SourcePropertyTypePropertyName, sourceTypeName);
         properties.Add(DestinationPropertyTypePropertyName, destTypeName);
+        if (isElementNullability)
+        {
+            properties.Add(ElementNullabilityPropertyName, "true");
+        }
 
         var diagnostic = Diagnostic.Create(
             NullableToNonNullableRule,

--- a/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM002_NullableCompatibilityCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM002_NullableCompatibilityCodeFixProvider.cs
@@ -71,10 +71,19 @@ public class AM002_NullableCompatibilityCodeFixProvider : AutoMapperCodeFixProvi
             string? destinationType = ExtractDestinationTypeFromDiagnostic(diagnostic);
             string defaultValue = GetDefaultValueForDestination(invocation, propertyName!, destinationType, operationContext.SemanticModel);
 
+            // A "src.X ?? default" coalesce scaffold cannot fix element-level nullability (the elements of
+            // List<string?> are still nullable), so the element-nullability diagnostic gets only the
+            // manual-review ignore action below.
+            bool isElementNullability =
+                diagnostic.Properties.TryGetValue(
+                    AM002_NullableCompatibilityAnalyzer.ElementNullabilityPropertyName, out string? elementFlag) &&
+                string.Equals(elementFlag, "true", StringComparison.Ordinal);
+
             InvocationExpressionSyntax? existingConfiguration = FindDestinationConfiguration(invocation, propertyName!);
-            if (existingConfiguration == null ||
+            if (!isElementNullability &&
+                (existingConfiguration == null ||
                 (!ConfigurationCanVetoAssignment(existingConfiguration) &&
-                 ConfigurationCanAcceptDefaultValueFix(existingConfiguration, operationContext.SemanticModel)))
+                 ConfigurationCanAcceptDefaultValueFix(existingConfiguration, operationContext.SemanticModel))))
             {
                 // Option 1: Map with default value
                 context.RegisterCodeFix(

--- a/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM021_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM021_CodeFixTests.cs
@@ -1084,7 +1084,7 @@ public class AM021_CodeFixTests
     }
 
     [Fact]
-    public async Task AM021_ShouldOnlyOfferIgnore_WhenDictionaryValueTypesMismatch()
+    public async Task AM021_ShouldOfferToDictionaryFix_WhenDictionaryValueTypesMismatch()
     {
         const string testCode = """
                                 using AutoMapper;
@@ -1117,10 +1117,285 @@ public class AM021_CodeFixTests
         Diagnostic diagnostic = Assert.Single(diagnostics);
         List<CodeAction> actions = await RegisterActionsAsync(document, diagnostic);
 
-        CodeAction action = Assert.Single(actions);
-        Assert.Equal("Ignore property 'Data' (manual review)", action.Title);
+        // Now offers an executable ToDictionary conversion alongside ignore — but never a
+        // CreateMap<KeyValuePair<...>, KeyValuePair<...>> (which would not compile).
+        Assert.Contains(actions, a => a.EquivalenceKey == "AM021_DictionaryConversion_Data");
+        Assert.Contains(actions, a => a.EquivalenceKey == "AM021_Ignore_Data");
         Assert.DoesNotContain(actions, codeAction =>
-            codeAction.Title.StartsWith("Add CreateMap<", StringComparison.Ordinal));
+            codeAction.Title.StartsWith("Add CreateMap<KeyValuePair", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task AM021_ShouldFixDictionaryValueConversion_WithToDictionary()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Collections.Generic;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public Dictionary<string, int> Data { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public Dictionary<string, string> Data { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string expectedFixedCode = """
+                                         using AutoMapper;
+                                         using System.Collections.Generic;
+                                         using System.Linq;
+
+                                         namespace TestNamespace
+                                         {
+                                             public class Source
+                                             {
+                                                 public Dictionary<string, int> Data { get; set; }
+                                             }
+
+                                             public class Destination
+                                             {
+                                                 public Dictionary<string, string> Data { get; set; }
+                                             }
+
+                                             public class TestProfile : Profile
+                                             {
+                                                 public TestProfile()
+                                                 {
+                                                     CreateMap<Source, Destination>().ForMember(dest => dest.Data, opt => opt.MapFrom(src => src.Data.ToDictionary(kvp => kvp.Key, kvp => global::System.Convert.ToString(kvp.Value))));
+                                                 }
+                                             }
+                                         }
+                                         """;
+
+        await CodeFixVerifier<AM021_CollectionElementMismatchAnalyzer, AM021_CollectionElementMismatchCodeFixProvider>
+            .VerifyFixAsync(
+                testCode,
+                new DiagnosticResult(AM021_CollectionElementMismatchAnalyzer.CollectionElementIncompatibilityRule)
+                    .WithLocation(20, 13)
+                    .WithArguments("Data", "Source", "System.Collections.Generic.KeyValuePair<string, int>",
+                        "Destination", "Data", "System.Collections.Generic.KeyValuePair<string, string>"),
+                expectedFixedCode,
+                codeActionIndex: 0);
+    }
+
+    [Fact]
+    public async Task AM021_ShouldOfferCreateMapFix_WhenDictionaryValueIsComplexType()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Collections.Generic;
+
+                                namespace TestNamespace
+                                {
+                                    public class Foo { public string Name { get; set; } }
+
+                                    public class FooDto { public string Name { get; set; } }
+
+                                    public class Source
+                                    {
+                                        public Dictionary<int, Foo> Lookup { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public Dictionary<int, FooDto> Lookup { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        Document document = CreateDocument(testCode);
+        Diagnostic diagnostic = Assert.Single(await GetDiagnosticsAsync(document));
+        List<CodeAction> actions = await RegisterActionsAsync(document, diagnostic);
+
+        Assert.Contains(actions, a =>
+            a.Title == "Add CreateMap<Foo, FooDto>() for element mapping");
+        Assert.Contains(actions, a => a.EquivalenceKey == "AM021_Ignore_Lookup");
+        Assert.DoesNotContain(actions, codeAction =>
+            codeAction.Title.StartsWith("Add CreateMap<KeyValuePair", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task AM021_ShouldOfferOnlyIgnore_WhenBothDictionaryAxesMismatch()
+    {
+        // Dictionary<string, Foo> -> Dictionary<int, FooDto>: both key (string -> int) and value
+        // (Foo -> FooDto) mismatch. A value-only CreateMap<Foo, FooDto> would leave the key unresolved, so
+        // the partial fix is withheld and only the manual-review ignore is offered.
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Collections.Generic;
+
+                                namespace TestNamespace
+                                {
+                                    public class Foo { public string Name { get; set; } }
+
+                                    public class FooDto { public string Name { get; set; } }
+
+                                    public class Source
+                                    {
+                                        public Dictionary<string, Foo> Data { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public Dictionary<int, FooDto> Data { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        Document document = CreateDocument(testCode);
+        Diagnostic diagnostic = Assert.Single(await GetDiagnosticsAsync(document));
+        List<CodeAction> actions = await RegisterActionsAsync(document, diagnostic);
+
+        CodeAction action = Assert.Single(actions);
+        Assert.Equal("AM021_Ignore_Data", action.EquivalenceKey);
+    }
+
+    [Fact]
+    public async Task AM021_ShouldOfferOnlyIgnore_WhenDictionaryValueParsesFromNonStringSource()
+    {
+        // int -> DateTime would emit DateTime.Parse(kvp.Value) where kvp.Value is int, which does not
+        // compile (DateTime.Parse only accepts a string). The ToDictionary fix must be withheld.
+        const string testCode = """
+                                using AutoMapper;
+                                using System;
+                                using System.Collections.Generic;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public Dictionary<string, int> Data { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public Dictionary<string, DateTime> Data { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        Document document = CreateDocument(testCode);
+        Diagnostic diagnostic = Assert.Single(await GetDiagnosticsAsync(document));
+        List<CodeAction> actions = await RegisterActionsAsync(document, diagnostic);
+
+        CodeAction action = Assert.Single(actions);
+        Assert.Equal("AM021_Ignore_Data", action.EquivalenceKey);
+    }
+
+    [Fact]
+    public async Task AM021_ShouldOfferToDictionaryFix_WhenDictionaryValueParsesFromStringSource()
+    {
+        // string -> DateTime is a safe Parse conversion, so the ToDictionary fix is still offered.
+        const string testCode = """
+                                using AutoMapper;
+                                using System;
+                                using System.Collections.Generic;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public Dictionary<string, string> Data { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public Dictionary<string, DateTime> Data { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        Document document = CreateDocument(testCode);
+        Diagnostic diagnostic = Assert.Single(await GetDiagnosticsAsync(document));
+        List<CodeAction> actions = await RegisterActionsAsync(document, diagnostic);
+
+        Assert.Contains(actions, a => a.EquivalenceKey == "AM021_DictionaryConversion_Data");
+    }
+
+    [Fact]
+    public async Task AM021_ShouldOfferOnlyIgnore_WhenDictionaryValueIsMismatchedGenericCollection()
+    {
+        // Dictionary<string, List<int>> -> Dictionary<int, List<string>>: the value axis is a generic
+        // collection whose inner elements mismatch. Neither a ToDictionary pass-through (would not compile)
+        // nor a CreateMap<List<int>, List<string>> is a valid fix, so only the manual-review ignore is offered.
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Collections.Generic;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public Dictionary<string, List<int>> Data { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public Dictionary<int, List<string>> Data { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        Document document = CreateDocument(testCode);
+        Diagnostic diagnostic = Assert.Single(await GetDiagnosticsAsync(document));
+        List<CodeAction> actions = await RegisterActionsAsync(document, diagnostic);
+
+        CodeAction action = Assert.Single(actions);
+        Assert.Equal("AM021_Ignore_Data", action.EquivalenceKey);
     }
 
     [Fact]

--- a/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM021_CollectionElementMismatchTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM021_CollectionElementMismatchTests.cs
@@ -668,6 +668,93 @@ public class AM021_CollectionElementMismatchTests
     }
 
     [Fact]
+    public async Task AM021_ShouldNotReportDiagnostic_WhenDictionaryValueHasElementMapping()
+    {
+        // AutoMapper maps Dictionary<int, Foo> -> Dictionary<int, FooDto> correctly when CreateMap<Foo, FooDto>
+        // is registered (verified at runtime). Reporting it was a false positive: AM021 was asking the registry
+        // for CreateMap<KeyValuePair<...>, KeyValuePair<...>> (which never exists) instead of decomposing the
+        // KeyValuePair into key/value axes.
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Collections.Generic;
+
+                                namespace TestNamespace
+                                {
+                                    public class Foo { public string Name { get; set; } }
+
+                                    public class FooDto { public string Name { get; set; } }
+
+                                    public class Source
+                                    {
+                                        public Dictionary<int, Foo> Lookup { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public Dictionary<int, FooDto> Lookup { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Foo, FooDto>();
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM021_CollectionElementMismatchAnalyzer>()
+            .WithSource(testCode)
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM021_ShouldReportDiagnostic_WhenDictionaryValueMissingElementMapping()
+    {
+        // Without CreateMap<Foo, FooDto>, AutoMapper throws at runtime (verified), so AM021 must still fire.
+        const string testCode = """
+                                using AutoMapper;
+                                using System.Collections.Generic;
+
+                                namespace TestNamespace
+                                {
+                                    public class Foo { public string Name { get; set; } }
+
+                                    public class FooDto { public string Name { get; set; } }
+
+                                    public class Source
+                                    {
+                                        public Dictionary<int, Foo> Lookup { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public Dictionary<int, FooDto> Lookup { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM021_CollectionElementMismatchAnalyzer>()
+            .WithSource(testCode)
+            .ExpectDiagnostic(AM021_CollectionElementMismatchAnalyzer.CollectionElementIncompatibilityRule, 24, 13,
+                "Lookup", "Source", "System.Collections.Generic.KeyValuePair<int, TestNamespace.Foo>", "Destination",
+                "Lookup", "System.Collections.Generic.KeyValuePair<int, TestNamespace.FooDto>")
+            .RunAsync();
+    }
+
+    [Fact]
     public async Task AM021_ShouldNotReportDiagnostic_WhenCustomCollectionWithElementMapping()
     {
         const string testCode = """

--- a/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM002_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM002_CodeFixTests.cs
@@ -1369,6 +1369,48 @@ public class AM002_CodeFixTests
         Assert.Empty(actions);
     }
 
+    [Fact]
+    public async Task AM002_ShouldOfferOnlyIgnore_ForNullableElementCollection()
+    {
+        // A "src.Tags ?? default" coalesce scaffold cannot fix element-level nullability (the elements are
+        // still nullable), so the element-nullability diagnostic must offer only the manual-review ignore
+        // action — the user has to choose filter-vs-default semantics deliberately.
+        const string testCode = """
+                                #nullable enable
+                                using AutoMapper;
+                                using System.Collections.Generic;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public List<string?> Tags { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public List<string> Tags { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        Document document = CreateDocument(testCode);
+        Diagnostic diagnostic = Assert.Single(await GetDiagnosticsAsync(document));
+
+        List<CodeAction> actions = await RegisterActionsAsync(document, diagnostic);
+
+        CodeAction action = Assert.Single(actions);
+        Assert.Equal("AM002_Ignore_Tags", action.EquivalenceKey);
+    }
+
     private static Document CreateDocument(string source)
     {
         var workspace = new AdhocWorkspace();

--- a/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM002_NullableCompatibilityTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM002_NullableCompatibilityTests.cs
@@ -1815,4 +1815,223 @@ public class AM002_NullableCompatibilityTests
             Diagnostic(AM002_NullableCompatibilityAnalyzer.NullableToNonNullableRule, 21, 13, "Age", "Source", "int?",
                 "Destination", "int"));
     }
+
+    // --- Collection element nullability -------------------------------------------------------------
+    // AM002 catches a null collection (List<string>?) but historically missed a non-null collection whose
+    // ELEMENTS are nullable (List<string?>). A null element flows straight into a non-nullable element slot,
+    // the same NRE class one level down. Scoped to reference-type elements with the same underlying type so
+    // genuine element-type mismatches (and value-type nullables) stay AM021/AM001's responsibility.
+
+    [Fact]
+    public async Task AM002_ShouldReportDiagnostic_WhenNullableElementListToNonNullableElementList()
+    {
+        string testCode = """
+
+                          #nullable enable
+                          using AutoMapper;
+                          using System.Collections.Generic;
+
+                          namespace TestNamespace
+                          {
+                              public class Source
+                              {
+                                  public List<string?> Tags { get; set; }
+                              }
+
+                              public class Destination
+                              {
+                                  public List<string> Tags { get; set; }
+                              }
+
+                              public class TestProfile : Profile
+                              {
+                                  public TestProfile()
+                                  {
+                                      CreateMap<Source, Destination>();
+                                  }
+                              }
+                          }
+                          """;
+
+        await AnalyzerVerifier<AM002_NullableCompatibilityAnalyzer>.VerifyAnalyzerAsync(
+            testCode,
+            Diagnostic(AM002_NullableCompatibilityAnalyzer.NullableToNonNullableRule, 22, 13, "Tags", "Source",
+                "System.Collections.Generic.List<string?>", "Destination", "System.Collections.Generic.List<string>"));
+    }
+
+    [Fact]
+    public async Task AM002_ShouldReportDiagnostic_WhenNullableElementArrayToNonNullableElementArray()
+    {
+        string testCode = """
+
+                          #nullable enable
+                          using AutoMapper;
+
+                          namespace TestNamespace
+                          {
+                              public class Source
+                              {
+                                  public string?[] Tags { get; set; }
+                              }
+
+                              public class Destination
+                              {
+                                  public string[] Tags { get; set; }
+                              }
+
+                              public class TestProfile : Profile
+                              {
+                                  public TestProfile()
+                                  {
+                                      CreateMap<Source, Destination>();
+                                  }
+                              }
+                          }
+                          """;
+
+        await AnalyzerVerifier<AM002_NullableCompatibilityAnalyzer>.VerifyAnalyzerAsync(
+            testCode,
+            Diagnostic(AM002_NullableCompatibilityAnalyzer.NullableToNonNullableRule, 21, 13, "Tags", "Source",
+                "string?[]", "Destination", "string[]"));
+    }
+
+    [Fact]
+    public async Task AM002_ShouldNotReportDiagnostic_WhenNullableElementToNullableElement()
+    {
+        string testCode = """
+
+                          #nullable enable
+                          using AutoMapper;
+                          using System.Collections.Generic;
+
+                          namespace TestNamespace
+                          {
+                              public class Source
+                              {
+                                  public List<string?> Tags { get; set; }
+                              }
+
+                              public class Destination
+                              {
+                                  public List<string?> Tags { get; set; }
+                              }
+
+                              public class TestProfile : Profile
+                              {
+                                  public TestProfile()
+                                  {
+                                      CreateMap<Source, Destination>();
+                                  }
+                              }
+                          }
+                          """;
+
+        await AnalyzerVerifier<AM002_NullableCompatibilityAnalyzer>.VerifyAnalyzerAsync(testCode);
+    }
+
+    [Fact]
+    public async Task AM002_ShouldNotReportDiagnostic_WhenNonNullableElementToNullableElement()
+    {
+        // Non-null element -> nullable element widens nullability safely; the Error rule must stay silent.
+        string testCode = """
+
+                          #nullable enable
+                          using AutoMapper;
+                          using System.Collections.Generic;
+
+                          namespace TestNamespace
+                          {
+                              public class Source
+                              {
+                                  public List<string> Tags { get; set; }
+                              }
+
+                              public class Destination
+                              {
+                                  public List<string?> Tags { get; set; }
+                              }
+
+                              public class TestProfile : Profile
+                              {
+                                  public TestProfile()
+                                  {
+                                      CreateMap<Source, Destination>();
+                                  }
+                              }
+                          }
+                          """;
+
+        await AnalyzerVerifier<AM002_NullableCompatibilityAnalyzer>.VerifyAnalyzerAsync(testCode);
+    }
+
+    [Fact]
+    public async Task AM002_ShouldNotReportDiagnostic_WhenElementNullabilityHandledByIgnore()
+    {
+        string testCode = """
+
+                          #nullable enable
+                          using AutoMapper;
+                          using System.Collections.Generic;
+
+                          namespace TestNamespace
+                          {
+                              public class Source
+                              {
+                                  public List<string?> Tags { get; set; }
+                              }
+
+                              public class Destination
+                              {
+                                  public List<string> Tags { get; set; }
+                              }
+
+                              public class TestProfile : Profile
+                              {
+                                  public TestProfile()
+                                  {
+                                      CreateMap<Source, Destination>()
+                                          .ForMember(dest => dest.Tags, opt => opt.Ignore());
+                                  }
+                              }
+                          }
+                          """;
+
+        await AnalyzerVerifier<AM002_NullableCompatibilityAnalyzer>.VerifyAnalyzerAsync(testCode);
+    }
+
+    [Fact]
+    public async Task AM002_ShouldNotReportDiagnostic_WhenElementTypesDifferentReferenceTypes()
+    {
+        // Different reference element types are a type mismatch (AM021's lane), not nullability — AM002 must
+        // not fire just because the source element is nullable.
+        string testCode = """
+
+                          #nullable enable
+                          using AutoMapper;
+                          using System.Collections.Generic;
+
+                          namespace TestNamespace
+                          {
+                              public class Source
+                              {
+                                  public List<string?> Tags { get; set; }
+                              }
+
+                              public class Destination
+                              {
+                                  public List<object> Tags { get; set; }
+                              }
+
+                              public class TestProfile : Profile
+                              {
+                                  public TestProfile()
+                                  {
+                                      CreateMap<Source, Destination>();
+                                  }
+                              }
+                          }
+                          """;
+
+        await AnalyzerVerifier<AM002_NullableCompatibilityAnalyzer>.VerifyAnalyzerAsync(testCode);
+    }
 }


### PR DESCRIPTION
Two net-new analyzer detection capabilities, rebased onto current `main` (2.30.48). Premises and generated fixes were verified against a real AutoMapper 14 runtime probe.

## AM021 — dictionary key/value decomposition
- Decomposes `KeyValuePair<TKey, TValue>` element types into independent key/value axes.
- **Removes a false positive**: `Dictionary<K, Foo>` → `Dictionary<K, FooDto>` maps correctly when `CreateMap<Foo, FooDto>` is registered (previously reported because the analyzer looked for a non-existent `CreateMap<KeyValuePair<…>, KeyValuePair<…>>`).
- **Adds executable fixes** where only manual-ignore existed: a `ToDictionary(…)` projection for simple primitive conversions (`DateTime`/`Guid` `Parse` targets gated to string sources), and a decomposed `CreateMap<TValueSource, TValueDest>()` for a complex value with a pass-through key. Generic-collection axes and both-axes-incompatible dictionaries keep manual-review ignore only.
- Integrated onto `main`'s compiler-aware `AreElementTypesCompatible` element check.

## AM002 — collection element nullability
- Detects element nullability loss (`List<string?>` → `List<string>`, `string?[]` → `string[]`).
- Scoped to convention mappings and reference-type elements of the same underlying type; element-type mismatches and value-type nullables stay with AM021/AM001. Offers the manual-review ignore action only.

## Scope note
The exploratory work also covered AM003 immutable containers, AM031 `.GetAwaiter().GetResult()`, and AM030 `ConvertUsing(typeof)` — all dropped here because `main` independently shipped AM003/AM031 and split AM030 into AM030/AM032/AM033. Only these two are net-new.

## Validation
- Full solution test suite green on net10.0 (874 tests).
- AnalyzerVerifier `--check-catalog --check-snapshots` green.
- Release `dotnet build -warnaserror` clean.
- This exact logic previously passed four `codex review` rounds on the exploratory branch (all findings fixed, regression tests included).

Version bumped to **2.30.49** (patch, consistent with the repo's convention of shipping each new detection capability as a `2.30.x` patch). Tag `v2.30.49` after merge triggers the NuGet release.