### PR TITLE
test: code-fix harness prerequisites (key selection + menu introspection)

### DIFF
--- a/tests/AutoMapperAnalyzer.Tests/Infrastructure/CodeFixActionInspector.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Infrastructure/CodeFixActionInspector.cs
@@ -1,0 +1,99 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace AutoMapperAnalyzer.Tests.Infrastructure;
+
+/// <summary>
+///     Introspects the code actions a <see cref="CodeFixProvider"/> registers for a diagnostic,
+///     flattening any nested (sub-menu) actions so tests can assert on the full action tree by
+///     equivalence key and on the number of top-level lightbulb entries.
+///     Replaces the per-file ad-hoc <c>RegisterActionsAsync</c> helpers, and adds nesting awareness
+///     needed by the fixer item-picker redesign (aggregate + grouped per-property actions).
+/// </summary>
+internal static class CodeFixActionInspector
+{
+    /// <summary>
+    ///     A single code action in the (possibly nested) registration tree.
+    /// </summary>
+    /// <param name="Title">The action's display title.</param>
+    /// <param name="EquivalenceKey">The action's equivalence key (used for FixAll grouping / selection).</param>
+    /// <param name="Depth">0 for a top-level lightbulb entry, 1+ for nested sub-menu entries.</param>
+    /// <param name="IsNested">True when the action lives under a parent action (Depth &gt; 0).</param>
+    /// <param name="HasChildren">True when the action is itself a parent with nested children.</param>
+    public sealed record ActionInfo(
+        string Title,
+        string? EquivalenceKey,
+        int Depth,
+        bool IsNested,
+        bool HasChildren);
+
+    /// <summary>
+    ///     Registers the provider's fixes for a single diagnostic and returns the flattened action tree.
+    /// </summary>
+    public static async Task<IReadOnlyList<ActionInfo>> GetActionsAsync(
+        Document document,
+        CodeFixProvider provider,
+        Diagnostic diagnostic)
+    {
+        var topLevel = new List<CodeAction>();
+        var context = new CodeFixContext(
+            document,
+            diagnostic,
+            (action, _) => topLevel.Add(action),
+            CancellationToken.None);
+
+        await provider.RegisterCodeFixesAsync(context);
+
+        return Flatten(topLevel);
+    }
+
+    /// <summary>
+    ///     Flattens a sequence of top-level code actions (recursing into nested sub-menu actions)
+    ///     into a depth-annotated list. Exposed directly so the flattening can be exercised against
+    ///     synthetic nested actions without a provider/document round-trip.
+    /// </summary>
+    public static IReadOnlyList<ActionInfo> Flatten(IEnumerable<CodeAction> topLevelActions)
+    {
+        var flattened = new List<ActionInfo>();
+        foreach (CodeAction action in topLevelActions)
+        {
+            Flatten(action, depth: 0, flattened);
+        }
+
+        return flattened;
+    }
+
+    /// <summary>
+    ///     The number of top-level lightbulb entries (parents and flat leaves at depth 0).
+    /// </summary>
+    public static int TopLevelCount(IEnumerable<ActionInfo> actions)
+    {
+        return actions.Count(a => a.Depth == 0);
+    }
+
+    private static void Flatten(CodeAction action, int depth, List<ActionInfo> sink)
+    {
+        // CodeAction.NestedActions is the public accessor for sub-menu (grouped) actions.
+        ImmutableArray<CodeAction> nested = action.NestedActions;
+        bool hasChildren = !nested.IsDefaultOrEmpty;
+
+        sink.Add(new ActionInfo(
+            action.Title,
+            action.EquivalenceKey,
+            depth,
+            IsNested: depth > 0,
+            HasChildren: hasChildren));
+
+        if (!hasChildren)
+        {
+            return;
+        }
+
+        foreach (CodeAction child in nested)
+        {
+            Flatten(child, depth + 1, sink);
+        }
+    }
+}

--- a/tests/AutoMapperAnalyzer.Tests/Infrastructure/CodeFixHarnessTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Infrastructure/CodeFixHarnessTests.cs
@@ -1,0 +1,311 @@
+using System.Collections.Immutable;
+using System.IO;
+using AutoMapper;
+using AutoMapperAnalyzer.Analyzers.ComplexMappings;
+using AutoMapperAnalyzer.Analyzers.DataIntegrity;
+using AutoMapperAnalyzer.Tests.Infrastructure;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Text;
+
+namespace AutoMapperAnalyzer.Tests.Infrastructure;
+
+/// <summary>
+///     Meta-tests for the code-fix test harness helpers added in the fixer item-picker redesign
+///     (Phase 0). They exercise the new <c>VerifyFixByKeyAsync</c> equivalence-key selection path and
+///     the <see cref="CodeFixActionInspector"/> flattening/top-level-count helpers against existing,
+///     fully-verified AM005 behaviour so the helpers themselves are proven before later phases rely on
+///     them to select aggregate / nested actions by key.
+/// </summary>
+public class CodeFixHarnessTests
+{
+    private const string FirstNameSource = """
+                                           using AutoMapper;
+
+                                           namespace TestNamespace
+                                           {
+                                               public class Source
+                                               {
+                                                   public string firstName { get; set; }
+                                               }
+
+                                               public class Destination
+                                               {
+                                                   public string FirstName { get; set; }
+                                               }
+
+                                               public class TestProfile : Profile
+                                               {
+                                                   public TestProfile()
+                                                   {
+                                                       CreateMap<Source, Destination>();
+                                                   }
+                                               }
+                                           }
+                                           """;
+
+    private const string FirstNameFixed = """
+                                          using AutoMapper;
+
+                                          namespace TestNamespace
+                                          {
+                                              public class Source
+                                              {
+                                                  public string firstName { get; set; }
+                                              }
+
+                                              public class Destination
+                                              {
+                                                  public string FirstName { get; set; }
+                                              }
+
+                                              public class TestProfile : Profile
+                                              {
+                                                  public TestProfile()
+                                                  {
+                                                      CreateMap<Source, Destination>().ForMember(dest => dest.FirstName, opt => opt.MapFrom(src => src.firstName));
+                                                  }
+                                              }
+                                          }
+                                          """;
+
+    private const string EmailSource = """
+                                       using AutoMapper;
+
+                                       namespace TestNamespace
+                                       {
+                                           public class Source
+                                           {
+                                               public string emailAddress { get; set; }
+                                           }
+
+                                           public class Destination
+                                           {
+                                               public string EmailAddress { get; set; }
+                                           }
+
+                                           public class TestProfile : Profile
+                                           {
+                                               public TestProfile()
+                                               {
+                                                   CreateMap<Source, Destination>();
+                                               }
+                                           }
+                                       }
+                                       """;
+
+    [Fact]
+    public async Task VerifyFixByKeyAsync_AppliesActionSelectedByEquivalenceKey()
+    {
+        await CodeFixVerifier<AM005_CaseSensitivityMismatchAnalyzer, AM005_CaseSensitivityMismatchCodeFixProvider>
+            .VerifyFixByKeyAsync(
+                FirstNameSource,
+                new DiagnosticResult(AM005_CaseSensitivityMismatchAnalyzer.CaseSensitivityMismatchRule)
+                    .WithLocation(19, 13)
+                    .WithArguments("firstName", "FirstName"),
+                FirstNameFixed,
+                "AM005_ExplicitMapping_firstName_FirstName");
+    }
+
+    [Fact]
+    public async Task VerifyFixByKeyAsync_FixesAllSameKeyDiagnostics_WithoutExplicitIterations()
+    {
+        // Two self-referencing maps => two AM022 diagnostics, both offering the category-level
+        // "AM022_AddMaxDepth" action. Selecting by that key with the DEFAULT iteration count must fix
+        // BOTH maps; if the default ignored expectedDiagnostics.Length it would fix only the first.
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class NodeA
+                                    {
+                                        public string Name { get; set; }
+                                        public NodeA Parent { get; set; }
+                                    }
+
+                                    public class NodeADto
+                                    {
+                                        public string Name { get; set; }
+                                        public NodeADto Parent { get; set; }
+                                    }
+
+                                    public class NodeB
+                                    {
+                                        public string Name { get; set; }
+                                        public NodeB Parent { get; set; }
+                                    }
+
+                                    public class NodeBDto
+                                    {
+                                        public string Name { get; set; }
+                                        public NodeBDto Parent { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<NodeA, NodeADto>();
+                                            CreateMap<NodeB, NodeBDto>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string expectedFixedCode = """
+                                         using AutoMapper;
+
+                                         namespace TestNamespace
+                                         {
+                                             public class NodeA
+                                             {
+                                                 public string Name { get; set; }
+                                                 public NodeA Parent { get; set; }
+                                             }
+
+                                             public class NodeADto
+                                             {
+                                                 public string Name { get; set; }
+                                                 public NodeADto Parent { get; set; }
+                                             }
+
+                                             public class NodeB
+                                             {
+                                                 public string Name { get; set; }
+                                                 public NodeB Parent { get; set; }
+                                             }
+
+                                             public class NodeBDto
+                                             {
+                                                 public string Name { get; set; }
+                                                 public NodeBDto Parent { get; set; }
+                                             }
+
+                                             public class TestProfile : Profile
+                                             {
+                                                 public TestProfile()
+                                                 {
+                                                     CreateMap<NodeA, NodeADto>().MaxDepth(2);
+                                                     CreateMap<NodeB, NodeBDto>().MaxDepth(2);
+                                                 }
+                                             }
+                                         }
+                                         """;
+
+        await CodeFixVerifier<AM022_InfiniteRecursionAnalyzer, AM022_InfiniteRecursionCodeFixProvider>
+            .VerifyFixByKeyAsync(
+                testCode,
+                new[]
+                {
+                    new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.SelfReferencingTypeRule)
+                        .WithLocation(33, 13)
+                        .WithArguments("NodeA", "NodeADto"),
+                    new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.SelfReferencingTypeRule)
+                        .WithLocation(34, 13)
+                        .WithArguments("NodeB", "NodeBDto")
+                },
+                expectedFixedCode,
+                "AM022_AddMaxDepth");
+    }
+
+    [Fact]
+    public async Task Inspector_FlattensActions_AndCountsTopLevel()
+    {
+        Document document = CreateDocument(EmailSource);
+        Diagnostic diagnostic = await GetSingleDiagnosticAsync<AM005_CaseSensitivityMismatchAnalyzer>(document);
+
+        IReadOnlyList<CodeFixActionInspector.ActionInfo> actions =
+            await CodeFixActionInspector.GetActionsAsync(
+                document,
+                new AM005_CaseSensitivityMismatchCodeFixProvider(),
+                diagnostic);
+
+        Assert.Equal(1, CodeFixActionInspector.TopLevelCount(actions));
+        Assert.Contains(
+            actions,
+            a => a.EquivalenceKey == "AM005_ExplicitMapping_emailAddress_EmailAddress"
+                 && !a.IsNested
+                 && !a.HasChildren
+                 && a.Depth == 0);
+    }
+
+    [Fact]
+    public async Task Inspector_FlattensNestedActions_WithDepthAndTopLevelCount()
+    {
+        Document document = CreateDocument(EmailSource);
+
+        // A grouped per-property action (the shape later phases will register): one top-level parent
+        // with two nested children. The inspector must report ONE top-level entry and surface both
+        // children at depth 1 with IsNested = true so menu-length / key assertions work on sub-menus.
+        CodeAction child1 = CodeAction.Create(
+            "Map 'emailAddress' to 'EmailAddress' explicitly",
+            _ => Task.FromResult(document),
+            "AM005_ExplicitMapping_emailAddress_EmailAddress");
+        CodeAction child2 = CodeAction.Create(
+            "Ignore destination property 'EmailAddress'",
+            _ => Task.FromResult(document),
+            "AM005_Ignore_EmailAddress");
+        CodeAction parent = CodeAction.Create(
+            "Fix property 'EmailAddress'…",
+            ImmutableArray.Create(child1, child2),
+            isInlinable: false);
+
+        IReadOnlyList<CodeFixActionInspector.ActionInfo> actions =
+            CodeFixActionInspector.Flatten(new[] { parent });
+
+        Assert.Equal(1, CodeFixActionInspector.TopLevelCount(actions));
+        Assert.Contains(
+            actions,
+            a => a.Title == "Fix property 'EmailAddress'…" && a.Depth == 0 && !a.IsNested && a.HasChildren);
+        Assert.Contains(
+            actions,
+            a => a.EquivalenceKey == "AM005_ExplicitMapping_emailAddress_EmailAddress"
+                 && a.Depth == 1 && a.IsNested && !a.HasChildren);
+        Assert.Contains(
+            actions,
+            a => a.EquivalenceKey == "AM005_Ignore_EmailAddress"
+                 && a.Depth == 1 && a.IsNested && !a.HasChildren);
+    }
+
+    private static Document CreateDocument(string source)
+    {
+        var workspace = new AdhocWorkspace();
+        ProjectId projectId = ProjectId.CreateNewId();
+        DocumentId documentId = DocumentId.CreateNewId(projectId);
+
+        Solution solution = workspace.CurrentSolution
+            .AddProject(projectId, "CodeFixHarnessTests", "CodeFixHarnessTests", LanguageNames.CSharp)
+            .WithProjectCompilationOptions(projectId, new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+            .WithProjectParseOptions(projectId, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+
+        string trustedPlatformAssemblies = (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") ?? string.Empty;
+        foreach (string assemblyPath in trustedPlatformAssemblies.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(assemblyPath))
+            {
+                solution = solution.AddMetadataReference(projectId, MetadataReference.CreateFromFile(assemblyPath));
+            }
+        }
+
+        solution = solution
+            .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(Profile).Assembly.Location))
+            .AddDocument(documentId, "Test0.cs", SourceText.From(source));
+
+        return solution.GetDocument(documentId)!;
+    }
+
+    private static async Task<Diagnostic> GetSingleDiagnosticAsync<TAnalyzer>(Document document)
+        where TAnalyzer : DiagnosticAnalyzer, new()
+    {
+        Compilation compilation = (await document.Project.GetCompilationAsync())!;
+        ImmutableArray<Diagnostic> diagnostics = await compilation
+            .WithAnalyzers(ImmutableArray.Create<DiagnosticAnalyzer>(new TAnalyzer()))
+            .GetAnalyzerDiagnosticsAsync();
+
+        return Assert.Single(diagnostics);
+    }
+}

--- a/tests/AutoMapperAnalyzer.Tests/Infrastructure/CodeFixVerifier.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Infrastructure/CodeFixVerifier.cs
@@ -90,6 +90,61 @@ internal static class CodeFixVerifier<TAnalyzer, TCodeFix>
         await VerifyFixAsync(source, expectedDiagnostics, fixedSource, codeActionIndex, iterations, remainingDiagnostics);
     }
 
+    /// <summary>
+    ///     Applies the single code action whose <see cref="CodeAction.EquivalenceKey"/> matches
+    ///     <paramref name="equivalenceKey"/> and verifies the resulting document equals
+    ///     <paramref name="fixedSource"/>. Selecting by equivalence key (instead of positional index)
+    ///     keeps tests stable as aggregate / nested actions are added by later redesign phases.
+    /// </summary>
+    public static Task VerifyFixByKeyAsync(string source, DiagnosticResult expectedDiagnostic, string fixedSource,
+        string equivalenceKey, DiagnosticResult[]? remainingDiagnostics = null, int? iterations = null)
+    {
+        return VerifyFixByKeyAsync(source, new[] { expectedDiagnostic }, fixedSource, equivalenceKey,
+            remainingDiagnostics, iterations);
+    }
+
+    /// <summary>
+    ///     Applies the single code action selected by <paramref name="equivalenceKey"/> and verifies the
+    ///     resulting document. Useful for asserting that one aggregate action (e.g. an <c>*_IgnoreAll</c>
+    ///     key) clears every diagnostic in a single application (pass <paramref name="iterations"/> = 1).
+    /// </summary>
+    public static async Task VerifyFixByKeyAsync(string source, DiagnosticResult[] expectedDiagnostics,
+        string fixedSource, string equivalenceKey, DiagnosticResult[]? remainingDiagnostics = null,
+        int? iterations = null)
+    {
+        var test = new CSharpCodeFixTest<TAnalyzer, TCodeFix, LineEndingAgnosticVerifier>
+        {
+            TestCode = source,
+            FixedCode = fixedSource,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            CodeActionEquivalenceKey = equivalenceKey
+        };
+        ConfigureNonLocalDiagnosticSupport(test);
+
+        AddAutoMapperReferences(test.TestState);
+        AddAutoMapperReferences(test.FixedState);
+
+        // Incremental fixes apply ONE action per pass (re-analyzing between), so default to enough
+        // passes to clear every expected diagnostic — matching the index-based helper and fixing
+        // Codex's "only the first diagnostic gets fixed" gap. FixAll batches all same-key diagnostics
+        // in a single pass (selection here is by one equivalence key), so it converges in one pass per
+        // remaining-set. Aggregate-action tests can still opt into iterations: 1 for both.
+        int incrementalDefault = Math.Max(
+            1,
+            Math.Max((remainingDiagnostics?.Length ?? 0) + 1, expectedDiagnostics.Length));
+        int fixAllDefault = Math.Max(1, (remainingDiagnostics?.Length ?? 0) + 1);
+        test.NumberOfIncrementalIterations = iterations ?? incrementalDefault;
+        test.NumberOfFixAllIterations = iterations ?? fixAllDefault;
+        test.ExpectedDiagnostics.AddRange(expectedDiagnostics);
+
+        if (remainingDiagnostics != null)
+        {
+            test.FixedState.ExpectedDiagnostics.AddRange(remainingDiagnostics);
+        }
+
+        await test.RunAsync();
+    }
+
     public static async Task VerifyFixWithIterationsAsync(string source, DiagnosticResult[] expectedDiagnostics,
         string fixedSource, int iterations)
     {


### PR DESCRIPTION
## Summary
Phase 0 of the code-fix **item-picker redesign** (reducing the long/duplicate-looking lightbulb when a `CreateMap` has many unmapped properties). Test-harness prerequisites only — **no analyzer behavior change, not shipped as a package**.

Adds two harness capabilities later phases depend on:
- **`VerifyFixByKeyAsync`** — selects the code action by `CodeActionEquivalenceKey` instead of a brittle positional index. Uses separate incremental vs FixAll iteration defaults so multiple same-key diagnostics converge correctly (incremental fixes one per pass; FixAll batches same-key fixes in a single pass).
- **`CodeFixActionInspector`** — flattens the public `NestedActions` tree into depth-annotated entries (`Title`, `EquivalenceKey`, `Depth`, `IsNested`, `HasChildren`) plus `TopLevelCount`, enabling menu-length and nested-action assertions.

## Impact
- No production/analyzer code touched. Public diagnostic surface unchanged.
- Unblocks Phase 1 (aggregate `*_MapAll`/`*_IgnoreAll` actions selected by key), Phase 3 (FixAll), and Phase 4 (nested submenu / `AssertTopLevelCount`).

## Validation
- Full suite green: **878 tests, 0 failures** (`dotnet test automapper-analyser.sln -c Release`).
- New meta-tests: AM005 key-based fix, AM022 two-map **same-key** regression (caught & fixed a wrong iteration default flagged by Codex review), AM005 flat-action introspection, and a **synthetic nested-action** flatten test.
- `git diff --check` clean.
- Codex review (`codex review --uncommitted`): no actionable findings; explicitly judged a meaningful harness improvement.

No SemVer release accompanies this PR (test-only).