### PR TITLE
feat: fixer UX Batch 3 + release 2.30.61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+## [2.30.61] - 2026-07-08
+
+Fixer UX executable polish (Batch 3).
+
+### Changed
+
+- **AM032**: null-guard code fix emits `ArgumentNullException.ThrowIfNull` (matches modern guard recognition).
+- **AM031**: lightbulb order is Cache → Remove convention ForMember → Ignore (manual review).
+- **AM003 / AM021**: keyword-escaped MapFrom sources; humanized conversion titles (quoted property names / short conversion labels).
+
+### Validation
+
+- Full solution test suite (`net10.0`) green: 1381 passed.
+
 ## [2.30.60] - 2026-07-08
 
 Fixer UX shared infrastructure (Batch 2).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Fixer UX executable polish (Batch 3).
 
 ### Changed
 
-- **AM032**: null-guard code fix emits `ArgumentNullException.ThrowIfNull` (matches modern guard recognition).
+- **AM032**: null-guard remains net48-compatible classic `if-throw` (analyzer still recognizes ThrowIfNull when written by hand).
 - **AM031**: lightbulb order is Cache → Remove convention ForMember → Ignore (manual review).
 - **AM003 / AM021**: keyword-escaped MapFrom sources; humanized conversion titles (quoted property names / short conversion labels).
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ prevention*
 
 ✅ **Highlights**
 
-- **AM032**: inserts `ArgumentNullException.ThrowIfNull` for missing converter null guards.
+- **AM032**: null-guard fix stays net48-compatible classic if-throw (analyzer recognizes ThrowIfNull).
 - **AM031**: Remove redundant convention ForMember appears before Ignore.
 - **AM003/AM021**: keyword-safe generated MapFrom; clearer lightbulb titles.
 
@@ -30,7 +30,7 @@ prevention*
 
 ### Recent Releases
 
-- **v2.30.61**: Fixer UX Batch 3 — AM032 ThrowIfNull emit, AM031 best-first Remove/Ignore, AM003/AM021 escape + titles.
+- **v2.30.61**: Fixer UX Batch 3 — AM031 best-first Remove/Ignore, AM003/AM021 escape + titles, AM032 net48-safe guard emit.
 - **v2.30.60**: Fixer UX Batch 2 — AM001 multi-property Convert-all/Ignore-all, AM022 MaxDepth best-first, shared AddUsingIfMissing.
 - **v2.30.59**: Fixer UX honesty — AM011 Map-all/Scaffold-all honesty, manual-review aggregate titles, no silent no-op lightbulbs for AM020/AM021/AM031, AM022 MaxDepth scaffold title.
 - **v2.30.58**: AM001 ReverseMap direction keys, Nullable scalar reporting, fixer culture/null/keyword/framework conversion hardening.

--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ prevention*
 
 ---
 
-## 🎉 Latest Release: v2.30.60
+## 🎉 Latest Release: v2.30.61
 
-**Fixer UX shared infra — AM001 multi-property aggregates, AM022 best-first order**
+**Fixer UX polish — ThrowIfNull, best-first AM031, clearer Convert titles**
 
 ✅ **Highlights**
 
-- **AM001**: Convert-all / Ignore-all + nested Fix individual when multiple type mismatches share a CreateMap.
-- **AM022**: MaxDepth scaffold always first in the lightbulb.
-- **Helpers**: shared `AddUsingIfMissing` for collection/performance fixers.
+- **AM032**: inserts `ArgumentNullException.ThrowIfNull` for missing converter null guards.
+- **AM031**: Remove redundant convention ForMember appears before Ignore.
+- **AM003/AM021**: keyword-safe generated MapFrom; clearer lightbulb titles.
 
 🧪 **Validation**
 
@@ -30,6 +30,7 @@ prevention*
 
 ### Recent Releases
 
+- **v2.30.61**: Fixer UX Batch 3 — AM032 ThrowIfNull emit, AM031 best-first Remove/Ignore, AM003/AM021 escape + titles.
 - **v2.30.60**: Fixer UX Batch 2 — AM001 multi-property Convert-all/Ignore-all, AM022 MaxDepth best-first, shared AddUsingIfMissing.
 - **v2.30.59**: Fixer UX honesty — AM011 Map-all/Scaffold-all honesty, manual-review aggregate titles, no silent no-op lightbulbs for AM020/AM021/AM031, AM022 MaxDepth scaffold title.
 - **v2.30.58**: AM001 ReverseMap direction keys, Nullable scalar reporting, fixer culture/null/keyword/framework conversion hardening.
@@ -226,7 +227,7 @@ Install-Package AutoMapperAnalyzer.Analyzers
 ### Project File (For CI/CD)
 
 ```xml
-<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.60">
+<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.61">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 </PackageReference>

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -1,6 +1,6 @@
 # Analyzer Health
 
-Reviewed: 2026-07-08 (previous review: 2026-07-08 hitlist; current shipped version: 2.30.60)
+Reviewed: 2026-07-08 (previous review: 2026-07-08 hitlist; current shipped version: 2.30.61)
 
 This is a deliberately harsh health audit for the 16 implemented AutoMapper analyzer rule IDs in this repository. Several rule IDs expose multiple diagnostic descriptors, especially `AM002`, `AM022`, and `AM031`; the scorecard rates the public rule ID as the user experiences it.
 
@@ -125,7 +125,7 @@ Full rule+fixer reanalysis driven by four parallel subagent audits (Type Safety,
 | AM030 | ~5 direct tests in shared 146-test bucket. | Tests 4→3; tightened Notes. | AM030 Tests −1 |
 | AM032 | Null-flow heuristic + throw-only fix policy risk. | False Positives 4→3; tightened Notes. | AM032 False Positives −1 |
 
-## Fixer Trust Summary (v2.30.60)
+## Fixer Trust Summary (v2.30.61)
 
 | Rule | Fixable? | Catalog trust | Notes |
 | --- | --- | --- | --- |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -725,7 +725,7 @@ dotnet pack --configuration Release
 
 # Test package locally
 cd test-install/NetCoreTest
-dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.60-local
+dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.61-local
 ```
 
 ---
@@ -909,4 +909,4 @@ dotnet build
 
 **Last Updated**: 2026-05-14
 **Maintainer**: George Wall
-**Version**: 2.30.60
+**Version**: 2.30.61

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -112,8 +112,8 @@ The AutoMapper Roslyn Analyzer project uses GitHub Actions for continuous integr
 ### Package Versioning
 
 - **Format**: Major.Minor.Patch (SemVer)
-- **Current**: 2.30.60
-- **Pre-release**: 2.30.60-preview, 2.30.60-beta
+- **Current**: 2.30.61
+- **Pre-release**: 2.30.61-preview, 2.30.61-beta
 
 ## 🔧 Configuration
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -43,7 +43,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.60">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.61">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -67,7 +67,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.60">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.61">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -86,7 +86,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="14.0.0" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.60">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.61">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -218,7 +218,7 @@ public class Destination
 
 2. **Verify Package Installation**
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.60">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.61">
      <PrivateAssets>all</PrivateAssets>
      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -280,4 +280,4 @@ This guide ensures smooth installation and usage across all supported .NET frame
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.60
+**Version**: 2.30.61

--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -1544,7 +1544,7 @@ using System.Diagnostics.CodeAnalysis;
 
 1. **Check package reference**:
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.60">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.61">
        <PrivateAssets>all</PrivateAssets>
        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -1583,5 +1583,5 @@ If analyzer slows down builds:
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.60
+**Version**: 2.30.61
 **Maintainer**: George Wall

--- a/docs/RULE_CATALOG.md
+++ b/docs/RULE_CATALOG.md
@@ -2,7 +2,7 @@
 
 This file is generated from `RuleCatalog`.
 
-Package version: `2.30.60`
+Package version: `2.30.61`
 
 | Rule ID | Descriptor Title | Severity | Category | Analyzer | Code Fix | Trust | Sample | Docs |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,3 +1,15 @@
+## Release 2.30.61
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
+### Removed Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
 ## Release 2.30.60
 
 ### New Rules

--- a/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
+++ b/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
@@ -17,7 +17,7 @@
         <!-- Fallback for local builds: 2.0.YYYYMMDD-local -->
         <MajorVersion>2</MajorVersion>
         <MinorVersion>30</MinorVersion>
-        <PatchVersion>60</PatchVersion>
+        <PatchVersion>61</PatchVersion>
         <BuildNumber Condition="'$(BuildNumber)' == ''"
         >$([System.DateTime]::Now.ToString('yyyyMMdd'))
         </BuildNumber
@@ -32,10 +32,10 @@
         <RepositoryUrl>https://github.com/georgepwall1991/automapper-analyser</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <PackageReleaseNotes>Version 2.30.60 - Fixer UX shared infra (Batch 2)
-- AM001 Convert-all / Ignore-all + nested Fix individual for multi-property maps
-- AM022 MaxDepth scaffold always best-first before Ignore
-- Shared AddUsingIfMissing for AM003/AM021/AM031
+                <PackageReleaseNotes>Version 2.30.61 - Fixer UX polish (Batch 3)
+- AM032 null-guard fix emits ArgumentNullException.ThrowIfNull
+- AM031 Remove convention ForMember before Ignore
+- AM003/AM021 keyword-safe MapFrom + clearer conversion titles
 </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>

--- a/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
+++ b/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
@@ -33,7 +33,7 @@
         <RepositoryType>git</RepositoryType>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
                 <PackageReleaseNotes>Version 2.30.61 - Fixer UX polish (Batch 3)
-- AM032 null-guard fix emits ArgumentNullException.ThrowIfNull
+- AM032 null-guard stays net48-compatible classic if-throw
 - AM031 Remove convention ForMember before Ignore
 - AM003/AM021 keyword-safe MapFrom + clearer conversion titles
 </PackageReleaseNotes>

--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM021_CollectionElementMismatchCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM021_CollectionElementMismatchCodeFixProvider.cs
@@ -164,13 +164,32 @@ public class AM021_CollectionElementMismatchCodeFixProvider : AutoMapperCodeFixP
             return;
         }
 
+        string shortConversion = GetShortConversionLabel(conversionMethod);
         context.RegisterCodeFix(
             CodeAction.Create(
-                $"Add Select with {conversionMethod} for '{destinationPropertyName}'",
+                $"Convert '{destinationPropertyName}' elements with {shortConversion}",
                 cancellationToken =>
                     AddMapFromWithLinqAsync(context.Document, root, invocation, destinationPropertyName, mapFromExpression),
                 $"AM021_SimpleConversion_{destinationPropertyName}"),
             diagnostic);
+    }
+
+    private static string GetShortConversionLabel(string conversionMethod)
+    {
+        // e.g. global::System.Convert.ToInt32 → ToInt32; global::System.DateTime.Parse → DateTime.Parse
+        const string convertPrefix = "global::System.Convert.";
+        if (conversionMethod.StartsWith(convertPrefix, StringComparison.Ordinal))
+        {
+            return conversionMethod.Substring(convertPrefix.Length);
+        }
+
+        const string systemPrefix = "global::System.";
+        if (conversionMethod.StartsWith(systemPrefix, StringComparison.Ordinal))
+        {
+            return conversionMethod.Substring(systemPrefix.Length);
+        }
+
+        return conversionMethod;
     }
 
     private void RegisterDictionaryFixes(
@@ -207,7 +226,7 @@ public class AM021_CollectionElementMismatchCodeFixProvider : AutoMapperCodeFixP
                 ? $"{GetConversionMethod(valueDest!)}(kvp.Value)"
                 : "kvp.Value";
             string mapFromExpression =
-                $"src.{sourcePropertyName}.ToDictionary(kvp => {keySelector}, kvp => {valueSelector})";
+                $"src.{CodeFixSyntaxHelper.EscapeIdentifier(sourcePropertyName)}.ToDictionary(kvp => {keySelector}, kvp => {valueSelector})";
 
             context.RegisterCodeFix(
                 CodeAction.Create(
@@ -516,7 +535,8 @@ public class AM021_CollectionElementMismatchCodeFixProvider : AutoMapperCodeFixP
             return null;
         }
 
-        string selectExpression = $"src.{sourcePropertyName}.Select(x => {conversionMethod}(x))";
+        string selectExpression =
+            $"src.{CodeFixSyntaxHelper.EscapeIdentifier(sourcePropertyName)}.Select(x => {conversionMethod}(x))";
         string destinationTypeName = destProperty.Type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
 
         if (destProperty.Type.TypeKind == TypeKind.Array)

--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM030_CustomTypeConverterCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM030_CustomTypeConverterCodeFixProvider.cs
@@ -75,9 +75,10 @@ public class AM030_CustomTypeConverterCodeFixProvider : AutoMapperCodeFixProvide
         string sourceParameterName,
         CancellationToken cancellationToken)
     {
-        // Prefer modern ThrowIfNull (recognized by AM032 analyzer) over classic if-throw.
+        // Classic if-throw remains the emit form so net48 consumers (documented support matrix)
+        // get compiling code. AM032 analyzer still recognizes ThrowIfNull* when users write it.
         StatementSyntax guardStatement = SyntaxFactory.ParseStatement(
-            $"global::System.ArgumentNullException.ThrowIfNull({sourceParameterName});")
+            $"if ({sourceParameterName} == null) throw new global::System.ArgumentNullException(nameof({sourceParameterName}));")
             .WithTrailingTrivia(SyntaxFactory.ElasticLineFeed);
 
         MethodDeclarationSyntax updatedMethod;

--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM030_CustomTypeConverterCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM030_CustomTypeConverterCodeFixProvider.cs
@@ -75,8 +75,9 @@ public class AM030_CustomTypeConverterCodeFixProvider : AutoMapperCodeFixProvide
         string sourceParameterName,
         CancellationToken cancellationToken)
     {
+        // Prefer modern ThrowIfNull (recognized by AM032 analyzer) over classic if-throw.
         StatementSyntax guardStatement = SyntaxFactory.ParseStatement(
-            $"if ({sourceParameterName} == null) throw new global::System.ArgumentNullException(nameof({sourceParameterName}));")
+            $"global::System.ArgumentNullException.ThrowIfNull({sourceParameterName});")
             .WithTrailingTrivia(SyntaxFactory.ElasticLineFeed);
 
         MethodDeclarationSyntax updatedMethod;

--- a/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningCodeFixProvider.cs
@@ -115,11 +115,9 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
 
         // Ignore/Remove rewrite the ForMember link; only register when the peel target exists
         // so the lightbulb never advertises a silent no-op.
+        // Best-first order: Cache (above) → Remove convention ForMember → Ignore last.
         if (GetInvocationWithoutForMember(destinationConfigurationInvocation) != null)
         {
-            RegisterIgnoreMappingFix(context, operationContext.Root, destinationConfigurationInvocation, propertyName!,
-                relatedDiagnostics);
-
             if (await CanUseConventionMappingAsync(
                     context.Document,
                     destinationConfigurationInvocation,
@@ -130,6 +128,9 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
                     propertyName!,
                     relatedDiagnostics);
             }
+
+            RegisterIgnoreMappingFix(context, operationContext.Root, destinationConfigurationInvocation, propertyName!,
+                relatedDiagnostics);
         }
     }
 

--- a/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
@@ -130,7 +130,7 @@ public static class RuleCatalog
     /// <summary>
     ///     Current package version used by docs/package drift tests.
     /// </summary>
-    public const string CurrentPackageVersion = "2.30.60";
+    public const string CurrentPackageVersion = "2.30.61";
 
     /// <summary>
     ///     Implemented rules, grouped by public diagnostic ID.

--- a/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM003_CollectionTypeIncompatibilityCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM003_CollectionTypeIncompatibilityCodeFixProvider.cs
@@ -131,13 +131,13 @@ public class AM003_CollectionTypeIncompatibilityCodeFixProvider : AutoMapperCode
                 {
                     context.RegisterCodeFix(
                         CodeAction.Create(
-                            $"Convert {propertyName} elements using Select()",
+                            $"Convert \'{propertyName}\' elements using Select()",
                             ct => AddMapFromAsync(
                                 context.Document,
                                 operationContext.Root,
                                 invocation,
                                 propertyName,
-                                $"src.{propertyName}.Select({conversionLambda})",
+                                $"src.{CodeFixSyntaxHelper.EscapeIdentifier(propertyName)}.Select({conversionLambda})",
                                 true,
                                 ct),
                             $"AM003_Select_{propertyName}"),
@@ -253,12 +253,12 @@ public class AM003_CollectionTypeIncompatibilityCodeFixProvider : AutoMapperCode
                 if (isConstructor)
                 {
                     // new List<T>(src.Prop.Select(x => ...))
-                    return collectionConversion.Replace($"src.{propertyName}",
-                        $"src.{propertyName}.Select({elementConversionLambda})");
+                    return collectionConversion.Replace($"src.{CodeFixSyntaxHelper.EscapeIdentifier(propertyName)}",
+                        $"src.{CodeFixSyntaxHelper.EscapeIdentifier(propertyName)}.Select({elementConversionLambda})");
                 }
 
                 // src.Prop.Select(x => ...).ToList()
-                return $"src.{propertyName}.Select({elementConversionLambda}).{collectionConversion.Split('.').Last()}";
+                return $"src.{CodeFixSyntaxHelper.EscapeIdentifier(propertyName)}.Select({elementConversionLambda}).{collectionConversion.Split('.').Last()}";
             }
 
             return collectionConversion;
@@ -278,8 +278,8 @@ public class AM003_CollectionTypeIncompatibilityCodeFixProvider : AutoMapperCode
         if (Contains(sourceType, "HashSet") && IsKnownConcreteCollectionType(destType, "List"))
         {
             fixes.Add((
-                $"Convert {propertyName} using ToList()",
-                BuildExpression($"src.{propertyName}.ToList()"),
+                $"Convert \'{propertyName}\' using ToList()",
+                BuildExpression($"src.{CodeFixSyntaxHelper.EscapeIdentifier(propertyName)}.ToList()"),
                 true, // Always true if using ToList or Select
                 $"AM003_ToList_{propertyName}"));
         }
@@ -324,11 +324,11 @@ public class AM003_CollectionTypeIncompatibilityCodeFixProvider : AutoMapperCode
         {
             // Arrays are IEnumerable, so AsEnumerable is fine, but if we need element conversion, we need Select
             string expr = needsElementConversion
-                ? $"src.{propertyName}.Select({elementConversionLambda})"
-                : $"src.{propertyName}.AsEnumerable()";
+                ? $"src.{CodeFixSyntaxHelper.EscapeIdentifier(propertyName)}.Select({elementConversionLambda})"
+                : $"src.{CodeFixSyntaxHelper.EscapeIdentifier(propertyName)}.AsEnumerable()";
 
             fixes.Add((
-                $"Convert {propertyName} using {(needsElementConversion ? "Select" : "AsEnumerable")}()",
+                $"Convert \'{propertyName}\' using {(needsElementConversion ? "Select" : "AsEnumerable")}()",
                 expr,
                 true,
                 $"AM003_AsEnumerable_{propertyName}"));
@@ -348,7 +348,7 @@ public class AM003_CollectionTypeIncompatibilityCodeFixProvider : AutoMapperCode
             string targetType = string.IsNullOrWhiteSpace(simplifiedDestType)
                 ? "System.Collections.Generic.List<object>"
                 : simplifiedDestType;
-            return ($"Convert {propertyName} using collection constructor", $"new {targetType}(src.{propertyName})",
+            return ($"Convert '{propertyName}' using collection constructor", $"new {targetType}(src.{CodeFixSyntaxHelper.EscapeIdentifier(propertyName)})",
                 false, $"AM003_Constructor_{propertyName}");
         }
     }
@@ -363,10 +363,10 @@ public class AM003_CollectionTypeIncompatibilityCodeFixProvider : AutoMapperCode
         if (IsListLikeInterface(destinationType))
         {
             string expression = needsElementConversion
-                ? $"src.{propertyName}.Select({elementConversionLambda}).ToList()"
-                : $"src.{propertyName}.ToList()";
+                ? $"src.{CodeFixSyntaxHelper.EscapeIdentifier(propertyName)}.Select({elementConversionLambda}).ToList()"
+                : $"src.{CodeFixSyntaxHelper.EscapeIdentifier(propertyName)}.ToList()";
             fix = (
-                $"Convert {propertyName} using ToList()",
+                $"Convert \'{propertyName}\' using ToList()",
                 expression,
                 true,
                 $"AM003_ToList_{propertyName}");
@@ -376,10 +376,10 @@ public class AM003_CollectionTypeIncompatibilityCodeFixProvider : AutoMapperCode
         if (IsSetLikeInterface(destinationType) && TryGetGenericArgument(destinationType, out string? elementType))
         {
             string sourceExpression = needsElementConversion
-                ? $"src.{propertyName}.Select({elementConversionLambda})"
-                : $"src.{propertyName}";
+                ? $"src.{CodeFixSyntaxHelper.EscapeIdentifier(propertyName)}.Select({elementConversionLambda})"
+                : $"src.{CodeFixSyntaxHelper.EscapeIdentifier(propertyName)}";
             fix = (
-                $"Convert {propertyName} using HashSet constructor",
+                $"Convert \'{propertyName}\' using HashSet constructor",
                 $"new global::System.Collections.Generic.HashSet<{elementType}>({sourceExpression})",
                 needsElementConversion,
                 $"AM003_HashSet_{propertyName}");
@@ -398,13 +398,13 @@ public class AM003_CollectionTypeIncompatibilityCodeFixProvider : AutoMapperCode
         out (string Title, string Expression, bool RequiresLinq, string EquivalenceKey) fix)
     {
         string sourceExpression = needsElementConversion
-            ? $"src.{propertyName}.Select({elementConversionLambda})"
-            : $"src.{propertyName}";
+            ? $"src.{CodeFixSyntaxHelper.EscapeIdentifier(propertyName)}.Select({elementConversionLambda})"
+            : $"src.{CodeFixSyntaxHelper.EscapeIdentifier(propertyName)}";
 
         if (IsKnownConcreteCollectionType(destinationType, "ImmutableList", "System.Collections.Immutable."))
         {
             fix = (
-                $"Convert {propertyName} using ImmutableList.CreateRange()",
+                $"Convert \'{propertyName}\' using ImmutableList.CreateRange()",
                 $"global::System.Collections.Immutable.ImmutableList.CreateRange({sourceExpression})",
                 needsElementConversion,
                 $"AM003_ImmutableList_{propertyName}");
@@ -414,7 +414,7 @@ public class AM003_CollectionTypeIncompatibilityCodeFixProvider : AutoMapperCode
         if (IsKnownConcreteCollectionType(destinationType, "ImmutableArray", "System.Collections.Immutable."))
         {
             fix = (
-                $"Convert {propertyName} using ImmutableArray.CreateRange()",
+                $"Convert \'{propertyName}\' using ImmutableArray.CreateRange()",
                 $"global::System.Collections.Immutable.ImmutableArray.CreateRange({sourceExpression})",
                 needsElementConversion,
                 $"AM003_ImmutableArray_{propertyName}");
@@ -424,7 +424,7 @@ public class AM003_CollectionTypeIncompatibilityCodeFixProvider : AutoMapperCode
         if (IsKnownConcreteCollectionType(destinationType, "ImmutableHashSet", "System.Collections.Immutable."))
         {
             fix = (
-                $"Convert {propertyName} using ImmutableHashSet.CreateRange()",
+                $"Convert \'{propertyName}\' using ImmutableHashSet.CreateRange()",
                 $"global::System.Collections.Immutable.ImmutableHashSet.CreateRange({sourceExpression})",
                 needsElementConversion,
                 $"AM003_ImmutableHashSet_{propertyName}");
@@ -434,7 +434,7 @@ public class AM003_CollectionTypeIncompatibilityCodeFixProvider : AutoMapperCode
         if (IsKnownConcreteCollectionType(destinationType, "FrozenSet", "System.Collections.Frozen."))
         {
             fix = (
-                $"Convert {propertyName} using FrozenSet.ToFrozenSet()",
+                $"Convert \'{propertyName}\' using FrozenSet.ToFrozenSet()",
                 $"global::System.Collections.Frozen.FrozenSet.ToFrozenSet({sourceExpression})",
                 needsElementConversion,
                 $"AM003_FrozenSet_{propertyName}");

--- a/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM030_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM030_CodeFixTests.cs
@@ -50,7 +50,7 @@ public class AM030_CodeFixTests
                                              {
                                                  public int Convert(string? source, int destination, ResolutionContext context)
                                                  {
-                                                     global::System.ArgumentNullException.ThrowIfNull(source);
+                                                     if (source == null) throw new global::System.ArgumentNullException(nameof(source));
                                                      return int.Parse(source);
                                                  }
                                              }
@@ -162,7 +162,7 @@ public class AM030_CodeFixTests
                                              {
                                                  public int Convert(string? source, int destination, ResolutionContext context)
                                                  {
-                                                     global::System.ArgumentNullException.ThrowIfNull(source);
+                                                     if (source == null) throw new global::System.ArgumentNullException(nameof(source));
                                                      return int.Parse(source);
                                                  }
                                              }
@@ -223,7 +223,7 @@ public class AM030_CodeFixTests
                                              {
                                                  public int Convert(string? source, int destination, ResolutionContext context)
                                                  {
-                                                     global::System.ArgumentNullException.ThrowIfNull(source);
+                                                     if (source == null) throw new global::System.ArgumentNullException(nameof(source));
                                                      return int.Parse(source);
                                                  }
                                              }
@@ -306,7 +306,7 @@ public class AM030_CodeFixTests
                                     {
                                         public int Convert(string? source, int destination, ResolutionContext context)
                                         {
-                                            global::System.ArgumentNullException.ThrowIfNull(source);
+                                            if (source == null) throw new global::System.ArgumentNullException(nameof(source));
                                             return int.Parse(source);
                                         }
                                     }
@@ -359,7 +359,7 @@ public class AM030_CodeFixTests
                                              {
                                                  public string Convert(int? source, string destination, ResolutionContext context)
                                                  {
-                                                     global::System.ArgumentNullException.ThrowIfNull(source);
+                                                     if (source == null) throw new global::System.ArgumentNullException(nameof(source));
                                                      return source.ToString();
                                                  }
                                              }
@@ -418,7 +418,7 @@ public class AM030_CodeFixTests
                                              {
                                                  public int Convert(string? source, int destination, ResolutionContext context)
                                                  {
-                                                     global::System.ArgumentNullException.ThrowIfNull(source);
+                                                     if (source == null) throw new global::System.ArgumentNullException(nameof(source));
                                                      return int.Parse(source);
                                                  }
                                              }
@@ -483,7 +483,7 @@ public class AM030_CodeFixTests
                                              {
                                                  public int Convert(string? source, int destination, ResolutionContext context)
                                                  {
-                                                     global::System.ArgumentNullException.ThrowIfNull(source);
+                                                     if (source == null) throw new global::System.ArgumentNullException(nameof(source));
                                                      return int.Parse(source);
                                                  }
                                              }
@@ -546,7 +546,7 @@ public class AM030_CodeFixTests
                                              {
                                                  public int Convert(string? source, int destination, ResolutionContext context)
                                                  {
-                                                     global::System.ArgumentNullException.ThrowIfNull(source);
+                                                     if (source == null) throw new global::System.ArgumentNullException(nameof(source));
                                                      return source.Contains("test") ? int.Parse(source.Split('-')[0]) : 0;
                                                  }
                                              }
@@ -607,7 +607,7 @@ public class AM030_CodeFixTests
                                              {
                                                  public string Convert(List<string>? source, string destination, ResolutionContext context)
                                                  {
-                                                     global::System.ArgumentNullException.ThrowIfNull(source);
+                                                     if (source == null) throw new global::System.ArgumentNullException(nameof(source));
                                                      return string.Join(",", source);
                                                  }
                                              }
@@ -668,7 +668,7 @@ public class AM030_CodeFixTests
                                              {
                                                  public int Convert(string? source, int destination, ResolutionContext context)
                                                  {
-                                                     global::System.ArgumentNullException.ThrowIfNull(source);
+                                                     if (source == null) throw new global::System.ArgumentNullException(nameof(source));
                                                      return int.Parse(source);
                                                  }
                                              }
@@ -726,7 +726,7 @@ public class AM030_CodeFixTests
                                          {
                                              public int Convert(string? source, int destination, ResolutionContext context)
                                              {
-                                                 global::System.ArgumentNullException.ThrowIfNull(source);
+                                                 if (source == null) throw new global::System.ArgumentNullException(nameof(source));
                                                  return int.Parse(source);
                                              }
                                          }
@@ -793,7 +793,7 @@ public class AM030_CodeFixTests
                                              {
                                                  public int Convert(string? source, int destination, ResolutionContext context)
                                                  {
-                                                     global::System.ArgumentNullException.ThrowIfNull(source);
+                                                     if (source == null) throw new global::System.ArgumentNullException(nameof(source));
                                                      return int.Parse(source);
                                                  }
                                              }
@@ -802,7 +802,7 @@ public class AM030_CodeFixTests
                                              {
                                                  public decimal Convert(string? source, decimal destination, ResolutionContext context)
                                                  {
-                                                     global::System.ArgumentNullException.ThrowIfNull(source);
+                                                     if (source == null) throw new global::System.ArgumentNullException(nameof(source));
                                                      return decimal.Parse(source);
                                                  }
                                              }

--- a/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM030_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM030_CodeFixTests.cs
@@ -50,7 +50,7 @@ public class AM030_CodeFixTests
                                              {
                                                  public int Convert(string? source, int destination, ResolutionContext context)
                                                  {
-                                                     if (source == null) throw new global::System.ArgumentNullException(nameof(source));
+                                                     global::System.ArgumentNullException.ThrowIfNull(source);
                                                      return int.Parse(source);
                                                  }
                                              }
@@ -162,7 +162,7 @@ public class AM030_CodeFixTests
                                              {
                                                  public int Convert(string? source, int destination, ResolutionContext context)
                                                  {
-                                                     if (source == null) throw new global::System.ArgumentNullException(nameof(source));
+                                                     global::System.ArgumentNullException.ThrowIfNull(source);
                                                      return int.Parse(source);
                                                  }
                                              }
@@ -223,7 +223,7 @@ public class AM030_CodeFixTests
                                              {
                                                  public int Convert(string? source, int destination, ResolutionContext context)
                                                  {
-                                                     if (source == null) throw new global::System.ArgumentNullException(nameof(source));
+                                                     global::System.ArgumentNullException.ThrowIfNull(source);
                                                      return int.Parse(source);
                                                  }
                                              }
@@ -306,7 +306,7 @@ public class AM030_CodeFixTests
                                     {
                                         public int Convert(string? source, int destination, ResolutionContext context)
                                         {
-                                            if (source == null) throw new ArgumentNullException(nameof(source));
+                                            global::System.ArgumentNullException.ThrowIfNull(source);
                                             return int.Parse(source);
                                         }
                                     }
@@ -359,7 +359,7 @@ public class AM030_CodeFixTests
                                              {
                                                  public string Convert(int? source, string destination, ResolutionContext context)
                                                  {
-                                                     if (source == null) throw new global::System.ArgumentNullException(nameof(source));
+                                                     global::System.ArgumentNullException.ThrowIfNull(source);
                                                      return source.ToString();
                                                  }
                                              }
@@ -418,7 +418,7 @@ public class AM030_CodeFixTests
                                              {
                                                  public int Convert(string? source, int destination, ResolutionContext context)
                                                  {
-                                                     if (source == null) throw new global::System.ArgumentNullException(nameof(source));
+                                                     global::System.ArgumentNullException.ThrowIfNull(source);
                                                      return int.Parse(source);
                                                  }
                                              }
@@ -483,7 +483,7 @@ public class AM030_CodeFixTests
                                              {
                                                  public int Convert(string? source, int destination, ResolutionContext context)
                                                  {
-                                                     if (source == null) throw new global::System.ArgumentNullException(nameof(source));
+                                                     global::System.ArgumentNullException.ThrowIfNull(source);
                                                      return int.Parse(source);
                                                  }
                                              }
@@ -546,7 +546,7 @@ public class AM030_CodeFixTests
                                              {
                                                  public int Convert(string? source, int destination, ResolutionContext context)
                                                  {
-                                                     if (source == null) throw new global::System.ArgumentNullException(nameof(source));
+                                                     global::System.ArgumentNullException.ThrowIfNull(source);
                                                      return source.Contains("test") ? int.Parse(source.Split('-')[0]) : 0;
                                                  }
                                              }
@@ -607,7 +607,7 @@ public class AM030_CodeFixTests
                                              {
                                                  public string Convert(List<string>? source, string destination, ResolutionContext context)
                                                  {
-                                                     if (source == null) throw new global::System.ArgumentNullException(nameof(source));
+                                                     global::System.ArgumentNullException.ThrowIfNull(source);
                                                      return string.Join(",", source);
                                                  }
                                              }
@@ -668,7 +668,7 @@ public class AM030_CodeFixTests
                                              {
                                                  public int Convert(string? source, int destination, ResolutionContext context)
                                                  {
-                                                     if (source == null) throw new global::System.ArgumentNullException(nameof(source));
+                                                     global::System.ArgumentNullException.ThrowIfNull(source);
                                                      return int.Parse(source);
                                                  }
                                              }
@@ -726,7 +726,7 @@ public class AM030_CodeFixTests
                                          {
                                              public int Convert(string? source, int destination, ResolutionContext context)
                                              {
-                                                 if (source == null) throw new global::System.ArgumentNullException(nameof(source));
+                                                 global::System.ArgumentNullException.ThrowIfNull(source);
                                                  return int.Parse(source);
                                              }
                                          }
@@ -793,7 +793,7 @@ public class AM030_CodeFixTests
                                              {
                                                  public int Convert(string? source, int destination, ResolutionContext context)
                                                  {
-                                                     if (source == null) throw new global::System.ArgumentNullException(nameof(source));
+                                                     global::System.ArgumentNullException.ThrowIfNull(source);
                                                      return int.Parse(source);
                                                  }
                                              }
@@ -802,7 +802,7 @@ public class AM030_CodeFixTests
                                              {
                                                  public decimal Convert(string? source, decimal destination, ResolutionContext context)
                                                  {
-                                                     if (source == null) throw new global::System.ArgumentNullException(nameof(source));
+                                                     global::System.ArgumentNullException.ThrowIfNull(source);
                                                      return decimal.Parse(source);
                                                  }
                                              }

--- a/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM003_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM003_CodeFixTests.cs
@@ -940,7 +940,7 @@ public class AM003_CodeFixTests
         List<CodeAction> actions = await RegisterActionsAsync(document, diagnostic);
 
         Assert.Contains(actions, action =>
-            action.Title == "Convert Values using collection constructor" &&
+            action.Title == "Convert 'Values' using collection constructor" &&
             action.EquivalenceKey == "AM003_Constructor_Values");
         Assert.Contains(actions, action =>
             action.Title == "Ignore property 'Values' (manual review)" &&
@@ -982,7 +982,7 @@ public class AM003_CodeFixTests
         List<CodeAction> actions = await RegisterActionsAsync(document, diagnostic);
 
         Assert.Contains(actions, action =>
-            action.Title == "Convert Values using collection constructor" &&
+            action.Title == "Convert 'Values' using collection constructor" &&
             action.EquivalenceKey == "AM003_Constructor_Values");
         Assert.Contains(actions, action =>
             action.Title == "Ignore property 'Values' (manual review)" &&


### PR DESCRIPTION
## Summary
- **AM031**: best-first lightbulb order (Cache → Remove convention → Ignore)
- **AM003/AM021**: keyword-escaped MapFrom sources; clearer conversion titles
- **AM032**: keeps net48-compatible classic if-throw (Codex P1 closed)
- Release **v2.30.61**

## Validation
- 1381 tests green
- Codex: no remaining P1; shippable meaningful improvement