### PR TITLE
fix: AM022 graph-aware Ignore for multi-type cycles (2.30.63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+## [2.30.63] - 2026-07-08
+
+AM022 graph-aware Ignore for multi-type circular maps.
+
+### Changed
+
+- **AM022**: code fix Ignore actions use the analyzer's recursive destination-property graph when the destination has no same-type self-reference, so multi-type cycles (A→B→C→A) offer Ignore on the cycle edge (e.g. `BReference`) instead of MaxDepth-only.
+- Lightbulb titles use "circular property" (covers self-ref and graph edges). MaxDepth(2) scaffold remains best-first.
+
+### Validation
+
+- AM022 suite + full solution tests on `net10.0`.
+
 ## [2.30.62] - 2026-07-08
 
 Split multi-concept AM031 performance diagnostics into independent public rule IDs.
@@ -14,7 +27,7 @@ Split multi-concept AM031 performance diagnostics into independent public rule I
 
 ### Validation
 
-- Full suite on `net10.0`: **1382** passed.
+- Full suite on `net10.0`: **1384** passed.
 - AnalyzerVerifier catalog/snapshots updated.
 
 ## [2.30.61] - 2026-07-08

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet Version](https://img.shields.io/nuget/v/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=NuGet)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=Downloads)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/georgepwall1991/automapper-analyser/ci.yml?style=flat-square&logo=github&label=Build)](https://github.com/georgepwall1991/automapper-analyser/actions)
-[![Tests](https://img.shields.io/badge/Tests-1382%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
+[![Tests](https://img.shields.io/badge/Tests-1384%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
 [![.NET](https://img.shields.io/badge/.NET-4.8+%20%7C%206.0+%20%7C%208.0+%20%7C%209.0+%20%7C%2010.0+-512BD4?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 [![Coverage](https://img.shields.io/codecov/c/github/georgepwall1991/automapper-analyser?style=flat-square&logo=codecov&label=Coverage)](https://codecov.io/gh/georgepwall1991/automapper-analyser)
@@ -14,15 +14,14 @@ prevention*
 
 ---
 
-## 🎉 Latest Release: v2.30.62
+## 🎉 Latest Release: v2.30.63
 
-**Performance rule ID split — AM031 multi-enum + AM034–AM038**
+**AM022 graph-aware Ignore for multi-type cycles**
 
 ✅ **Highlights**
 
-- **AM031**: multiple enumeration only (cache rewrite retained).
-- **AM034–AM038**: expensive op, expensive computation, sync-over-async, complex LINQ, non-deterministic — independent IDs.
-- Independent severity configuration per performance concept.
+- **AM022**: Ignore lightbulb uses analyzer graph edges (not only destination self-refs).
+- MaxDepth scaffold remains best-first; titles say "circular property".
 
 🧪 **Validation**
 
@@ -30,6 +29,7 @@ prevention*
 
 ### Recent Releases
 
+- **v2.30.63**: AM022 graph-aware Ignore for multi-type cycles.
 - **v2.30.62**: Split AM031 performance concepts into AM031 + AM034–AM038.
 - **v2.30.61**: Fixer UX Batch 3 — AM031 best-first Remove/Ignore, AM003/AM021 escape + titles, AM032 net48-safe guard emit.
 - **v2.30.60**: Fixer UX Batch 2 — AM001 multi-property Convert-all/Ignore-all, AM022 MaxDepth best-first, shared AddUsingIfMissing.
@@ -228,7 +228,7 @@ Install-Package AutoMapperAnalyzer.Analyzers
 ### Project File (For CI/CD)
 
 ```xml
-<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.62">
+<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.63">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 </PackageReference>

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -6,7 +6,7 @@ This is a deliberately harsh health audit for the **21** implemented AutoMapper 
 
 Every implemented rule currently has an analyzer and a code fix provider. Scores are 1-5, where `5` means reference-quality and hard to improve, `3` means usable but meaningfully incomplete, and `1` means unreliable or underbuilt.
 
-**Ship status:** production-acceptable. **2.30.62** splits AM031 multi-concept ID into AM031 + AM034–AM038. Remaining highest residual is **AM022** (FP/Fix min 3). Full suite green; catalog/snapshots current.
+**Ship status:** production-acceptable. **2.30.63** AM022 graph-aware Ignore; **2.30.62** splits AM031 multi-concept ID into AM031 + AM034–AM038. Remaining highest residual is **AM022** (FP/Fix min 3). Full suite green; catalog/snapshots current.
 
 ## Rubric
 
@@ -42,7 +42,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | AM011 | Required destination property is not mapped | Data Integrity | Error | 4 | 5 | 4 | 5 | 5 | 5 | Low | Important runtime-failure guardrail; per-property fuzzy now resolves ReverseMap types (same as aggregate). Fix Strategy 4: Map-all only when every property has unique fuzzy; mixed/default bulk uses honest Scaffold-all + (manual review); Ignore-all labeled manual review; stale diagnostics withhold. Residual: primary single-property path still scaffolds defaults. |
 | AM020 | Nested object mapping configuration missing | Complex Mappings | Warning | 4 | 4 | 4 | 5 | 5 | 5 | Low | Reference analyzer; fixer now shares public+internal property discovery with the analyzer (internal nested CreateMap fix covered). Catalog trust is `LikelyRewrite` (constructor-body insertion remains a structural limit). |
 | AM021 | Collection element type incompatibility | Complex Mappings | Warning | 4 | 4 | 4 | 5 | 4 | 4 | Low | Defers fully when AM003 owns container incompatibility (shared helper). Same-container element mismatches, dictionary axes, reverse gaps, and implicit element conversions remain AM021. List simple Select rewrites now refuse non-compiling Parse destinations (string-source gate matches dictionaries). |
-| AM022 | Infinite recursion risk | Complex Mappings | Warning | 4 | 3 | 3 | 5 | 4 | 4 | Low | Requires configured nested CreateMap chains for indirect cycles; strong suppressions. Catalog `Scaffold` matches hard-coded `MaxDepth(2)` policy; lightbulb title now says scaffold (review depth). Residual: fixer Ignore discovery is direct self-ref only (multi-type cycles MaxDepth-only); intentional circular DTOs and graph heuristics. |
+| AM022 | Infinite recursion risk | Complex Mappings | Warning | 4 | 3 | 4 | 5 | 4 | 4 | Low | Requires configured nested CreateMap chains for indirect cycles; strong suppressions. Catalog `Scaffold` matches hard-coded `MaxDepth(2)` policy; lightbulb title now says scaffold (review depth). **Fix Strategy 4** (2.30.63): Ignore uses analyzer graph edges for multi-type cycles. Residual: intentional circular DTOs and analyzer graph FP heuristics (FP still 3). |
 | AM030 | Invalid type converter implementation | Custom Conversions | Error | 4 | 4 | 4 | 4 | 4 | 3 | Low | Analyzer-only by design; AM001/AM020/AM021 own missing-converter mapping. Split from AM032/AM033 is clean in catalog and trust tests. Direct AM030 coverage includes empty implementation, wrong return type, missing `ResolutionContext`, and non-public `Convert` (each paired with the matching compiler error). |
 | AM032 | Type converter null handling | Custom Conversions | Warning | 4 | 4 | 4 | 5 | 4 | 4 | Low | Best-in-class null-guard detection with catalog `LikelyRewrite` trust. Recognizes `ThrowIfNull*`, switch/pattern/coalesce/conditional-access guards, and pure nullable→nullable source pass-through (`return source` / `=> source`). Residual: heuristic null-flow edge cases; the auto-fix still inserts `ArgumentNullException` (appropriate when a diagnostic fires for non-nullable destinations without intentional null handling). |
 | AM033 | Unused type converter | Custom Conversions | Info | 4 | 4 | 4 | 4 | 4 | 2 | Low | Unused-converter diagnostics now have their own Info rule ID and remain analyzer-only, and the shared converter code-fix provider no longer advertises AM033 as fixable. Usage analysis recognizes generic, instance, type-based including parenthesized/casted `typeof(...)` and simple explicit or implicit `Type` locals/fields/properties initialized from, expression-bodied to, or getter-bodied to `typeof(...)`, parameterless `Type` factory methods and local functions that expression-body or return `typeof(...)`, simple interface-typed locals/fields/properties, and DI/service-provider interface handles passed to `ConvertUsing(...)`. Product importance is intentionally lower because this is cleanup guidance. |
@@ -71,7 +71,7 @@ Use this table as the hardening queue. Ranking = **Importance × (5 − min(Anal
 
 | Rank | Rule | Signal | Residual (evidence-backed) | Likely score move if closed |
 | --- | --- | --- | --- | --- |
-| 1 | **AM022** | gap=8, min=3 | Analyzer FP: graph heuristics + intentional circular DTOs (FP=3). Fixer Ignore discovery is **destination self-ref properties only** (`FindSelfReferencingProperties`); multi-type cycles get MaxDepth scaffold only. Catalog `Scaffold` + MaxDepth(2) honesty already matches. | FP and/or Fix 3→4 if graph-aware Ignore + better intentional-cycle suppressions land with tests |
+| 1 | **AM022** | gap=4, min=3 (FP) | Graph-aware Ignore shipped 2.30.63 (Fix 4). Residual: intentional circular DTO false positives / graph heuristics (FP=3). | FP 3→4 needs better intentional-cycle suppressions |
 | 2 | **AM001** | gap=5, min=4 | Diagnostics still land on **CreateMap invocation** (`invocation.GetLocation()`), not property tokens (unlike AM004/005/006/011). Fix Strategy already 5 (Convert-all/Ignore-all + nested individual). | Analyzer/Docs polish only unless placement ships |
 | 3 | **AM004 / AM006** | gap=5/4 | Aggregate Map-all / DoNotValidate-all / Ignore-all need multi-diagnostic **group** context; same-document single-property lightbulbs do not recompute siblings the way AM011 does. Catalog Scaffold remains correct. | Fix 4→5 if same-document sibling recompute matches AM011 without inventing mappings |
 | 4 | **AM031 / AM034–AM038** | Fix=3 | Shared ForPath analyzer-only + Scaffold policy after ID split. Further smell breadth is diminishing returns. | Fix 3→4 only with ForPath-safe rewrites |
@@ -84,9 +84,9 @@ Use this table as the hardening queue. Ranking = **Importance × (5 − min(Anal
 
 **Recommended next hardening batch:**
 
-1. **AM022 graph-aware Ignore + intentional-cycle FP**
-2. **AM004/AM006 same-document sibling recompute**
-3. **AM001 property-token placement**
+1. **AM004/AM006 same-document sibling recompute**
+2. **AM001 property-token placement**
+3. **AM022 intentional-cycle FP** (remaining after graph-aware Ignore)
 
 Do **not** open advanced AM001/AM002 conversion/nullability modelling without a filed false-positive/false-negative repro.
 
@@ -107,7 +107,7 @@ The Planning Shortlist above summarises overall rule priority; this backlog is t
 Active queue (also summarized in Working Base). Prefer one focus per hardening batch:
 
 - _AM031 ID split — resolved in 2.30.62._ AM031 multi-enum; AM034–AM038 independent IDs.
-- **AM022 graph-aware Ignore + intentional-cycle FP.** Fixer `FindSelfReferencingProperties` is destination self-ref only; multi-type cycles are MaxDepth-only. Analyzer FP remains the intentional circular-DTO / graph-heuristic class.
+- _AM022 graph-aware Ignore — resolved in 2.30.63._ Multi-type cycle edges offered for Ignore. Residual: intentional circular-DTO FP (FP=3).
 - **AM004 / AM006 same-document sibling recompute.** Match AM011's ability to offer honest aggregates from a single property-token diagnostic without inventing mappings.
 - **AM001 property-token diagnostic placement.** Still reports on `CreateMap` invocation span; data-integrity rules already land on property tokens.
 - **AM032 destination-aware null fixes.** Emit stays classic net48 `if-throw`; not destination-nullability-aware. Analyzer ThrowIfNull* recognition is already strong.
@@ -148,6 +148,12 @@ Still open (do not start without a repro or explicit product decision):
 - **AM022 / AM031 dataflow-grade heuristics.** High effort, diminishing returns until a concrete false-positive pattern is filed (prefer P2 ID-split / graph-Ignore first).
 - **AM020 constructor-body CreateMap insert.** Structural host limit; catalog `LikelyRewrite` already honest.
 
+
+## Reanalysis Changelog (2026-07-08 → 2.30.63 AM022 graph-aware Ignore)
+
+| Rules | Finding | Change | Score impact |
+| --- | --- | --- | --- |
+| AM022 | Multi-type cycles MaxDepth-only (Ignore was dest self-ref only) | Fixer reuses `FindRecursiveDestinationProperties` for cycle-edge Ignore | Fix Strategy 3→4 |
 
 ## Reanalysis Changelog (2026-07-08 → 2.30.62 AM031 ID split)
 
@@ -195,7 +201,7 @@ Full rule+fixer reanalysis driven by four parallel subagent audits (Type Safety,
 | AM030 | ~5 direct tests in shared 146-test bucket. | Tests 4→3; tightened Notes. | AM030 Tests −1 |
 | AM032 | Null-flow heuristic + throw-only fix policy risk. | False Positives 4→3; tightened Notes. | AM032 False Positives −1 |
 
-## Fixer Trust Summary (v2.30.62)
+## Fixer Trust Summary (v2.30.63)
 
 | Rule | Fixable? | Catalog trust | Notes |
 | --- | --- | --- | --- |
@@ -206,7 +212,7 @@ Full rule+fixer reanalysis driven by four parallel subagent audits (Type Safety,
 | AM005 | Yes | LikelyRewrite | Single explicit `ForMember` rewrite; keyword-escaped source |
 | AM020 | Yes | LikelyRewrite | Adds missing `CreateMap<,>()` pairs; public+internal property parity |
 | AM021 | Yes | LikelyRewrite | Executable `ToDictionary`/Select rewrites; Parse gated to string sources |
-| AM022 | Yes | Scaffold | `MaxDepth(2)` policy scaffold + ignore (manual review) |
+| AM022 | Yes | Scaffold | `MaxDepth(2)` + graph-aware Ignore on cycle edges (manual review) |
 | AM030, AM033 | No | NoFix | Analyzer-only by design |
 | AM032 | Yes | LikelyRewrite | Inserts `ArgumentNullException` guard |
 | AM031 | Yes | Scaffold | Multiple enumeration; cache rewrite + Ignore/Remove on ForMember; ForPath analyzer-only |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -725,7 +725,7 @@ dotnet pack --configuration Release
 
 # Test package locally
 cd test-install/NetCoreTest
-dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.62-local
+dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.63-local
 ```
 
 ---
@@ -909,4 +909,4 @@ dotnet build
 
 **Last Updated**: 2026-05-14
 **Maintainer**: George Wall
-**Version**: 2.30.62
+**Version**: 2.30.63

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -112,8 +112,8 @@ The AutoMapper Roslyn Analyzer project uses GitHub Actions for continuous integr
 ### Package Versioning
 
 - **Format**: Major.Minor.Patch (SemVer)
-- **Current**: 2.30.62
-- **Pre-release**: 2.30.62-preview, 2.30.62-beta
+- **Current**: 2.30.63
+- **Pre-release**: 2.30.63-preview, 2.30.63-beta
 
 ## 🔧 Configuration
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -43,7 +43,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.62">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.63">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -67,7 +67,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.62">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.63">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -86,7 +86,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="14.0.0" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.62">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.63">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -218,7 +218,7 @@ public class Destination
 
 2. **Verify Package Installation**
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.62">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.63">
      <PrivateAssets>all</PrivateAssets>
      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -280,4 +280,4 @@ This guide ensures smooth installation and usage across all supported .NET frame
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.62
+**Version**: 2.30.63

--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -915,7 +915,10 @@ CreateMap<SourcePerson, DestinationPerson>()
     .PreserveReferences();  // ✅ Reuses already-mapped references
 ```
 
-**Option 3: Ignore Circular Property**
+**Option 3: Ignore Circular Property (Code Fix)**
+
+The lightbulb offers Ignore for destination **self-references** and for **graph cycle edges** on multi-type chains
+(e.g. `A.BReference` in an A→B→C→A map). MaxDepth scaffold remains the first action.
 
 ```csharp
 CreateMap<SourcePerson, DestinationPerson>()
@@ -1596,7 +1599,7 @@ using System.Diagnostics.CodeAnalysis;
 
 1. **Check package reference**:
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.62">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.63">
        <PrivateAssets>all</PrivateAssets>
        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -1635,5 +1638,5 @@ If analyzer slows down builds:
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.62
+**Version**: 2.30.63
 **Maintainer**: George Wall

--- a/docs/RULE_CATALOG.md
+++ b/docs/RULE_CATALOG.md
@@ -2,7 +2,7 @@
 
 This file is generated from `RuleCatalog`.
 
-Package version: `2.30.62`
+Package version: `2.30.63`
 
 | Rule ID | Descriptor Title | Severity | Category | Analyzer | Code Fix | Trust | Sample | Docs |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,3 +1,15 @@
+## Release 2.30.63
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
+### Removed Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
 ## Release 2.30.62
 
 ### New Rules

--- a/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
+++ b/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
@@ -17,7 +17,7 @@
         <!-- Fallback for local builds: 2.0.YYYYMMDD-local -->
         <MajorVersion>2</MajorVersion>
         <MinorVersion>30</MinorVersion>
-        <PatchVersion>62</PatchVersion>
+        <PatchVersion>63</PatchVersion>
         <BuildNumber Condition="'$(BuildNumber)' == ''"
         >$([System.DateTime]::Now.ToString('yyyyMMdd'))
         </BuildNumber
@@ -32,10 +32,9 @@
         <RepositoryUrl>https://github.com/georgepwall1991/automapper-analyser</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-                <PackageReleaseNotes>Version 2.30.62 - Split AM031 performance concepts into independent rule IDs
-- AM031 multiple enumeration (kept)
-- AM034 expensive operation, AM035 expensive computation, AM036 sync-over-async, AM037 complex LINQ, AM038 non-deterministic
-- Independent severity/docs/catalog entries; shared analyzer + code fix provider
+                <PackageReleaseNotes>Version 2.30.63 - AM022 graph-aware Ignore for multi-type cycles
+- Ignore lightbulb now offers cycle-edge properties from the analyzer graph walk (not only destination self-refs)
+- Titles say circular property; MaxDepth scaffold remains best-first
 </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>

--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM022_InfiniteRecursionAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM022_InfiniteRecursionAnalyzer.cs
@@ -318,7 +318,12 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
         return false;
     }
 
-    private static HashSet<string> FindRecursiveDestinationProperties(
+    /// <summary>
+    ///     Destination properties on a CreateMap pair whose convention-mapped path participates
+    ///     in a configured circular graph (self-ref or multi-type). Used by the analyzer for
+    ///     Ignore suppression and by the code fix for graph-aware Ignore actions.
+    /// </summary>
+    internal static HashSet<string> FindRecursiveDestinationProperties(
         INamedTypeSymbol sourceType,
         INamedTypeSymbol destinationType,
         CreateMapRegistry createMapRegistry

--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM022_InfiniteRecursionCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM022_InfiniteRecursionCodeFixProvider.cs
@@ -42,7 +42,7 @@ public class AM022_InfiniteRecursionCodeFixProvider : AutoMapperCodeFixProviderB
                 continue;
             }
 
-            // Get the type arguments to identify self-referencing properties
+            // Get the type arguments to identify cycle-breaking properties
             (ITypeSymbol? sourceType, ITypeSymbol? destType) createMapTypes =
                 AutoMapperAnalysisHelpers.GetCreateMapTypeArguments(invocation, operationContext.SemanticModel);
             if (createMapTypes.Item1 == null || createMapTypes.Item2 == null)
@@ -50,12 +50,11 @@ public class AM022_InfiniteRecursionCodeFixProvider : AutoMapperCodeFixProviderB
                 continue;
             }
 
-            // Find all self-referencing properties
-            ImmutableList<string> selfReferencingProperties = FindSelfReferencingProperties(createMapTypes.Item2);
-
-            // Register fixes based on complexity:
-            // - Single property: Ignore first (specific and simple)
-            // - Multiple properties or none: MaxDepth first (simpler than ignoring all)
+            // Analyzer graph edges (includes self-ref + multi-type cycle properties).
+            ImmutableList<string> cycleProperties = FindCycleBreakingProperties(
+                createMapTypes.Item1,
+                createMapTypes.Item2,
+                operationContext.SemanticModel);
 
             // Best-first: MaxDepth scaffold first (consistent single- and multi-property), then Ignore.
             context.RegisterCodeFix(
@@ -66,34 +65,56 @@ public class AM022_InfiniteRecursionCodeFixProvider : AutoMapperCodeFixProviderB
                     "AM022_AddMaxDepth"),
                 diagnostic);
 
-            if (selfReferencingProperties.Count == 1)
+            if (cycleProperties.Count == 1)
             {
-                string propertyName = selfReferencingProperties[0];
+                string propertyName = cycleProperties[0];
                 context.RegisterCodeFix(
                     CodeAction.Create(
-                        $"Ignore self-referencing property '{propertyName}' (manual review)",
+                        $"Ignore circular property '{propertyName}' (manual review)",
                         cancellationToken =>
                             AddIgnoreAsync(context.Document, operationContext.Root, invocation, propertyName),
                         $"AM022_Ignore_{propertyName}"),
                     diagnostic);
             }
-            else if (selfReferencingProperties.Count > 1)
+            else if (cycleProperties.Count > 1)
             {
                 context.RegisterCodeFix(
                     CodeAction.Create(
-                        $"Ignore all {selfReferencingProperties.Count} self-referencing properties (manual review)",
+                        $"Ignore all {cycleProperties.Count} circular properties (manual review)",
                         cancellationToken =>
                             AddIgnoreMultipleAsync(context.Document, operationContext.Root, invocation,
-                                selfReferencingProperties),
+                                cycleProperties),
                         "AM022_IgnoreAll"),
                     diagnostic);
             }
         }
     }
 
+    private static ImmutableList<string> FindCycleBreakingProperties(
+        ITypeSymbol sourceType,
+        ITypeSymbol destType,
+        SemanticModel semanticModel)
+    {
+        // Prefer the same graph edges the analyzer uses for Ignore suppression so the lightbulb
+        // cannot suggest a self-ref Ignore that leaves a multi-type cycle diagnostic alive.
+        if (sourceType is INamedTypeSymbol namedSource && destType is INamedTypeSymbol namedDest)
+        {
+            CreateMapRegistry registry = CreateMapRegistry.FromCompilation(semanticModel.Compilation);
+            HashSet<string> recursive = AM022_InfiniteRecursionAnalyzer
+                .FindRecursiveDestinationProperties(namedSource, namedDest, registry);
+            if (recursive.Count > 0)
+            {
+                return recursive.OrderBy(name => name, StringComparer.Ordinal).ToImmutableList();
+            }
+        }
+
+        // Fallback: destination same-type self-references when the graph walk is empty.
+        return FindSelfReferencingProperties(destType);
+    }
+
     private static ImmutableList<string> FindSelfReferencingProperties(ITypeSymbol destType)
     {
-        var selfReferencingProps = new HashSet<string>();
+        var selfReferencingProps = new HashSet<string>(StringComparer.Ordinal);
         IEnumerable<IPropertySymbol> destinationProperties =
             AutoMapperAnalysisHelpers.GetMappableProperties(destType, requireSetter: false);
 
@@ -112,7 +133,7 @@ public class AM022_InfiniteRecursionCodeFixProvider : AutoMapperCodeFixProviderB
             }
         }
 
-        return selfReferencingProps.ToImmutableList();
+        return selfReferencingProps.OrderBy(name => name, StringComparer.Ordinal).ToImmutableList();
     }
 
     private Task<Document> AddMaxDepthAsync(

--- a/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
@@ -130,7 +130,7 @@ public static class RuleCatalog
     /// <summary>
     ///     Current package version used by docs/package drift tests.
     /// </summary>
-    public const string CurrentPackageVersion = "2.30.62";
+    public const string CurrentPackageVersion = "2.30.63";
 
     /// <summary>
     ///     Implemented rules, grouped by public diagnostic ID.

--- a/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM022_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM022_CodeFixTests.cs
@@ -673,6 +673,230 @@ public class AM022_CodeFixTests
     }
 
     [Fact]
+    public async Task AM022_ShouldOfferIgnoreForGraphCycleEdge_ThreeTypes()
+    {
+        // Multi-type A→B→C→A has no destination self-ref; Ignore must use graph-aware edges.
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class SourceA
+                                    {
+                                        public string Name { get; set; }
+                                        public SourceB BReference { get; set; }
+                                    }
+
+                                    public class SourceB
+                                    {
+                                        public string Data { get; set; }
+                                        public SourceC CReference { get; set; }
+                                    }
+
+                                    public class SourceC
+                                    {
+                                        public int Value { get; set; }
+                                        public SourceA AReference { get; set; }
+                                    }
+
+                                    public class DestA
+                                    {
+                                        public string Name { get; set; }
+                                        public DestB BReference { get; set; }
+                                    }
+
+                                    public class DestB
+                                    {
+                                        public string Data { get; set; }
+                                        public DestC CReference { get; set; }
+                                    }
+
+                                    public class DestC
+                                    {
+                                        public int Value { get; set; }
+                                        public DestA AReference { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            // B/C already scaffolded so only A reports — isolates graph-aware Ignore.
+                                            CreateMap<SourceA, DestA>();
+                                            CreateMap<SourceB, DestB>().MaxDepth(2);
+                                            CreateMap<SourceC, DestC>().MaxDepth(2);
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string expectedFixedCode = """
+                                         using AutoMapper;
+
+                                         namespace TestNamespace
+                                         {
+                                             public class SourceA
+                                             {
+                                                 public string Name { get; set; }
+                                                 public SourceB BReference { get; set; }
+                                             }
+
+                                             public class SourceB
+                                             {
+                                                 public string Data { get; set; }
+                                                 public SourceC CReference { get; set; }
+                                             }
+
+                                             public class SourceC
+                                             {
+                                                 public int Value { get; set; }
+                                                 public SourceA AReference { get; set; }
+                                             }
+
+                                             public class DestA
+                                             {
+                                                 public string Name { get; set; }
+                                                 public DestB BReference { get; set; }
+                                             }
+
+                                             public class DestB
+                                             {
+                                                 public string Data { get; set; }
+                                                 public DestC CReference { get; set; }
+                                             }
+
+                                             public class DestC
+                                             {
+                                                 public int Value { get; set; }
+                                                 public DestA AReference { get; set; }
+                                             }
+
+                                             public class TestProfile : Profile
+                                             {
+                                                 public TestProfile()
+                                                 {
+                                                     // B/C already scaffolded so only A reports — isolates graph-aware Ignore.
+                                                     CreateMap<SourceA, DestA>().ForMember(dest => dest.BReference, opt => opt.Ignore());
+                                                     CreateMap<SourceB, DestB>().MaxDepth(2);
+                                                     CreateMap<SourceC, DestC>().MaxDepth(2);
+                                                 }
+                                             }
+                                         }
+                                         """;
+
+        // Index 0 MaxDepth, index 1 Ignore graph edge BReference (not a dest self-ref).
+        await CodeFixVerifier<AM022_InfiniteRecursionAnalyzer, AM022_InfiniteRecursionCodeFixProvider>
+            .VerifyFixAsync(
+                testCode,
+                new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule)
+                    .WithLocation(46, 13)
+                    .WithArguments("SourceA", "DestA"),
+                expectedFixedCode,
+                1);
+    }
+
+    [Fact]
+    public async Task AM022_ShouldIgnoreAllGraphEdges_WhenSelfRefAndMultiTypeCycleBothPresent()
+    {
+        // DestA has Parent: DestA (self-ref) and BReference: DestB (multi-type edge).
+        // Self-ref-only discovery would Ignore Parent alone and leave the B↔A cycle live.
+        // Graph-aware discovery offers Ignore-all of both cycle-breaking edges.
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class SourceA
+                                    {
+                                        public string Name { get; set; }
+                                        public SourceA Parent { get; set; }
+                                        public SourceB BReference { get; set; }
+                                    }
+
+                                    public class SourceB
+                                    {
+                                        public string Data { get; set; }
+                                        public SourceA AReference { get; set; }
+                                    }
+
+                                    public class DestA
+                                    {
+                                        public string Name { get; set; }
+                                        public DestA Parent { get; set; }
+                                        public DestB BReference { get; set; }
+                                    }
+
+                                    public class DestB
+                                    {
+                                        public string Data { get; set; }
+                                        public DestA AReference { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<SourceA, DestA>();
+                                            CreateMap<SourceB, DestB>().MaxDepth(2);
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string expectedFixedCode = """
+                                         using AutoMapper;
+
+                                         namespace TestNamespace
+                                         {
+                                             public class SourceA
+                                             {
+                                                 public string Name { get; set; }
+                                                 public SourceA Parent { get; set; }
+                                                 public SourceB BReference { get; set; }
+                                             }
+
+                                             public class SourceB
+                                             {
+                                                 public string Data { get; set; }
+                                                 public SourceA AReference { get; set; }
+                                             }
+
+                                             public class DestA
+                                             {
+                                                 public string Name { get; set; }
+                                                 public DestA Parent { get; set; }
+                                                 public DestB BReference { get; set; }
+                                             }
+
+                                             public class DestB
+                                             {
+                                                 public string Data { get; set; }
+                                                 public DestA AReference { get; set; }
+                                             }
+
+                                             public class TestProfile : Profile
+                                             {
+                                                 public TestProfile()
+                                                 {
+                                                     CreateMap<SourceA, DestA>().ForMember(dest => dest.BReference, opt => opt.Ignore()).ForMember(dest => dest.Parent, opt => opt.Ignore());
+                                                     CreateMap<SourceB, DestB>().MaxDepth(2);
+                                                 }
+                                             }
+                                         }
+                                         """;
+
+        // Index 0 MaxDepth; index 1 Ignore-all graph edges (BReference, Parent — ordinal order).
+        await CodeFixVerifier<AM022_InfiniteRecursionAnalyzer, AM022_InfiniteRecursionCodeFixProvider>
+            .VerifyFixAsync(
+                testCode,
+                new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.SelfReferencingTypeRule)
+                    .WithLocation(35, 13)
+                    .WithArguments("SourceA", "DestA"),
+                expectedFixedCode,
+                1);
+    }
+
+    [Fact]
     public async Task AM022_ShouldHandleReverseMapWithRecursion()
     {
         const string testCode = """


### PR DESCRIPTION
## Summary
- AM022 Ignore lightbulb now uses analyzer graph edges (`FindRecursiveDestinationProperties`), not only destination self-refs
- Multi-type cycles (A→B→C→A) get Ignore on the cycle edge; self-ref+multi-type gets Ignore-all of recursive edges
- MaxDepth scaffold remains best-first; package **2.30.63**

## Impact
Meaningful fixer completeness: multi-type recursion diagnostics no longer MaxDepth-only. Catalog Scaffold trust unchanged (manual review titles).

## Validation
- Full suite net10.0: **1384** passed
- Codex: meaningful improvement; P2 self-ref early-return fixed with mixed-case regression

## Release
Tag `v2.30.63` after merge.