### PR TITLE
feat: fixer UX Batch 2 + release 2.30.60

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+## [2.30.60] - 2026-07-08
+
+Fixer UX shared infrastructure (Batch 2).
+
+### Changed
+
+- **AM001 multi-property lightbulb**: Convert-all (when every mismatch has a conversion recipe) and Ignore-all with nested "Fix individual type mismatch…".
+- **AM022**: MaxDepth scaffold is always registered before Ignore (single- and multi-property).
+- **Shared** `CodeFixSyntaxHelper.AddUsingIfMissing` used by AM003/AM021/AM031.
+
+### Validation
+
+- Full solution test suite (`net10.0`) green: 1381 passed.
+
 ## [2.30.59] - 2026-07-08
 
 Fixer UX honesty hardening (Batch 1).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet Version](https://img.shields.io/nuget/v/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=NuGet)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=Downloads)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/georgepwall1991/automapper-analyser/ci.yml?style=flat-square&logo=github&label=Build)](https://github.com/georgepwall1991/automapper-analyser/actions)
-[![Tests](https://img.shields.io/badge/Tests-1380%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
+[![Tests](https://img.shields.io/badge/Tests-1381%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
 [![.NET](https://img.shields.io/badge/.NET-4.8+%20%7C%206.0+%20%7C%208.0+%20%7C%209.0+%20%7C%2010.0+-512BD4?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 [![Coverage](https://img.shields.io/codecov/c/github/georgepwall1991/automapper-analyser?style=flat-square&logo=codecov&label=Coverage)](https://codecov.io/gh/georgepwall1991/automapper-analyser)
@@ -14,25 +14,23 @@ prevention*
 
 ---
 
-## 🎉 Latest Release: v2.30.59
+## 🎉 Latest Release: v2.30.60
 
-**Fixer UX honesty — no silent no-ops, honest Map-all / Scaffold-all titles**
+**Fixer UX shared infra — AM001 multi-property aggregates, AM022 best-first order**
 
 ✅ **Highlights**
 
-- **AM011**: Map-all only when every required property has a unique fuzzy match; otherwise Scaffold-all with `(manual review)`. Ignore-all labeled; stale diagnostics withhold.
-- **AM004 / AM006**: aggregate DoNotValidate-all / Ignore-all titles include `(manual review)`.
-- **AM022**: MaxDepth title is `Add MaxDepth(2) scaffold (review depth)`.
-- **AM031 / AM020 / AM021**: lightbulbs no longer advertise fixes that apply as no-ops; CreateMap inserts require bare/`this` hosts.
+- **AM001**: Convert-all / Ignore-all + nested Fix individual when multiple type mismatches share a CreateMap.
+- **AM022**: MaxDepth scaffold always first in the lightbulb.
+- **Helpers**: shared `AddUsingIfMissing` for collection/performance fixers.
 
 🧪 **Validation**
 
-- Full solution test validation passed on `net10.0` with 1380 tests.
-- Codex review: meaningful UX improvement; receiver-qualified CreateMap inserts withheld.
-- Analyzer and test projects build clean under `-warnaserror` (the release gate; the samples project intentionally carries diagnostics).
+- Full solution test validation passed on `net10.0` with 1381 tests.
 
 ### Recent Releases
 
+- **v2.30.60**: Fixer UX Batch 2 — AM001 multi-property Convert-all/Ignore-all, AM022 MaxDepth best-first, shared AddUsingIfMissing.
 - **v2.30.59**: Fixer UX honesty — AM011 Map-all/Scaffold-all honesty, manual-review aggregate titles, no silent no-op lightbulbs for AM020/AM021/AM031, AM022 MaxDepth scaffold title.
 - **v2.30.58**: AM001 ReverseMap direction keys, Nullable scalar reporting, fixer culture/null/keyword/framework conversion hardening.
 - **v2.30.57**: Full analyzer+fixer audit hardening — AM003/AM021 ownership, AM020 internal fixer parity, AM021 Parse gate, AM041 paren reverse, AM011 reverse fuzzy, AM031 multi-enum all keys, docs/trust honesty.
@@ -228,7 +226,7 @@ Install-Package AutoMapperAnalyzer.Analyzers
 ### Project File (For CI/CD)
 
 ```xml
-<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.59">
+<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.60">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 </PackageReference>

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -1,6 +1,6 @@
 # Analyzer Health
 
-Reviewed: 2026-07-08 (previous review: 2026-07-08 hitlist; current shipped version: 2.30.59)
+Reviewed: 2026-07-08 (previous review: 2026-07-08 hitlist; current shipped version: 2.30.60)
 
 This is a deliberately harsh health audit for the 16 implemented AutoMapper analyzer rule IDs in this repository. Several rule IDs expose multiple diagnostic descriptors, especially `AM002`, `AM022`, and `AM031`; the scorecard rates the public rule ID as the user experiences it.
 
@@ -31,7 +31,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 
 | Rule | Title | Domain | Severity | Analyzer | False Positives | Fix Strategy | Tests | Docs/Samples | Importance | Priority | Notes |
 | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |
-| AM001 | Property type mismatch | Type Safety | Error | 4 | 4 | 4 | 5 | 4 | 5 | Low | Direction-preserving ReverseMap keys; collection-only generic deferral restores Nullable scalar reporting; fixer peels nullables, uses invariant-culture Parse/ToString, escapes keywords, and covers DateTime/Uri/bool/Guid. Residual: aggregate multi-property UX and property-token diagnostic placement. |
+| AM001 | Property type mismatch | Type Safety | Error | 4 | 4 | 5 | 5 | 4 | 5 | Low | Direction-preserving ReverseMap keys; collection-only generic deferral; fixer peels nullables, invariant-culture Parse/ToString, keywords, DateTime/Uri/bool/Guid. **Fix Strategy 5**: Convert-all/Ignore-all + nested Fix individual for multi-property maps (Batch 2). Residual: property-token diagnostic placement. |
 | AM002 | Nullable compatibility issue | Type Safety | Error/Info | 4 | 4 | 4 | 5 | 4 | 5 | Low | Descriptor-accurate docs now call out the Error/Info split, reverse-map nullable-to-non-nullable losses report and fix even when forward-side nullability policy is configured before `ReverseMap()`, pass-through and different-member nullable `MapFrom` bodies no longer hide nullable-to-non-nullable errors even when the same-name source member is non-nullable, diagnostics name the actual nullable source member for explicit different-source mappings, constructed generic source/destination labels such as `Source<T>` and `Destination<T>` are preserved, null-forgiving-only generic `MapFrom` bodies now report instead of treating compiler suppression as runtime null handling, semantic string literal/`nameof(...)`/const destination-member selectors and typed-lambda safe mappings are recognized as explicit nullability configuration, helper methods inside member options no longer masquerade as AutoMapper null handlers or mapping configuration, unsafe `NullSubstitute` values still report while assignable fallback values and typed value-type defaults are respected, unguarded nullable receiver dereferences inside `MapFrom` still report even when the final mapped value has a different type, while guarded dereferences and nullable value `GetValueOrDefault()` stay quiet, member-level converter/resolver ownership is respected including generic member-resolver `MapFrom<TResolver, TSourceMember>(...)` forms while generic expression `MapFrom<TSourceMember>(...)` overloads remain analyzable, top-level `ForPath` including typed-lambda paths respects null handling while child-only `ForPath` does not suppress parent nullability, repeated destination-member configuration uses the later effective mapping, the fixer preserves existing member options/source expressions and emits fully qualified framework defaults or `default!` for generic/reference fallback defaults when adding defaults without appending behind `Condition`/`PreCondition`, and catalog trust now marks the Info descriptor as analyzer-only. Remaining opportunities are advanced generic/nullability-flow semantics. |
 | AM003 | Collection type incompatibility | Type Safety | Error | 4 | 4 | 4 | 5 | 4 | 4 | Low | Shared container-incompatibility predicate with AM021 (HashSet/Queue/Stack/SortedSet/LinkedList/Immutable*/FrozenSet). Combined container+element mismatches report AM003 only; CreateRange fixes still convert elements when a named conversion exists. Sample isolates same-element List→HashSet. Custom-collection edge cases remain. |
 | AM004 | Source property has no corresponding destination property | Data Integrity | Warning | 4 | 4 | 4 | 5 | 5 | 5 | Low | Strong source-loss guardrail with unique-best fuzzy, reverse-map, and property-token placement. Aggregate Map-all/DoNotValidate-all still primarily surfaces for metadata pile-up / multi-diagnostic context (not same-document single-property lightbulbs). Catalog `Scaffold` trust remains accurate. |
@@ -125,7 +125,7 @@ Full rule+fixer reanalysis driven by four parallel subagent audits (Type Safety,
 | AM030 | ~5 direct tests in shared 146-test bucket. | Tests 4→3; tightened Notes. | AM030 Tests −1 |
 | AM032 | Null-flow heuristic + throw-only fix policy risk. | False Positives 4→3; tightened Notes. | AM032 False Positives −1 |
 
-## Fixer Trust Summary (v2.30.59)
+## Fixer Trust Summary (v2.30.60)
 
 | Rule | Fixable? | Catalog trust | Notes |
 | --- | --- | --- | --- |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -725,7 +725,7 @@ dotnet pack --configuration Release
 
 # Test package locally
 cd test-install/NetCoreTest
-dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.59-local
+dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.60-local
 ```
 
 ---
@@ -909,4 +909,4 @@ dotnet build
 
 **Last Updated**: 2026-05-14
 **Maintainer**: George Wall
-**Version**: 2.30.59
+**Version**: 2.30.60

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -112,8 +112,8 @@ The AutoMapper Roslyn Analyzer project uses GitHub Actions for continuous integr
 ### Package Versioning
 
 - **Format**: Major.Minor.Patch (SemVer)
-- **Current**: 2.30.59
-- **Pre-release**: 2.30.59-preview, 2.30.59-beta
+- **Current**: 2.30.60
+- **Pre-release**: 2.30.60-preview, 2.30.60-beta
 
 ## 🔧 Configuration
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -43,7 +43,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.59">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.60">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -67,7 +67,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.59">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.60">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -86,7 +86,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="14.0.0" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.59">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.60">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -218,7 +218,7 @@ public class Destination
 
 2. **Verify Package Installation**
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.59">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.60">
      <PrivateAssets>all</PrivateAssets>
      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -280,4 +280,4 @@ This guide ensures smooth installation and usage across all supported .NET frame
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.59
+**Version**: 2.30.60

--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -1544,7 +1544,7 @@ using System.Diagnostics.CodeAnalysis;
 
 1. **Check package reference**:
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.59">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.60">
        <PrivateAssets>all</PrivateAssets>
        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -1583,5 +1583,5 @@ If analyzer slows down builds:
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.59
+**Version**: 2.30.60
 **Maintainer**: George Wall

--- a/docs/RULE_CATALOG.md
+++ b/docs/RULE_CATALOG.md
@@ -2,7 +2,7 @@
 
 This file is generated from `RuleCatalog`.
 
-Package version: `2.30.59`
+Package version: `2.30.60`
 
 | Rule ID | Descriptor Title | Severity | Category | Analyzer | Code Fix | Trust | Sample | Docs |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,3 +1,15 @@
+## Release 2.30.60
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
+### Removed Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
 ## Release 2.30.59
 
 ### New Rules

--- a/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
+++ b/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
@@ -17,7 +17,7 @@
         <!-- Fallback for local builds: 2.0.YYYYMMDD-local -->
         <MajorVersion>2</MajorVersion>
         <MinorVersion>30</MinorVersion>
-        <PatchVersion>59</PatchVersion>
+        <PatchVersion>60</PatchVersion>
         <BuildNumber Condition="'$(BuildNumber)' == ''"
         >$([System.DateTime]::Now.ToString('yyyyMMdd'))
         </BuildNumber
@@ -32,10 +32,10 @@
         <RepositoryUrl>https://github.com/georgepwall1991/automapper-analyser</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <PackageReleaseNotes>Version 2.30.59 - Fixer UX honesty (Batch 1)
-- AM011 Map-all only with full fuzzy coverage; otherwise Scaffold-all (manual review)
-- Aggregate suppress titles include (manual review); stale AM011 diags withhold
-- AM022 MaxDepth scaffold title; AM031/AM020/AM021 no silent no-op lightbulbs
+        <PackageReleaseNotes>Version 2.30.60 - Fixer UX shared infra (Batch 2)
+- AM001 Convert-all / Ignore-all + nested Fix individual for multi-property maps
+- AM022 MaxDepth scaffold always best-first before Ignore
+- Shared AddUsingIfMissing for AM003/AM021/AM031
 </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>

--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM021_CollectionElementMismatchCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM021_CollectionElementMismatchCodeFixProvider.cs
@@ -414,7 +414,7 @@ public class AM021_CollectionElementMismatchCodeFixProvider : AutoMapperCodeFixP
         // Add using System.Linq if not present
         if (newRoot is CompilationUnitSyntax compilationUnit)
         {
-            newRoot = AddUsingIfMissing(compilationUnit, "System.Linq");
+            newRoot = CodeFixSyntaxHelper.AddUsingIfMissing(compilationUnit, "System.Linq");
         }
 
         return await Task.FromResult(document.WithSyntaxRoot(newRoot));
@@ -747,17 +747,4 @@ public class AM021_CollectionElementMismatchCodeFixProvider : AutoMapperCodeFixP
         return match.Success ? match.Groups[1].Value : null;
     }
 
-    private static CompilationUnitSyntax AddUsingIfMissing(CompilationUnitSyntax root, string namespaceName)
-    {
-        if (root.Usings.Any(u =>
-                u.Name != null && string.Equals(u.Name.ToString(), namespaceName, StringComparison.Ordinal)))
-        {
-            return root;
-        }
-
-        UsingDirectiveSyntax usingDirective = SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(namespaceName))
-            .WithTrailingTrivia(SyntaxFactory.ElasticLineFeed);
-
-        return root.AddUsings(usingDirective);
-    }
 }

--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM022_InfiniteRecursionCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM022_InfiniteRecursionCodeFixProvider.cs
@@ -57,9 +57,17 @@ public class AM022_InfiniteRecursionCodeFixProvider : AutoMapperCodeFixProviderB
             // - Single property: Ignore first (specific and simple)
             // - Multiple properties or none: MaxDepth first (simpler than ignoring all)
 
+            // Best-first: MaxDepth scaffold first (consistent single- and multi-property), then Ignore.
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    "Add MaxDepth(2) scaffold (review depth)",
+                    cancellationToken =>
+                        AddMaxDepthAsync(context.Document, operationContext.Root, invocation),
+                    "AM022_AddMaxDepth"),
+                diagnostic);
+
             if (selfReferencingProperties.Count == 1)
             {
-                // Single property: offer Ignore first
                 string propertyName = selfReferencingProperties[0];
                 context.RegisterCodeFix(
                     CodeAction.Create(
@@ -68,39 +76,17 @@ public class AM022_InfiniteRecursionCodeFixProvider : AutoMapperCodeFixProviderB
                             AddIgnoreAsync(context.Document, operationContext.Root, invocation, propertyName),
                         $"AM022_Ignore_{propertyName}"),
                     diagnostic);
-
-                // Offer MaxDepth scaffold as alternative (hard-coded depth 2 — review before keeping)
-                context.RegisterCodeFix(
-                    CodeAction.Create(
-                        "Add MaxDepth(2) scaffold (review depth)",
-                        cancellationToken =>
-                            AddMaxDepthAsync(context.Document, operationContext.Root, invocation),
-                        "AM022_AddMaxDepth"),
-                    diagnostic);
             }
-            else
+            else if (selfReferencingProperties.Count > 1)
             {
-                // Multiple properties or none: offer MaxDepth scaffold first (simpler)
                 context.RegisterCodeFix(
                     CodeAction.Create(
-                        "Add MaxDepth(2) scaffold (review depth)",
+                        $"Ignore all {selfReferencingProperties.Count} self-referencing properties (manual review)",
                         cancellationToken =>
-                            AddMaxDepthAsync(context.Document, operationContext.Root, invocation),
-                        "AM022_AddMaxDepth"),
+                            AddIgnoreMultipleAsync(context.Document, operationContext.Root, invocation,
+                                selfReferencingProperties),
+                        "AM022_IgnoreAll"),
                     diagnostic);
-
-                if (selfReferencingProperties.Count > 1)
-                {
-                    // Offer to ignore all self-referencing properties as alternative
-                    context.RegisterCodeFix(
-                        CodeAction.Create(
-                            $"Ignore all {selfReferencingProperties.Count} self-referencing properties (manual review)",
-                            cancellationToken =>
-                                AddIgnoreMultipleAsync(context.Document, operationContext.Root, invocation,
-                                    selfReferencingProperties),
-                            "AM022_IgnoreAll"),
-                        diagnostic);
-                }
             }
         }
     }

--- a/src/AutoMapperAnalyzer.Analyzers/Helpers/CodeFixSyntaxHelper.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Helpers/CodeFixSyntaxHelper.cs
@@ -33,12 +33,8 @@ public static class CodeFixSyntaxHelper
                 SyntaxFactory.ArgumentList(
                     SyntaxFactory.SeparatedList(new[]
                     {
-                        // First argument: dest => dest.PropertyName
-                        SyntaxFactory.Argument(
-                            CreatePropertySelectorLambda("dest", propertyName)),
-                        // Second argument: opt => opt.MapFrom(src => expression)
-                        SyntaxFactory.Argument(
-                            CreateMapFromLambda(mapFromExpression))
+                        SyntaxFactory.Argument(CreatePropertySelectorLambda("dest", propertyName)),
+                        SyntaxFactory.Argument(CreateMapFromLambda(mapFromExpression))
                     })));
     }
 
@@ -62,10 +58,7 @@ public static class CodeFixSyntaxHelper
                 SyntaxFactory.ArgumentList(
                     SyntaxFactory.SeparatedList(new[]
                     {
-                        // First argument: dest => dest.PropertyName
-                        SyntaxFactory.Argument(
-                            CreatePropertySelectorLambda("dest", propertyName)),
-                        // Second argument: opt => opt.Ignore()
+                        SyntaxFactory.Argument(CreatePropertySelectorLambda("dest", propertyName)),
                         SyntaxFactory.Argument(
                             SyntaxFactory.SimpleLambdaExpression(
                                 SyntaxFactory.Parameter(SyntaxFactory.Identifier("opt")),
@@ -97,10 +90,7 @@ public static class CodeFixSyntaxHelper
                 SyntaxFactory.ArgumentList(
                     SyntaxFactory.SeparatedList(new[]
                     {
-                        // First argument: src => src.PropertyName
-                        SyntaxFactory.Argument(
-                            CreatePropertySelectorLambda("src", propertyName)),
-                        // Second argument: opt => opt.DoNotValidate()
+                        SyntaxFactory.Argument(CreatePropertySelectorLambda("src", propertyName)),
                         SyntaxFactory.Argument(
                             SyntaxFactory.SimpleLambdaExpression(
                                 SyntaxFactory.Parameter(SyntaxFactory.Identifier("opt")),
@@ -110,6 +100,24 @@ public static class CodeFixSyntaxHelper
                                         SyntaxFactory.IdentifierName("opt"),
                                         SyntaxFactory.IdentifierName("DoNotValidate")))))
                     })));
+    }
+
+    /// <summary>
+    ///     Adds a <c>using</c> directive for <paramref name="namespaceName"/> when missing.
+    ///     Shared by collection/performance fixers that inject LINQ helpers.
+    /// </summary>
+    public static CompilationUnitSyntax AddUsingIfMissing(CompilationUnitSyntax root, string namespaceName)
+    {
+        if (root.Usings.Any(u =>
+                u.Name != null && string.Equals(u.Name.ToString(), namespaceName, StringComparison.Ordinal)))
+        {
+            return root;
+        }
+
+        UsingDirectiveSyntax usingDirective = SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(namespaceName))
+            .WithTrailingTrivia(SyntaxFactory.ElasticLineFeed);
+
+        return root.AddUsings(usingDirective);
     }
 
     /// <summary>

--- a/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningCodeFixProvider.cs
@@ -378,7 +378,7 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
 
         if (newRoot is CompilationUnitSyntax compilationUnit)
         {
-            newRoot = AddUsingIfMissing(compilationUnit, "System.Linq");
+            newRoot = CodeFixSyntaxHelper.AddUsingIfMissing(compilationUnit, "System.Linq");
         }
 
         return Task.FromResult(document.WithSyntaxRoot(newRoot));
@@ -563,21 +563,6 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
 
         collectionPath = string.Join(".", pathSegments);
         return true;
-    }
-
-    private static CompilationUnitSyntax AddUsingIfMissing(CompilationUnitSyntax root, string namespaceName)
-    {
-        if (root.Usings.Any(u =>
-                u.Name != null &&
-                string.Equals(u.Name.ToString(), namespaceName, StringComparison.Ordinal)))
-        {
-            return root;
-        }
-
-        UsingDirectiveSyntax usingDirective = SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(namespaceName))
-            .WithTrailingTrivia(SyntaxFactory.ElasticLineFeed);
-
-        return root.AddUsings(usingDirective);
     }
 
     private static string InferIssueTypeFromDescriptor(DiagnosticDescriptor descriptor)

--- a/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
@@ -130,7 +130,7 @@ public static class RuleCatalog
     /// <summary>
     ///     Current package version used by docs/package drift tests.
     /// </summary>
-    public const string CurrentPackageVersion = "2.30.59";
+    public const string CurrentPackageVersion = "2.30.60";
 
     /// <summary>
     ///     Implemented rules, grouped by public diagnostic ID.

--- a/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM001_PropertyTypeMismatchCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM001_PropertyTypeMismatchCodeFixProvider.cs
@@ -23,140 +23,136 @@ public class AM001_PropertyTypeMismatchCodeFixProvider : AutoMapperCodeFixProvid
     public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create("AM001");
 
     /// <summary>
-    ///     Registers code fixes for the diagnostics.
+    ///     Registers code fixes for the diagnostics. Multi-property CreateMaps get Convert-all /
+    ///     Ignore-all aggregates (when every property has a conversion) plus a nested submenu.
     /// </summary>
-    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    public sealed override Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        var operationContext = await GetOperationContextAsync(context);
-        if (operationContext == null)
-        {
-            return;
-        }
-
-        foreach (Diagnostic diagnostic in GetRelevantDiagnostics(context, operationContext.Root))
-        {
-            InvocationExpressionSyntax? invocation = GetCreateMapInvocation(operationContext.Root, diagnostic);
-            if (invocation == null)
-            {
-                continue;
-            }
-
-            string? propertyName = ExtractPropertyNameFromDiagnostic(diagnostic);
-            if (string.IsNullOrEmpty(propertyName))
-            {
-                continue;
-            }
-
-            string propertyNameValue = propertyName!;
-
-            (ITypeSymbol? sourceType, ITypeSymbol? destinationType) =
-                ResolveCreateMapTypesWithReverse(invocation, operationContext.SemanticModel);
-            if (sourceType == null || destinationType == null)
-            {
-                continue;
-            }
-
-            IPropertySymbol? sourceProperty = FindProperty(sourceType, propertyNameValue, false);
-            IPropertySymbol? destinationProperty = FindProperty(destinationType, propertyNameValue, true);
-            if (sourceProperty == null || destinationProperty == null)
-            {
-                continue;
-            }
-
-            ITypeSymbol sourcePropertyType = sourceProperty.Type;
-            ITypeSymbol destinationPropertyType = destinationProperty.Type;
-
-            if (SymbolEqualityComparer.Default.Equals(sourcePropertyType, destinationPropertyType))
-            {
-                continue;
-            }
-
-            string? conversionExpression =
-                CreateConversionExpression(sourcePropertyType, destinationPropertyType, propertyNameValue);
-            // Equivalence keys are property-name scoped so Fix All can batch same-named
-            // mismatches across CreateMap calls; each action still closes over its diagnostic location.
-            if (conversionExpression != null)
-            {
-                context.RegisterCodeFix(
-                    CodeAction.Create(
-                        $"Map '{propertyNameValue}' with conversion",
-                        cancellationToken =>
-                            AddMapFromAsync(context.Document, diagnostic, propertyNameValue, conversionExpression, cancellationToken),
-                        $"AM001_MapWithConversion_{propertyNameValue}"),
-                    diagnostic);
-            }
-
-            context.RegisterCodeFix(
-                CodeAction.Create(
-                    $"Ignore property '{propertyNameValue}' (manual review)",
-                    cancellationToken =>
-                        AddIgnoreAsync(context.Document, diagnostic, propertyNameValue, cancellationToken),
-                    $"AM001_Ignore_{propertyNameValue}"),
-                diagnostic);
-        }
+        return RegisterGroupedPerPropertyFixesAsync(
+            context,
+            [AM001_PropertyTypeMismatchAnalyzer.PropertyNamePropertyName],
+            "Fix individual type mismatch…",
+            (operationContext, group, diagnostic, properties) =>
+                BuildPerPropertyActions(context, operationContext, group, diagnostic, properties["PropertyName"]),
+            (operationContext, group) => BuildAggregateActions(context, operationContext, group));
     }
 
-    private static IEnumerable<Diagnostic> GetRelevantDiagnostics(CodeFixContext context, SyntaxNode root)
-    {
-        return context.Diagnostics
-            .Where(diag =>
-                diag.Id == "AM001" &&
-                diag.Location.IsInSource &&
-                diag.Location.SourceTree == root.SyntaxTree &&
-                diag.Location.SourceSpan.IntersectsWith(context.Span))
-            .OrderBy(diag => diag.Location.SourceSpan.Start)
-            .ThenBy(diag => diag.Properties.TryGetValue(
-                    AM001_PropertyTypeMismatchAnalyzer.PropertyNamePropertyName,
-                    out string? propertyName)
-                ? propertyName
-                : diag.GetMessage(), StringComparer.Ordinal);
-    }
-
-    private async Task<Document> AddMapFromAsync(
-        Document document,
+    private (string SubMenuTitle, ImmutableArray<CodeAction> Actions)? BuildPerPropertyActions(
+        CodeFixContext context,
+        CodeFixOperationContext operationContext,
+        DiagnosticInvocationGroup group,
         Diagnostic diagnostic,
-        string propertyName,
-        string conversionExpression,
-        CancellationToken cancellationToken)
+        string propertyName)
     {
-        SyntaxNode? root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-        if (root == null)
+        if (!TryBuildConversion(operationContext, group.Invocation, propertyName, out string? conversionExpression))
         {
-            return document;
+            return null;
         }
 
-        InvocationExpressionSyntax? invocation = GetCreateMapInvocation(root, diagnostic);
-        if (invocation == null)
+        var actions = ImmutableArray.CreateBuilder<CodeAction>();
+        if (conversionExpression != null)
         {
-            return document;
+            string expression = conversionExpression;
+            actions.Add(CodeAction.Create(
+                $"Map '{propertyName}' with conversion",
+                _ => ReplaceNodeAsync(
+                    context.Document,
+                    operationContext.Root,
+                    group.Invocation,
+                    CodeFixSyntaxHelper.CreateForMemberWithMapFrom(group.Invocation, propertyName, expression)),
+                $"AM001_MapWithConversion_{propertyName}"));
         }
 
-        InvocationExpressionSyntax newInvocation =
-            CodeFixSyntaxHelper.CreateForMemberWithMapFrom(invocation, propertyName, conversionExpression);
-        return await ReplaceNodeAsync(document, root, invocation, newInvocation);
+        actions.Add(CodeAction.Create(
+            $"Ignore property '{propertyName}' (manual review)",
+            _ => ReplaceNodeAsync(
+                context.Document,
+                operationContext.Root,
+                group.Invocation,
+                CodeFixSyntaxHelper.CreateForMemberWithIgnore(group.Invocation, propertyName)),
+            $"AM001_Ignore_{propertyName}"));
+
+        return ($"Property '{propertyName}'", actions.ToImmutable());
     }
 
-    private async Task<Document> AddIgnoreAsync(
-        Document document,
-        Diagnostic diagnostic,
-        string propertyName,
-        CancellationToken cancellationToken)
+    private ImmutableArray<CodeAction> BuildAggregateActions(
+        CodeFixContext context,
+        CodeFixOperationContext operationContext,
+        DiagnosticInvocationGroup group)
     {
-        SyntaxNode? root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-        if (root == null)
+        if (group.PropertyNames.Count < 2)
         {
-            return document;
+            return ImmutableArray<CodeAction>.Empty;
         }
 
-        InvocationExpressionSyntax? invocation = GetCreateMapInvocation(root, diagnostic);
-        if (invocation == null)
+        InvocationExpressionSyntax invocation = group.Invocation;
+        SyntaxNode root = operationContext.Root;
+        int count = group.PropertyNames.Count;
+        var actions = ImmutableArray.CreateBuilder<CodeAction>();
+
+        var conversions = group.PropertyNames
+            .Select(name =>
+            {
+                TryBuildConversion(operationContext, invocation, name, out string? expression);
+                return (Name: name, Expression: expression);
+            })
+            .ToList();
+
+        // Convert-all only when every flagged property has a known conversion recipe (honest title).
+        if (conversions.All(c => c.Expression != null))
         {
-            return document;
+            List<PropertyFixSpec> mapSpecs = conversions
+                .Select(c => PropertyFixSpec.MapFrom(c.Name, c.Expression!))
+                .ToList();
+            actions.Add(CodeAction.Create(
+                $"Convert all {count} type mismatches",
+                _ => ReplaceNodeAsync(
+                    context.Document, root, invocation, FoldAggregateForMembers(invocation, mapSpecs)),
+                "AM001_ConvertAll"));
         }
 
-        InvocationExpressionSyntax newInvocation =
-            CodeFixSyntaxHelper.CreateForMemberWithIgnore(invocation, propertyName);
-        return await ReplaceNodeAsync(document, root, invocation, newInvocation);
+        List<PropertyFixSpec> ignoreSpecs = group.PropertyNames
+            .Select(PropertyFixSpec.Ignore)
+            .ToList();
+        actions.Add(CodeAction.Create(
+            $"Ignore all {count} type mismatches (manual review)",
+            _ => ReplaceNodeAsync(
+                context.Document, root, invocation, FoldAggregateForMembers(invocation, ignoreSpecs)),
+            "AM001_IgnoreAll"));
+
+        return actions.ToImmutable();
+    }
+
+    private static bool TryBuildConversion(
+        CodeFixOperationContext operationContext,
+        InvocationExpressionSyntax invocation,
+        string propertyName,
+        out string? conversionExpression)
+    {
+        conversionExpression = null;
+        (ITypeSymbol? sourceType, ITypeSymbol? destinationType) =
+            ResolveCreateMapTypesWithReverse(invocation, operationContext.SemanticModel);
+        if (sourceType == null || destinationType == null)
+        {
+            return false;
+        }
+
+        IPropertySymbol? sourceProperty = FindProperty(sourceType, propertyName, false);
+        IPropertySymbol? destinationProperty = FindProperty(destinationType, propertyName, true);
+        if (sourceProperty == null || destinationProperty == null)
+        {
+            return false;
+        }
+
+        if (SymbolEqualityComparer.Default.Equals(sourceProperty.Type, destinationProperty.Type))
+        {
+            return false;
+        }
+
+        conversionExpression =
+            CreateConversionExpression(sourceProperty.Type, destinationProperty.Type, propertyName);
+        // Still offer Ignore even when no conversion is known.
+        return true;
     }
 
     private static IPropertySymbol? FindProperty(ITypeSymbol typeSymbol, string name, bool expectSetter)

--- a/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM003_CollectionTypeIncompatibilityCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM003_CollectionTypeIncompatibilityCodeFixProvider.cs
@@ -192,7 +192,7 @@ public class AM003_CollectionTypeIncompatibilityCodeFixProvider : AutoMapperCode
 
         if (requiresLinq && newRoot is CompilationUnitSyntax updatedCompilationUnit)
         {
-            newRoot = AddUsingIfMissing(updatedCompilationUnit, "System.Linq");
+            newRoot = CodeFixSyntaxHelper.AddUsingIfMissing(updatedCompilationUnit, "System.Linq");
         }
 
         return await Task.FromResult(document.WithSyntaxRoot(newRoot));
@@ -564,17 +564,4 @@ public class AM003_CollectionTypeIncompatibilityCodeFixProvider : AutoMapperCode
         return typeName;
     }
 
-    private static CompilationUnitSyntax AddUsingIfMissing(CompilationUnitSyntax root, string namespaceName)
-    {
-        if (root.Usings.Any(u =>
-                u.Name != null && string.Equals(u.Name.ToString(), namespaceName, StringComparison.Ordinal)))
-        {
-            return root;
-        }
-
-        UsingDirectiveSyntax usingDirective = SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(namespaceName))
-            .WithTrailingTrivia(SyntaxFactory.ElasticLineFeed);
-
-        return root.AddUsings(usingDirective);
-    }
 }

--- a/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM022_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM022_CodeFixTests.cs
@@ -143,7 +143,7 @@ public class AM022_CodeFixTests
                 new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.SelfReferencingTypeRule)
                     .WithLocation(21, 13)
                     .WithArguments("SourcePerson", "DestPerson"),
-                expectedFixedCode);
+                expectedFixedCode, 1);
     }
 
     [Fact]
@@ -365,7 +365,7 @@ public class AM022_CodeFixTests
                                          }
                                          """;
 
-        // Index 1: MaxDepth (for single property, index 0 is Ignore)
+        // Index 0: MaxDepth first (Ignore second)
         await CodeFixVerifier<AM022_InfiniteRecursionAnalyzer, AM022_InfiniteRecursionCodeFixProvider>
             .VerifyFixAsync(
                 testCode,
@@ -373,7 +373,7 @@ public class AM022_CodeFixTests
                     .WithLocation(23, 13)
                     .WithArguments("SourceNode", "DestNode"),
                 expectedFixedCode,
-                1);
+                0);
     }
 
     [Fact]
@@ -460,17 +460,7 @@ public class AM022_CodeFixTests
                                                   }
                                                   """;
 
-        // Index 0: Ignore (for single property)
-        await CodeFixVerifier<AM022_InfiniteRecursionAnalyzer, AM022_InfiniteRecursionCodeFixProvider>
-            .VerifyFixAsync(
-                testCode,
-                new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.SelfReferencingTypeRule)
-                    .WithLocation(21, 13)
-                    .WithArguments("SourcePerson", "DestPerson"),
-                expectedFixedCodeIgnore,
-                0);
-
-        // Index 1: MaxDepth
+        // Index 0: MaxDepth (best-first)
         await CodeFixVerifier<AM022_InfiniteRecursionAnalyzer, AM022_InfiniteRecursionCodeFixProvider>
             .VerifyFixAsync(
                 testCode,
@@ -478,6 +468,16 @@ public class AM022_CodeFixTests
                     .WithLocation(21, 13)
                     .WithArguments("SourcePerson", "DestPerson"),
                 expectedFixedCodeMaxDepth,
+                0);
+
+        // Index 1: Ignore
+        await CodeFixVerifier<AM022_InfiniteRecursionAnalyzer, AM022_InfiniteRecursionCodeFixProvider>
+            .VerifyFixAsync(
+                testCode,
+                new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.SelfReferencingTypeRule)
+                    .WithLocation(21, 13)
+                    .WithArguments("SourcePerson", "DestPerson"),
+                expectedFixedCodeIgnore,
                 1);
     }
 
@@ -541,7 +541,7 @@ public class AM022_CodeFixTests
                                          """;
 
         // Analyzer reports base type name without generic parameters
-        // Index 1: MaxDepth (for single property, index 0 is Ignore)
+        // Index 0: MaxDepth first (Ignore second)
         await CodeFixVerifier<AM022_InfiniteRecursionAnalyzer, AM022_InfiniteRecursionCodeFixProvider>
             .VerifyFixAsync(
                 testCode,
@@ -549,7 +549,7 @@ public class AM022_CodeFixTests
                     .WithLocation(22, 13)
                     .WithArguments("SourceNode", "DestNode"),
                 expectedFixedCode,
-                1);
+                0);
     }
 
     [Fact]
@@ -729,7 +729,7 @@ public class AM022_CodeFixTests
                                          }
                                          """;
 
-        // Index 1: MaxDepth (for single property, index 0 is Ignore)
+        // Index 0: MaxDepth first (Ignore second)
         await CodeFixVerifier<AM022_InfiniteRecursionAnalyzer, AM022_InfiniteRecursionCodeFixProvider>
             .VerifyFixAsync(
                 testCode,
@@ -737,7 +737,7 @@ public class AM022_CodeFixTests
                     .WithLocation(21, 13)
                     .WithArguments("SourceNode", "DestNode"),
                 expectedFixedCode,
-                1);
+                0);
     }
 
     [Fact]
@@ -803,7 +803,7 @@ public class AM022_CodeFixTests
                 new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.SelfReferencingTypeRule)
                     .WithLocation(21, 13)
                     .WithArguments("ISourceNode", "IDestNode"),
-                expectedFixedCode);
+                expectedFixedCode, 1);
     }
 
     [Fact]
@@ -869,7 +869,7 @@ public class AM022_CodeFixTests
                 new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.SelfReferencingTypeRule)
                     .WithLocation(21, 13)
                     .WithArguments("SourceNode", "DestNode"),
-                expectedFixedCode);
+                expectedFixedCode, 1);
     }
 
     [Fact]
@@ -1043,7 +1043,7 @@ public class AM022_CodeFixTests
                 new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.SelfReferencingTypeRule)
                     .WithLocation(21, 13)
                     .WithArguments("SourceNode", "DestNode"),
-                expectedFixedCode);
+                expectedFixedCode, 1);
     }
 
     [Fact]
@@ -1143,7 +1143,7 @@ public class AM022_CodeFixTests
                                          """;
 
         // Generic types with constraints should be detected (analyzer reports base type name)
-        // Index 1: MaxDepth (for single property, index 0 is Ignore)
+        // Index 0: MaxDepth first (Ignore second)
         await CodeFixVerifier<AM022_InfiniteRecursionAnalyzer, AM022_InfiniteRecursionCodeFixProvider>
             .VerifyFixAsync(
                 testCode,
@@ -1151,6 +1151,6 @@ public class AM022_CodeFixTests
                     .WithLocation(22, 13)
                     .WithArguments("SourceNode", "DestNode"),
                 expectedFixedCode,
-                1);
+                0);
     }
 }

--- a/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM001_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM001_CodeFixTests.cs
@@ -366,17 +366,17 @@ public class AM001_CodeFixTests
         ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(document);
         List<CodeAction> actions = await RegisterActionsAsync(document, diagnostics);
 
-        Assert.Collection(
-            actions.Select(action => action.Title),
-            title => Assert.Equal("Map 'Age' with conversion", title),
-            title => Assert.Equal("Ignore property 'Age' (manual review)", title),
-            title => Assert.Equal("Map 'Score' with conversion", title),
-            title => Assert.Equal("Ignore property 'Score' (manual review)", title));
+        // Multi-property: aggregate Convert-all / Ignore-all + nested "Fix individual…".
+        Assert.Contains(actions, a => a.EquivalenceKey == "AM001_ConvertAll");
+        Assert.Contains(actions, a => a.EquivalenceKey == "AM001_IgnoreAll");
+        Assert.Contains(
+            actions,
+            a => a.Title.Contains("individual", StringComparison.OrdinalIgnoreCase));
 
-        string updatedCode = await ApplyActionAsync(actions[0], document);
-        Assert.Contains(".ForMember(dest => dest.Age, opt => opt.MapFrom(src => src.Age.ToString(global::System.Globalization.CultureInfo.InvariantCulture)))", updatedCode,
-            StringComparison.Ordinal);
-        Assert.DoesNotContain("dest => dest.Score", updatedCode, StringComparison.Ordinal);
+        CodeAction convertAll = Assert.Single(actions, a => a.EquivalenceKey == "AM001_ConvertAll");
+        string updatedCode = await ApplyActionAsync(convertAll, document);
+        Assert.Contains("dest => dest.Age", updatedCode, StringComparison.Ordinal);
+        Assert.Contains("dest => dest.Score", updatedCode, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -411,16 +411,69 @@ public class AM001_CodeFixTests
 
         Document document = CreateDocument(testCode);
         ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(document);
-        List<CodeAction> actions = await RegisterActionsAsync(document, diagnostics);
+        IReadOnlyList<CodeFixActionInspector.ActionInfo> flattened =
+            await CodeFixActionInspector.GetActionsAsync(
+                document,
+                new AM001_PropertyTypeMismatchCodeFixProvider(),
+                diagnostics);
 
-        CodeAction scoreAction = Assert.Single(
-            actions,
-            action => action.Title == "Map 'Score' with conversion");
-        string updatedCode = await ApplyActionAsync(scoreAction, document);
+        Assert.Contains(flattened, a => a.EquivalenceKey == "AM001_MapWithConversion_Score");
+        Document fixedDoc = await CodeFixActionInspector.ApplyActionByKeyAsync(
+            document,
+            new AM001_PropertyTypeMismatchCodeFixProvider(),
+            diagnostics,
+            "AM001_MapWithConversion_Score");
+        string updatedCode = (await fixedDoc.GetTextAsync()).ToString();
 
         Assert.Contains(".ForMember(dest => dest.Score, opt => opt.MapFrom(src => src.Score.ToString(global::System.Globalization.CultureInfo.InvariantCulture)))", updatedCode,
             StringComparison.Ordinal);
         Assert.DoesNotContain("dest => dest.Age", updatedCode, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task AM001_ConvertAll_ConvertsEveryMismatch_InOneEdit()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class Source
+                                    {
+                                        public int Age { get; set; }
+                                        public double Score { get; set; }
+                                    }
+
+                                    public class Destination
+                                    {
+                                        public string Age { get; set; }
+                                        public string Score { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        Document document = CreateDocument(testCode);
+        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(document);
+        Assert.Equal(2, diagnostics.Length);
+
+        Document fixedDocument = await CodeFixActionInspector.ApplyActionByKeyAsync(
+            document,
+            new AM001_PropertyTypeMismatchCodeFixProvider(),
+            diagnostics,
+            "AM001_ConvertAll");
+
+        string updatedCode = (await fixedDocument.GetTextAsync()).ToString();
+        Assert.Contains("dest => dest.Age", updatedCode, StringComparison.Ordinal);
+        Assert.Contains("dest => dest.Score", updatedCode, StringComparison.Ordinal);
+        Assert.Empty(await GetDiagnosticsAsync(fixedDocument));
     }
 
     [Fact]
@@ -488,6 +541,7 @@ public class AM001_CodeFixTests
                 "Score", "Source", "double", "Destination", "string")
         ];
 
+        // Iterative Fix All still applies one conversion per diagnostic (2 iterations).
         await CodeFixVerifier<AM001_PropertyTypeMismatchAnalyzer, AM001_PropertyTypeMismatchCodeFixProvider>
             .VerifyFixWithIterationsAsync(testCode, diagnostics, expectedFixedCode, iterations: 2);
     }


### PR DESCRIPTION
## Summary
- **AM001**: Convert-all / Ignore-all + nested Fix individual for multi-property type mismatches
- **AM022**: MaxDepth scaffold always best-first before Ignore
- **Shared** `AddUsingIfMissing` for AM003/AM021/AM031
- Release **v2.30.60**

## Validation
- 1381 tests green (net10.0)
- Codex: no P1/P2; shippable meaningful improvement