### PR TITLE
fix: AM004/AM006 same-document sibling recompute (2.30.65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+## [2.30.65] - 2026-07-08
+
+AM004/AM006 same-document sibling recompute for aggregate code actions.
+
+### Changed
+
+- **AM004 / AM006**: Map-all, DoNotValidate-all, and Ignore-all recompute live unmapped siblings from a single property-token caret (AM011-style), so same-document lightbulbs no longer require multi-diagnostic pile-up.
+- **AM006**: shared `GetUnmappedDestinationProperties` with the analyzer for ownership-accurate recompute.
+
+### Validation
+
+- Full suite on `net10.0`: **1390** passed.
+
 ## [2.30.64] - 2026-07-08
 
 AM001 property-token diagnostic placement with aggregate-preserving sibling recompute.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet Version](https://img.shields.io/nuget/v/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=NuGet)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=Downloads)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/georgepwall1991/automapper-analyser/ci.yml?style=flat-square&logo=github&label=Build)](https://github.com/georgepwall1991/automapper-analyser/actions)
-[![Tests](https://img.shields.io/badge/Tests-1386%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
+[![Tests](https://img.shields.io/badge/Tests-1390%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
 [![.NET](https://img.shields.io/badge/.NET-4.8+%20%7C%206.0+%20%7C%208.0+%20%7C%209.0+%20%7C%2010.0+-512BD4?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 [![Coverage](https://img.shields.io/codecov/c/github/georgepwall1991/automapper-analyser?style=flat-square&logo=codecov&label=Coverage)](https://codecov.io/gh/georgepwall1991/automapper-analyser)
@@ -14,14 +14,14 @@ prevention*
 
 ---
 
-## 🎉 Latest Release: v2.30.64
+## 🎉 Latest Release: v2.30.65
 
-**AM001 property-token placement**
+**AM004/AM006 same-document sibling recompute**
 
 ✅ **Highlights**
 
-- **AM001**: type-mismatch diagnostics land on destination property tokens.
-- Convert-all / Ignore-all still work via sibling recompute from one caret.
+- **AM004 / AM006**: aggregates from a single property-token caret.
+- Live unmapped-set recompute matches analyzer ownership.
 
 🧪 **Validation**
 
@@ -29,6 +29,7 @@ prevention*
 
 ### Recent Releases
 
+- **v2.30.65**: AM004/AM006 same-document sibling recompute for aggregates.
 - **v2.30.64**: AM001 property-token diagnostic placement + aggregate sibling recompute.
 - **v2.30.63**: AM022 graph-aware Ignore for multi-type cycles.
 - **v2.30.62**: Split AM031 performance concepts into AM031 + AM034–AM038.
@@ -229,7 +230,7 @@ Install-Package AutoMapperAnalyzer.Analyzers
 ### Project File (For CI/CD)
 
 ```xml
-<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.64">
+<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.65">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 </PackageReference>

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -6,7 +6,7 @@ This is a deliberately harsh health audit for the **21** implemented AutoMapper 
 
 Every implemented rule currently has an analyzer and a code fix provider. Scores are 1-5, where `5` means reference-quality and hard to improve, `3` means usable but meaningfully incomplete, and `1` means unreliable or underbuilt.
 
-**Ship status:** production-acceptable. **2.30.64** AM001 property-token placement; **2.30.63** AM022 graph-aware Ignore; **2.30.62** AM031 split multi-concept ID into AM031 + AM034–AM038. Remaining highest residual is **AM022** (FP/Fix min 3). Full suite green; catalog/snapshots current.
+**Ship status:** production-acceptable. **2.30.65** AM004/AM006 sibling recompute; **2.30.64** AM001 property tokens; **2.30.63** AM022; **2.30.62** AM031 split multi-concept ID into AM031 + AM034–AM038. Remaining highest residual is **AM022** (FP/Fix min 3). Full suite green; catalog/snapshots current.
 
 ## Rubric
 
@@ -36,9 +36,9 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | AM001 | Property type mismatch | Type Safety | Error | 4 | 4 | 5 | 5 | 4 | 5 | Low | Direction-preserving ReverseMap keys; collection-only generic deferral; fixer peels nullables, invariant-culture Parse/ToString, keywords, DateTime/Uri/bool/Guid. **Fix Strategy 5**: Convert-all/Ignore-all + nested Fix individual. **2.30.64**: destination property-token placement + MappingInvocation metadata + sibling recompute for aggregates. |
 | AM002 | Nullable compatibility issue | Type Safety | Error/Info | 4 | 4 | 4 | 5 | 4 | 5 | Low | Descriptor-accurate docs now call out the Error/Info split, reverse-map nullable-to-non-nullable losses report and fix even when forward-side nullability policy is configured before `ReverseMap()`, pass-through and different-member nullable `MapFrom` bodies no longer hide nullable-to-non-nullable errors even when the same-name source member is non-nullable, diagnostics name the actual nullable source member for explicit different-source mappings, constructed generic source/destination labels such as `Source<T>` and `Destination<T>` are preserved, null-forgiving-only generic `MapFrom` bodies now report instead of treating compiler suppression as runtime null handling, semantic string literal/`nameof(...)`/const destination-member selectors and typed-lambda safe mappings are recognized as explicit nullability configuration, helper methods inside member options no longer masquerade as AutoMapper null handlers or mapping configuration, unsafe `NullSubstitute` values still report while assignable fallback values and typed value-type defaults are respected, unguarded nullable receiver dereferences inside `MapFrom` still report even when the final mapped value has a different type, while guarded dereferences and nullable value `GetValueOrDefault()` stay quiet, member-level converter/resolver ownership is respected including generic member-resolver `MapFrom<TResolver, TSourceMember>(...)` forms while generic expression `MapFrom<TSourceMember>(...)` overloads remain analyzable, top-level `ForPath` including typed-lambda paths respects null handling while child-only `ForPath` does not suppress parent nullability, repeated destination-member configuration uses the later effective mapping, the fixer preserves existing member options/source expressions and emits fully qualified framework defaults or `default!` for generic/reference fallback defaults when adding defaults without appending behind `Condition`/`PreCondition`, and catalog trust now marks the Info descriptor as analyzer-only. Remaining opportunities are advanced generic/nullability-flow semantics. |
 | AM003 | Collection type incompatibility | Type Safety | Error | 4 | 4 | 4 | 5 | 4 | 4 | Low | Shared container-incompatibility predicate with AM021 (HashSet/Queue/Stack/SortedSet/LinkedList/Immutable*/FrozenSet). Combined container+element mismatches report AM003 only; CreateRange fixes still convert elements when a named conversion exists. Sample isolates same-element List→HashSet. Custom-collection edge cases remain. |
-| AM004 | Source property has no corresponding destination property | Data Integrity | Warning | 4 | 4 | 4 | 5 | 5 | 5 | Low | Strong source-loss guardrail with unique-best fuzzy, reverse-map, and property-token placement. Aggregate Map-all/DoNotValidate-all still primarily surfaces for metadata pile-up / multi-diagnostic context (not same-document single-property lightbulbs). Catalog `Scaffold` trust remains accurate. |
+| AM004 | Source property has no corresponding destination property | Data Integrity | Warning | 4 | 4 | 5 | 5 | 5 | 5 | Low | Unique-best fuzzy, reverse-map, property-token placement. **Fix Strategy 5 (2.30.65)**: same-document sibling recompute offers Map-all/DoNotValidate-all from one property-token caret. Catalog Scaffold remains accurate. |
 | AM005 | Property names differ only in casing | Data Integrity | Warning | 4 | 4 | 4 | 4 | 4 | 3 | Low | Focused and reasonably conservative with explicit mapping including direct string literal/`nameof(...)`/const destination-member forms and typed-lambda selectors including typed top-level `ForPath`, semantic string/`nameof(...)` source-member ignores, custom construction/conversion suppression, reverse-map, source-property diagnostic placement including positional-record source parameters, metadata-backed fixer routing from property-token diagnostics, executable fixer tests, and rule-prefixed code-action equivalence keys; rule docs now match shipped Warning severity/category metadata and the recommended warning configuration. |
-| AM006 | Destination property is not mapped | Data Integrity | Info | 4 | 4 | 4 | 4 | 4 | 4 | Low | Solid non-required counterpart to AM011; aggregate Map-all/Ignore-all + nested submenu documented. Same metadata-pile-up aggregate constraint as AM004 for same-document property-token lightbulbs. |
+| AM006 | Destination property is not mapped | Data Integrity | Info | 4 | 4 | 5 | 5 | 4 | 4 | Low | Non-required counterpart to AM011. **Fix Strategy 5 (2.30.65)**: same-document sibling recompute for Map-all/Ignore-all from one property-token caret. Shared unmapped-destination helper with analyzer. |
 | AM011 | Required destination property is not mapped | Data Integrity | Error | 4 | 5 | 4 | 5 | 5 | 5 | Low | Important runtime-failure guardrail; per-property fuzzy now resolves ReverseMap types (same as aggregate). Fix Strategy 4: Map-all only when every property has unique fuzzy; mixed/default bulk uses honest Scaffold-all + (manual review); Ignore-all labeled manual review; stale diagnostics withhold. Residual: primary single-property path still scaffolds defaults. |
 | AM020 | Nested object mapping configuration missing | Complex Mappings | Warning | 4 | 4 | 4 | 5 | 5 | 5 | Low | Reference analyzer; fixer now shares public+internal property discovery with the analyzer (internal nested CreateMap fix covered). Catalog trust is `LikelyRewrite` (constructor-body insertion remains a structural limit). |
 | AM021 | Collection element type incompatibility | Complex Mappings | Warning | 4 | 4 | 4 | 5 | 4 | 4 | Low | Defers fully when AM003 owns container incompatibility (shared helper). Same-container element mismatches, dictionary axes, reverse gaps, and implicit element conversions remain AM021. List simple Select rewrites now refuse non-compiling Parse destinations (string-source gate matches dictionaries). |
@@ -71,7 +71,7 @@ Use this table as the hardening queue. Ranking = **Importance × (5 − min(Anal
 
 | Rank | Rule | Signal | Residual (evidence-backed) | Likely score move if closed |
 | --- | --- | --- | --- | --- |
-| 1 | **AM022** | gap=4, min=3 (FP) | Graph-aware Ignore shipped 2.30.63 (Fix 4). Residual: intentional circular DTO false positives / graph heuristics (FP=3). | FP 3→4 needs better intentional-cycle suppressions |
+| 1 | **AM022** | gap=4, min=3 (FP) | Graph-aware Ignore shipped 2.30.63. Residual: intentional circular DTO FP (FP=3). | FP 3→4 needs intentional-cycle suppressions |
 | 2 | **AM001** | gap=4, min=4 | Property-token placement shipped 2.30.64. Residual: advanced conversion modelling only with user repros. | — |
 | 3 | **AM004 / AM006** | gap=5/4 | Aggregate Map-all / DoNotValidate-all / Ignore-all need multi-diagnostic **group** context; same-document single-property lightbulbs do not recompute siblings the way AM011 does. Catalog Scaffold remains correct. | Fix 4→5 if same-document sibling recompute matches AM011 without inventing mappings |
 | 4 | **AM031 / AM034–AM038** | Fix=3 | Shared ForPath analyzer-only + Scaffold policy after ID split. Further smell breadth is diminishing returns. | Fix 3→4 only with ForPath-safe rewrites |
@@ -84,9 +84,9 @@ Use this table as the hardening queue. Ranking = **Importance × (5 − min(Anal
 
 **Recommended next hardening batch:**
 
-1. **AM004/AM006 same-document sibling recompute**
-2. **AM022 intentional-cycle FP**
-3. **AM032 destination-aware null fix**
+1. **AM022 intentional-cycle FP**
+2. **AM032 destination-aware null fix**
+3. **AM031/AM034–AM038 ForPath-safe rewrites** (Fix still 3)
 
 Do **not** open advanced AM001/AM002 conversion/nullability modelling without a filed false-positive/false-negative repro.
 
@@ -108,7 +108,7 @@ Active queue (also summarized in Working Base). Prefer one focus per hardening b
 
 - _AM031 ID split — resolved in 2.30.62._ AM031 multi-enum; AM034–AM038 independent IDs.
 - _AM022 graph-aware Ignore — resolved in 2.30.63._ Multi-type cycle edges offered for Ignore. Residual: intentional circular-DTO FP (FP=3).
-- **AM004 / AM006 same-document sibling recompute.** Match AM011's ability to offer honest aggregates from a single property-token diagnostic without inventing mappings.
+- _AM004 / AM006 same-document sibling recompute — resolved in 2.30.65._
 - **AM001 property-token diagnostic placement.** Still reports on `CreateMap` invocation span; data-integrity rules already land on property tokens.
 - **AM032 destination-aware null fixes.** Emit stays classic net48 `if-throw`; not destination-nullability-aware. Analyzer ThrowIfNull* recognition is already strong.
 
@@ -148,6 +148,12 @@ Still open (do not start without a repro or explicit product decision):
 - **AM022 / AM031 dataflow-grade heuristics.** High effort, diminishing returns until a concrete false-positive pattern is filed (prefer P2 ID-split / graph-Ignore first).
 - **AM020 constructor-body CreateMap insert.** Structural host limit; catalog `LikelyRewrite` already honest.
 
+
+## Reanalysis Changelog (2026-07-08 → 2.30.65 AM004/AM006 sibling recompute)
+
+| Rules | Finding | Change | Score impact |
+| --- | --- | --- | --- |
+| AM004/AM006 | Aggregates required multi-diag pile-up for same-document property tokens | AM011-style live unmapped-set recompute from one caret | Fix Strategy 4→5 |
 
 ## Reanalysis Changelog (2026-07-08 → 2.30.64 AM001 property-token placement)
 
@@ -207,7 +213,7 @@ Full rule+fixer reanalysis driven by four parallel subagent audits (Type Safety,
 | AM030 | ~5 direct tests in shared 146-test bucket. | Tests 4→3; tightened Notes. | AM030 Tests −1 |
 | AM032 | Null-flow heuristic + throw-only fix policy risk. | False Positives 4→3; tightened Notes. | AM032 False Positives −1 |
 
-## Fixer Trust Summary (v2.30.64)
+## Fixer Trust Summary (v2.30.65)
 
 | Rule | Fixable? | Catalog trust | Notes |
 | --- | --- | --- | --- |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -725,7 +725,7 @@ dotnet pack --configuration Release
 
 # Test package locally
 cd test-install/NetCoreTest
-dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.64-local
+dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.65-local
 ```
 
 ---
@@ -909,4 +909,4 @@ dotnet build
 
 **Last Updated**: 2026-05-14
 **Maintainer**: George Wall
-**Version**: 2.30.64
+**Version**: 2.30.65

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -112,8 +112,8 @@ The AutoMapper Roslyn Analyzer project uses GitHub Actions for continuous integr
 ### Package Versioning
 
 - **Format**: Major.Minor.Patch (SemVer)
-- **Current**: 2.30.64
-- **Pre-release**: 2.30.64-preview, 2.30.64-beta
+- **Current**: 2.30.65
+- **Pre-release**: 2.30.65-preview, 2.30.65-beta
 
 ## 🔧 Configuration
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -43,7 +43,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.64">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.65">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -67,7 +67,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.64">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.65">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -86,7 +86,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="14.0.0" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.64">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.65">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -218,7 +218,7 @@ public class Destination
 
 2. **Verify Package Installation**
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.64">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.65">
      <PrivateAssets>all</PrivateAssets>
      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -280,4 +280,4 @@ This guide ensures smooth installation and usage across all supported .NET frame
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.64
+**Version**: 2.30.65

--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -1599,7 +1599,7 @@ using System.Diagnostics.CodeAnalysis;
 
 1. **Check package reference**:
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.64">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.65">
        <PrivateAssets>all</PrivateAssets>
        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -1638,5 +1638,5 @@ If analyzer slows down builds:
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.64
+**Version**: 2.30.65
 **Maintainer**: George Wall

--- a/docs/RULE_CATALOG.md
+++ b/docs/RULE_CATALOG.md
@@ -2,7 +2,7 @@
 
 This file is generated from `RuleCatalog`.
 
-Package version: `2.30.64`
+Package version: `2.30.65`
 
 | Rule ID | Descriptor Title | Severity | Category | Analyzer | Code Fix | Trust | Sample | Docs |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,3 +1,15 @@
+## Release 2.30.65
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
+### Removed Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
 ## Release 2.30.64
 
 ### New Rules

--- a/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
+++ b/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
@@ -17,7 +17,7 @@
         <!-- Fallback for local builds: 2.0.YYYYMMDD-local -->
         <MajorVersion>2</MajorVersion>
         <MinorVersion>30</MinorVersion>
-        <PatchVersion>64</PatchVersion>
+        <PatchVersion>65</PatchVersion>
         <BuildNumber Condition="'$(BuildNumber)' == ''"
         >$([System.DateTime]::Now.ToString('yyyyMMdd'))
         </BuildNumber
@@ -32,9 +32,9 @@
         <RepositoryUrl>https://github.com/georgepwall1991/automapper-analyser</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-                <PackageReleaseNotes>Version 2.30.64 - AM001 property-token diagnostic placement
-- Type-mismatch diagnostics land on destination property identifiers
-- MappingInvocation metadata + sibling recompute keep Convert-all/Ignore-all aggregates working
+                <PackageReleaseNotes>Version 2.30.65 - AM004/AM006 same-document sibling recompute
+- Map-all / DoNotValidate-all / Ignore-all from a single property-token caret
+- Recompute uses live analyzer unmapped sets (AM011-style)
 </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>

--- a/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM004_MissingDestinationPropertyCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM004_MissingDestinationPropertyCodeFixProvider.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
 
 namespace AutoMapperAnalyzer.Analyzers.DataIntegrity;
 
@@ -43,45 +44,149 @@ public class AM004_MissingDestinationPropertyCodeFixProvider : AutoMapperCodeFix
     }
 
     /// <summary>
-    ///     Registers code fixes for the specified context.
+    ///     Registers code fixes. Recomputes all unmapped source properties for the CreateMap so
+    ///     Map-all / DoNotValidate-all work from a single property-token caret (same-document).
     /// </summary>
-    /// <param name="context">The code fix context.</param>
-    /// <returns>A task representing the asynchronous operation.</returns>
-    public override Task RegisterCodeFixesAsync(CodeFixContext context)
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        return RegisterGroupedPerPropertyFixesAsync(
-            context,
-            ["PropertyName", "PropertyType", "SourceTypeName", "DestinationTypeName", "IsReverseMap"],
-            "Fix individual source property…",
-            (operationContext, group, _, properties) =>
-                BuildPerPropertyActions(context, operationContext, group, properties["PropertyName"]),
-            (operationContext, group) => BuildAggregateActions(context, operationContext, group));
+        CodeFixOperationContext? operationContext = await GetOperationContextAsync(context);
+        if (operationContext == null)
+        {
+            return;
+        }
+
+        var processedInvocations = new HashSet<TextSpan>();
+        foreach (Diagnostic diagnostic in context.Diagnostics)
+        {
+            Dictionary<string, string>? properties = TryGetDiagnosticProperties(
+                diagnostic,
+                "PropertyName",
+                "PropertyType",
+                "SourceTypeName",
+                "DestinationTypeName",
+                "IsReverseMap");
+            if (properties == null)
+            {
+                continue;
+            }
+
+            InvocationExpressionSyntax? invocation =
+                GetCreateMapInvocation(operationContext.Root, diagnostic, properties);
+            if (invocation == null ||
+                !TryResolveMappingContext(invocation, operationContext.SemanticModel, out MappingAnalysisContext? mappingContext))
+            {
+                continue;
+            }
+
+            List<IPropertySymbol> unmapped = FindUnmappedSourceProperties(
+                mappingContext!,
+                operationContext.SemanticModel);
+
+            IPropertySymbol? diagnosticProperty = unmapped.FirstOrDefault(
+                p => string.Equals(p.Name, properties["PropertyName"], StringComparison.Ordinal));
+            if (diagnosticProperty == null)
+            {
+                // Stale diagnostic — withhold rather than inventing a second suppress action.
+                continue;
+            }
+
+            if (unmapped.Count < 2)
+            {
+                (string title, ImmutableArray<CodeAction> actions)? built =
+                    BuildPerPropertyActions(context, operationContext, mappingContext!, diagnosticProperty.Name);
+                if (built == null)
+                {
+                    continue;
+                }
+
+                foreach (CodeAction action in built.Value.actions)
+                {
+                    context.RegisterCodeFix(action, diagnostic);
+                }
+
+                continue;
+            }
+
+            // Multi-property map: register aggregates once per CreateMap, even when several
+            // property-token diagnostics share the same IDE caret context.
+            if (!processedInvocations.Add(invocation.Span))
+            {
+                continue;
+            }
+
+            foreach (CodeAction aggregate in BuildAggregateActions(
+                         context, operationContext, mappingContext!, unmapped))
+            {
+                context.RegisterCodeFix(aggregate, diagnostic);
+            }
+
+            var perPropertySubMenus = new List<CodeAction>();
+            foreach (IPropertySymbol sourceProperty in unmapped)
+            {
+                (string title, ImmutableArray<CodeAction> actions)? built =
+                    BuildPerPropertyActions(context, operationContext, mappingContext!, sourceProperty.Name);
+                if (built == null || built.Value.actions.IsDefaultOrEmpty)
+                {
+                    continue;
+                }
+
+                perPropertySubMenus.Add(
+                    CodeAction.Create(built.Value.title, built.Value.actions, isInlinable: false));
+            }
+
+            if (perPropertySubMenus.Count > 0)
+            {
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        "Fix individual source property…",
+                        perPropertySubMenus.ToImmutableArray(),
+                        isInlinable: false),
+                    diagnostic);
+            }
+        }
+    }
+
+    private static List<IPropertySymbol> FindUnmappedSourceProperties(
+        MappingAnalysisContext mappingContext,
+        SemanticModel semanticModel)
+    {
+        if (MappingChainAnalysisHelper.HasCustomConstructionOrConversion(
+                mappingContext.MappingInvocation,
+                semanticModel,
+                mappingContext.StopAtReverseMapBoundary))
+        {
+            return [];
+        }
+
+        return MappingChainAnalysisHelper.GetUnmappedSourceProperties(
+            mappingContext.MappingInvocation,
+            mappingContext.SourceType,
+            mappingContext.DestinationType,
+            semanticModel,
+            mappingContext.StopAtReverseMapBoundary);
     }
 
     private (string SubMenuTitle, ImmutableArray<CodeAction> Actions)? BuildPerPropertyActions(
         CodeFixContext context,
         CodeFixOperationContext operationContext,
-        DiagnosticInvocationGroup group,
+        MappingAnalysisContext mappingContext,
         string propertyName)
     {
-        InvocationExpressionSyntax invocation = group.Invocation;
+        InvocationExpressionSyntax invocation = mappingContext.MappingInvocation;
         SyntaxNode root = operationContext.Root;
         var actions = ImmutableArray.CreateBuilder<CodeAction>();
 
-        if (TryResolveMappingContext(invocation, operationContext.SemanticModel, out MappingAnalysisContext? mappingContext))
+        IPropertySymbol? bestMatch = FindFuzzyDestinationMatch(mappingContext, propertyName);
+        if (bestMatch != null)
         {
-            IPropertySymbol? bestMatch = FindFuzzyDestinationMatch(mappingContext!, propertyName);
-            if (bestMatch != null)
-            {
-                string destName = bestMatch.Name;
-                string sourceExpression = $"src.{CodeFixSyntaxHelper.EscapeIdentifier(propertyName)}";
-                actions.Add(CodeAction.Create(
-                    $"Map '{propertyName}' to similar property '{destName}'",
-                    _ => ReplaceNodeAsync(
-                        context.Document, root, invocation,
-                        CodeFixSyntaxHelper.CreateForMemberWithMapFrom(invocation, destName, sourceExpression)),
-                    $"AM004_FuzzyMatch_{propertyName}_{destName}"));
-            }
+            string destName = bestMatch.Name;
+            string sourceExpression = $"src.{CodeFixSyntaxHelper.EscapeIdentifier(propertyName)}";
+            actions.Add(CodeAction.Create(
+                $"Map '{propertyName}' to similar property '{destName}'",
+                _ => ReplaceNodeAsync(
+                    context.Document, root, invocation,
+                    CodeFixSyntaxHelper.CreateForMemberWithMapFrom(invocation, destName, sourceExpression)),
+                $"AM004_FuzzyMatch_{propertyName}_{destName}"));
         }
 
         actions.Add(CodeAction.Create(
@@ -97,30 +202,19 @@ public class AM004_MissingDestinationPropertyCodeFixProvider : AutoMapperCodeFix
     private ImmutableArray<CodeAction> BuildAggregateActions(
         CodeFixContext context,
         CodeFixOperationContext operationContext,
-        DiagnosticInvocationGroup group)
+        MappingAnalysisContext mappingContext,
+        List<IPropertySymbol> orderedSourceProperties)
     {
-        if (!TryResolveMappingContext(group.Invocation, operationContext.SemanticModel, out MappingAnalysisContext? mappingContext))
-        {
-            return ImmutableArray<CodeAction>.Empty;
-        }
-
-        var flaggedNames = new HashSet<string>(group.PropertyNames);
-        List<IPropertySymbol> orderedSourceProperties = AutoMapperAnalysisHelpers
-            .GetMappableProperties(mappingContext!.SourceType, requireSetter: false)
-            .Where(p => flaggedNames.Contains(p.Name))
-            .ToList();
         if (orderedSourceProperties.Count < 2)
         {
             return ImmutableArray<CodeAction>.Empty;
         }
 
         int count = orderedSourceProperties.Count;
-        InvocationExpressionSyntax invocation = group.Invocation;
+        InvocationExpressionSyntax invocation = mappingContext.MappingInvocation;
         SyntaxNode root = operationContext.Root;
         var actions = ImmutableArray.CreateBuilder<CodeAction>();
 
-        // "Map all" only when every flagged source property has a unique-best fuzzy destination match.
-        // Ties (same Levenshtein distance) withhold the action so aggregate rewrites never invent a mapping.
         List<IPropertySymbol> destProperties = AutoMapperAnalysisHelpers
             .GetMappableProperties(mappingContext.DestinationType, requireSetter: true)
             .ToList();
@@ -166,8 +260,6 @@ public class AM004_MissingDestinationPropertyCodeFixProvider : AutoMapperCodeFix
 
         var destProperties = AutoMapperAnalysisHelpers.GetMappableProperties(
             mappingContext.DestinationType, requireSetter: true);
-        // Require a unique lowest-distance destination (same gate as AM006/AM011). First-match
-        // ordering is order-dependent and can map a source property to the wrong destination.
         return FuzzyMatchHelper.FindUniqueBestFuzzyMatch(
             propertyName, destProperties, sourcePropertySymbol.Type);
     }
@@ -179,7 +271,6 @@ public class AM004_MissingDestinationPropertyCodeFixProvider : AutoMapperCodeFix
     {
         mappingContext = null;
 
-        // Reverse-map diagnostic location
         if (MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(invocation, semanticModel, "ReverseMap"))
         {
             InvocationExpressionSyntax? createMapInvocation = FindForwardCreateMapInvocation(invocation, semanticModel);
@@ -202,7 +293,6 @@ public class AM004_MissingDestinationPropertyCodeFixProvider : AutoMapperCodeFix
             return true;
         }
 
-        // Forward-map diagnostic location
         if (MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(invocation, semanticModel, "CreateMap"))
         {
             var forwardTypes = MappingChainAnalysisHelper.GetCreateMapTypeArguments(invocation, semanticModel);
@@ -226,7 +316,6 @@ public class AM004_MissingDestinationPropertyCodeFixProvider : AutoMapperCodeFix
         InvocationExpressionSyntax invocation,
         SemanticModel semanticModel)
     {
-        // Walk up the fluent chain to find CreateMap (ancestor direction)
         var current = invocation;
         while (current != null)
         {
@@ -235,7 +324,6 @@ public class AM004_MissingDestinationPropertyCodeFixProvider : AutoMapperCodeFix
             current = (current.Expression as MemberAccessExpressionSyntax)?.Expression as InvocationExpressionSyntax;
         }
 
-        // Also check descendants (for cases where invocation IS the CreateMap chain)
         return invocation.DescendantNodesAndSelf()
             .OfType<InvocationExpressionSyntax>()
             .FirstOrDefault(node => MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(node, semanticModel, "CreateMap"));

--- a/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM006_UnmappedDestinationPropertyAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM006_UnmappedDestinationPropertyAnalyzer.cs
@@ -86,69 +86,18 @@ public class AM006_UnmappedDestinationPropertyAnalyzer : DiagnosticAnalyzer
         bool isReverseMap,
         InvocationExpressionSyntax? reverseMapInvocation = null)
     {
-        List<IPropertySymbol> sourcePropertiesList =
-            AutoMapperAnalysisHelpers.GetMappableProperties(sourceType, requireSetter: false).ToList();
-        HashSet<string> sourcePropertyNames = new HashSet<string>(sourcePropertiesList.Select(p => p.Name), StringComparer.OrdinalIgnoreCase);
-        IEnumerable<IPropertySymbol> destinationProperties =
-            AutoMapperAnalysisHelpers.GetMappableProperties(destinationType, requireGetter: false, requireSetter: true);
         InvocationExpressionSyntax mappingInvocation =
             isReverseMap && reverseMapInvocation != null ? reverseMapInvocation : invocation;
 
-        if (HasCustomConversion(
-                mappingInvocation,
-                context.SemanticModel,
-                stopAtReverseMapBoundary: !isReverseMap))
+        List<IPropertySymbol> unmapped = GetUnmappedDestinationProperties(
+            mappingInvocation,
+            sourceType,
+            destinationType,
+            context.SemanticModel,
+            stopAtReverseMapBoundary: !isReverseMap);
+
+        foreach (IPropertySymbol destProperty in unmapped)
         {
-            return;
-        }
-
-        foreach (IPropertySymbol destProperty in destinationProperties)
-        {
-            // Required members are enforced by AM011 (error). Skip here to avoid duplicate,
-            // contradictory diagnostics for the same property.
-            if (destProperty.IsRequired)
-            {
-                continue;
-            }
-
-            // 1. Check for direct mapping (same name)
-            if (sourcePropertyNames.Contains(destProperty.Name))
-            {
-                continue;
-            }
-
-            // 2. Check for flattening
-            // If Dest is "CustomerName" and Source has "Customer" (complex), and "Customer" has "Name".
-            if (sourcePropertiesList.Any(srcProp => IsFlatteningMatch(srcProp, destProperty)))
-            {
-                continue;
-            }
-
-            // 3. Check for explicit configuration (ForMember/ForPath)
-            if (IsPropertyConfiguredWithForMember(
-                    mappingInvocation,
-                    destProperty.Name,
-                    context.SemanticModel,
-                    stopAtReverseMapBoundary: !isReverseMap))
-            {
-                continue;
-            }
-
-            if (IsDestinationPropertyInitializedByConstructUsing(
-                    mappingInvocation,
-                    destProperty.Name,
-                    context.SemanticModel,
-                    stopAtReverseMapBoundary: !isReverseMap))
-            {
-                continue;
-            }
-
-            // 4. Check for Ignore? 
-            // IsPropertyConfiguredWithForMember checks if ForMember exists. 
-            // If ForMember exists (even if Ignore), it is "mapped" (or explicitly handled).
-            // So check 3 covers Ignore.
-
-            // Report diagnostic
             ImmutableDictionary<string, string?>.Builder properties =
                 ImmutableDictionary.CreateBuilder<string, string?>();
             properties.Add("PropertyName", destProperty.Name);
@@ -167,6 +116,70 @@ public class AM006_UnmappedDestinationPropertyAnalyzer : DiagnosticAnalyzer
 
             context.ReportDiagnostic(diagnostic);
         }
+    }
+
+    /// <summary>
+    ///     Live unmapped non-required destination properties for a mapping direction.
+    ///     Shared with the code fix so sibling recompute matches analyzer ownership.
+    /// </summary>
+    internal static List<IPropertySymbol> GetUnmappedDestinationProperties(
+        InvocationExpressionSyntax mappingInvocation,
+        ITypeSymbol sourceType,
+        ITypeSymbol destinationType,
+        SemanticModel semanticModel,
+        bool stopAtReverseMapBoundary)
+    {
+        if (HasCustomConversion(mappingInvocation, semanticModel, stopAtReverseMapBoundary))
+        {
+            return [];
+        }
+
+        List<IPropertySymbol> sourcePropertiesList =
+            AutoMapperAnalysisHelpers.GetMappableProperties(sourceType, requireSetter: false).ToList();
+        var sourcePropertyNames = new HashSet<string>(
+            sourcePropertiesList.Select(p => p.Name), StringComparer.OrdinalIgnoreCase);
+
+        var unmapped = new List<IPropertySymbol>();
+        foreach (IPropertySymbol destProperty in AutoMapperAnalysisHelpers.GetMappableProperties(
+                     destinationType, requireGetter: false, requireSetter: true))
+        {
+            if (destProperty.IsRequired)
+            {
+                continue;
+            }
+
+            if (sourcePropertyNames.Contains(destProperty.Name))
+            {
+                continue;
+            }
+
+            if (sourcePropertiesList.Any(srcProp => IsFlatteningMatch(srcProp, destProperty)))
+            {
+                continue;
+            }
+
+            if (IsPropertyConfiguredWithForMember(
+                    mappingInvocation,
+                    destProperty.Name,
+                    semanticModel,
+                    stopAtReverseMapBoundary))
+            {
+                continue;
+            }
+
+            if (IsDestinationPropertyInitializedByConstructUsing(
+                    mappingInvocation,
+                    destProperty.Name,
+                    semanticModel,
+                    stopAtReverseMapBoundary))
+            {
+                continue;
+            }
+
+            unmapped.Add(destProperty);
+        }
+
+        return unmapped;
     }
 
     private static bool HasCustomConversion(

--- a/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM006_UnmappedDestinationPropertyCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM006_UnmappedDestinationPropertyCodeFixProvider.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
 
 namespace AutoMapperAnalyzer.Analyzers.DataIntegrity;
 
@@ -22,28 +23,131 @@ public class AM006_UnmappedDestinationPropertyCodeFixProvider : AutoMapperCodeFi
     public override ImmutableArray<string> FixableDiagnosticIds => ["AM006"];
 
     /// <summary>
-    ///     Registers code fixes for the specified context.
+    ///     Registers code fixes. Recomputes all unmapped destination properties for the CreateMap so
+    ///     Map-all / Ignore-all work from a single property-token caret (same-document).
     /// </summary>
-    /// <param name="context">The code fix context.</param>
-    /// <returns>A task representing the asynchronous operation.</returns>
-    public override Task RegisterCodeFixesAsync(CodeFixContext context)
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        return RegisterGroupedPerPropertyFixesAsync(
-            context,
-            ["PropertyName", "PropertyType", "DestinationTypeName", "SourceTypeName"],
-            "Fix individual destination property…",
-            (operationContext, group, _, properties) =>
-                BuildPerPropertyActions(context, operationContext, group, properties["PropertyName"]),
-            (operationContext, group) => BuildAggregateActions(context, operationContext, group));
+        CodeFixOperationContext? operationContext = await GetOperationContextAsync(context);
+        if (operationContext == null)
+        {
+            return;
+        }
+
+        var processedInvocations = new HashSet<TextSpan>();
+        foreach (Diagnostic diagnostic in context.Diagnostics)
+        {
+            Dictionary<string, string>? properties = TryGetDiagnosticProperties(
+                diagnostic,
+                "PropertyName",
+                "PropertyType",
+                "DestinationTypeName",
+                "SourceTypeName");
+            if (properties == null)
+            {
+                continue;
+            }
+
+            InvocationExpressionSyntax? invocation =
+                GetCreateMapInvocation(operationContext.Root, diagnostic, properties);
+            if (invocation == null)
+            {
+                continue;
+            }
+
+            List<IPropertySymbol> unmapped = FindUnmappedDestinationProperties(
+                invocation,
+                operationContext.SemanticModel);
+
+            IPropertySymbol? diagnosticProperty = unmapped.FirstOrDefault(
+                p => string.Equals(p.Name, properties["PropertyName"], StringComparison.Ordinal));
+            if (diagnosticProperty == null)
+            {
+                continue;
+            }
+
+            if (unmapped.Count < 2)
+            {
+                (string title, ImmutableArray<CodeAction> actions)? built =
+                    BuildPerPropertyActions(context, operationContext, invocation, diagnosticProperty.Name);
+                if (built == null)
+                {
+                    continue;
+                }
+
+                foreach (CodeAction action in built.Value.actions)
+                {
+                    context.RegisterCodeFix(action, diagnostic);
+                }
+
+                continue;
+            }
+
+            if (!processedInvocations.Add(invocation.Span))
+            {
+                continue;
+            }
+
+            foreach (CodeAction aggregate in BuildAggregateActions(
+                         context, operationContext, invocation, unmapped))
+            {
+                context.RegisterCodeFix(aggregate, diagnostic);
+            }
+
+            var perPropertySubMenus = new List<CodeAction>();
+            foreach (IPropertySymbol destProperty in unmapped)
+            {
+                (string title, ImmutableArray<CodeAction> actions)? built =
+                    BuildPerPropertyActions(context, operationContext, invocation, destProperty.Name);
+                if (built == null || built.Value.actions.IsDefaultOrEmpty)
+                {
+                    continue;
+                }
+
+                perPropertySubMenus.Add(
+                    CodeAction.Create(built.Value.title, built.Value.actions, isInlinable: false));
+            }
+
+            if (perPropertySubMenus.Count > 0)
+            {
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        "Fix individual destination property…",
+                        perPropertySubMenus.ToImmutableArray(),
+                        isInlinable: false),
+                    diagnostic);
+            }
+        }
+    }
+
+    private static List<IPropertySymbol> FindUnmappedDestinationProperties(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel)
+    {
+        (ITypeSymbol? sourceType, ITypeSymbol? destinationType) =
+            ResolveCreateMapTypesWithReverse(invocation, semanticModel);
+        if (sourceType == null || destinationType == null)
+        {
+            return [];
+        }
+
+        bool isReverseMap = MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(
+            invocation, semanticModel, "ReverseMap");
+
+        return AM006_UnmappedDestinationPropertyAnalyzer.GetUnmappedDestinationProperties(
+            invocation,
+            sourceType,
+            destinationType,
+            semanticModel,
+            stopAtReverseMapBoundary: !isReverseMap);
     }
 
     private (string SubMenuTitle, ImmutableArray<CodeAction> Actions)? BuildPerPropertyActions(
         CodeFixContext context,
         CodeFixOperationContext operationContext,
-        DiagnosticInvocationGroup group,
+        InvocationExpressionSyntax invocation,
         string propertyName)
     {
-        InvocationExpressionSyntax invocation = group.Invocation;
         SyntaxNode root = operationContext.Root;
         var actions = ImmutableArray.CreateBuilder<CodeAction>();
 
@@ -73,34 +177,23 @@ public class AM006_UnmappedDestinationPropertyCodeFixProvider : AutoMapperCodeFi
     private ImmutableArray<CodeAction> BuildAggregateActions(
         CodeFixContext context,
         CodeFixOperationContext operationContext,
-        DiagnosticInvocationGroup group)
+        InvocationExpressionSyntax invocation,
+        List<IPropertySymbol> orderedProperties)
     {
-        // Reverse-aware: a ReverseMap() diagnostic resolves its (swapped) types from the forward CreateMap.
-        (ITypeSymbol? sourceType, ITypeSymbol? destType) =
-            ResolveCreateMapTypesWithReverse(group.Invocation, operationContext.SemanticModel);
-        if (destType == null)
-        {
-            return ImmutableArray<CodeAction>.Empty;
-        }
-
-        var flaggedNames = new HashSet<string>(group.PropertyNames);
-        List<IPropertySymbol> orderedProperties = AutoMapperAnalysisHelpers
-            .GetMappableProperties(destType, requireGetter: false, requireSetter: true)
-            .Where(p => flaggedNames.Contains(p.Name))
-            .ToList();
         if (orderedProperties.Count < 2)
         {
             return ImmutableArray<CodeAction>.Empty;
         }
 
+        (ITypeSymbol? sourceType, ITypeSymbol? _) =
+            ResolveCreateMapTypesWithReverse(invocation, operationContext.SemanticModel);
+
         int count = orderedProperties.Count;
-        InvocationExpressionSyntax invocation = group.Invocation;
         SyntaxNode root = operationContext.Root;
         var actions = ImmutableArray.CreateBuilder<CodeAction>();
 
-        // "Map all" only when every flagged property has a unique fuzzy source match, so the title is honest.
         List<IPropertySymbol> sourceProperties = sourceType == null
-            ? new List<IPropertySymbol>()
+            ? []
             : AutoMapperAnalysisHelpers.GetMappableProperties(sourceType, requireSetter: false).ToList();
         var matches = orderedProperties
             .Select(p => (Property: p,

--- a/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
@@ -130,7 +130,7 @@ public static class RuleCatalog
     /// <summary>
     ///     Current package version used by docs/package drift tests.
     /// </summary>
-    public const string CurrentPackageVersion = "2.30.64";
+    public const string CurrentPackageVersion = "2.30.65";
 
     /// <summary>
     ///     Implemented rules, grouped by public diagnostic ID.

--- a/tests/AutoMapperAnalyzer.Tests/DataIntegrity/AM004_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/DataIntegrity/AM004_CodeFixTests.cs
@@ -311,7 +311,7 @@ public class AM004_CodeFixTests
                                              {
                                                  public TestProfile()
                                                  {
-                                                     CreateMap<Source, Destination>().ForSourceMember(src => src.Extra2, opt => opt.DoNotValidate()).ForSourceMember(src => src.Extra1, opt => opt.DoNotValidate());
+                                                     CreateMap<Source, Destination>().ForSourceMember(src => src.Extra1, opt => opt.DoNotValidate()).ForSourceMember(src => src.Extra2, opt => opt.DoNotValidate());
                                                  }
                                              }
                                          }
@@ -332,7 +332,8 @@ public class AM004_CodeFixTests
                 testCode,
                 new[] { extra1Diagnostic, extra2Diagnostic },
                 expectedFixedCode,
-                2);
+                // Sibling recompute: DoNotValidate-all clears both property-token diagnostics in one iteration.
+                1);
     }
 
     [Fact]

--- a/tests/AutoMapperAnalyzer.Tests/DataIntegrity/AM004_SameDocumentSiblingAggregateTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/DataIntegrity/AM004_SameDocumentSiblingAggregateTests.cs
@@ -1,0 +1,151 @@
+using System.Collections.Immutable;
+using AutoMapperAnalyzer.Analyzers.DataIntegrity;
+using AutoMapperAnalyzer.Tests.Infrastructure;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+
+namespace AutoMapperAnalyzer.Tests.DataIntegrity;
+
+/// <summary>
+///     Same-document property-token AM004 diagnostics only put one diagnostic in the IDE
+///     CodeFixContext. Aggregates must recompute siblings (like AM011), not require multi-diag pile-up.
+/// </summary>
+public class AM004_SameDocumentSiblingAggregateTests
+{
+    private const string TwoUnmappedSource = """
+                                             using AutoMapper;
+
+                                             namespace TestNamespace
+                                             {
+                                                 public class Source
+                                                 {
+                                                     public string Name { get; set; }
+                                                     public string Unused1 { get; set; }
+                                                     public string Unused2 { get; set; }
+                                                 }
+
+                                                 public class Destination
+                                                 {
+                                                     public string Name { get; set; }
+                                                 }
+
+                                                 public class TestProfile : Profile
+                                                 {
+                                                     public TestProfile()
+                                                     {
+                                                         CreateMap<Source, Destination>();
+                                                     }
+                                                 }
+                                             }
+                                             """;
+
+    [Fact]
+    public async Task AM004_SinglePropertyTokenCaret_OffersDoNotValidateAll_ForSameDocumentSiblings()
+    {
+        Document document = CreateDocument(TwoUnmappedSource);
+        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(document);
+        Assert.Equal(2, diagnostics.Length);
+
+        // One property-token caret only — siblings must be recomputed.
+        IReadOnlyList<CodeFixActionInspector.ActionInfo> actions =
+            await CodeFixActionInspector.GetActionsAsync(
+                document,
+                new AM004_MissingDestinationPropertyCodeFixProvider(),
+                diagnostics[0]);
+
+        Assert.Contains(actions, a => a.EquivalenceKey == "AM004_DoNotValidateAll" && a.Depth == 0);
+        Assert.Contains(
+            actions,
+            a => a.Depth == 0 && a.HasChildren &&
+                 a.Title.Contains("individual", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(actions, a => a.IsNested && a.EquivalenceKey != null &&
+                                      a.EquivalenceKey.StartsWith("AM004_DoNotValidate_", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task AM004_DoNotValidateAll_FromSingleCaret_SuppressesEverySibling()
+    {
+        const string expectedFixedCode = """
+                                         using AutoMapper;
+
+                                         namespace TestNamespace
+                                         {
+                                             public class Source
+                                             {
+                                                 public string Name { get; set; }
+                                                 public string Unused1 { get; set; }
+                                                 public string Unused2 { get; set; }
+                                             }
+
+                                             public class Destination
+                                             {
+                                                 public string Name { get; set; }
+                                             }
+
+                                             public class TestProfile : Profile
+                                             {
+                                                 public TestProfile()
+                                                 {
+                                                     CreateMap<Source, Destination>().ForSourceMember(src => src.Unused1, opt => opt.DoNotValidate()).ForSourceMember(src => src.Unused2, opt => opt.DoNotValidate());
+                                                 }
+                                             }
+                                         }
+                                         """;
+
+        Document document = CreateDocument(TwoUnmappedSource);
+        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(document);
+        Assert.Equal(2, diagnostics.Length);
+
+        Document fixedDocument = await CodeFixActionInspector.ApplyActionByKeyAsync(
+            document,
+            new AM004_MissingDestinationPropertyCodeFixProvider(),
+            ImmutableArray.Create(diagnostics[0]),
+            "AM004_DoNotValidateAll");
+
+        string updated = (await fixedDocument.GetTextAsync()).ToString();
+        Assert.Equal(
+            Normalize(expectedFixedCode),
+            Normalize(updated));
+        Assert.Empty(await GetDiagnosticsAsync(fixedDocument));
+    }
+
+    private static string Normalize(string text) =>
+        text.Replace("\r\n", "\n", StringComparison.Ordinal).Trim();
+
+    private static Document CreateDocument(string source)
+    {
+        var workspace = new AdhocWorkspace();
+        ProjectId projectId = ProjectId.CreateNewId();
+        DocumentId documentId = DocumentId.CreateNewId(projectId);
+        Solution solution = workspace.CurrentSolution
+            .AddProject(projectId, "AM004Sibling", "AM004Sibling", LanguageNames.CSharp)
+            .WithProjectCompilationOptions(projectId, new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+            .WithProjectParseOptions(projectId, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+
+        string trusted = (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") ?? string.Empty;
+        foreach (string path in trusted.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(path))
+            {
+                solution = solution.AddMetadataReference(projectId, MetadataReference.CreateFromFile(path));
+            }
+        }
+
+        solution = solution
+            .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(AutoMapper.Profile).Assembly.Location))
+            .AddDocument(documentId, "Test0.cs", SourceText.From(source));
+        return solution.GetDocument(documentId)!;
+    }
+
+    private static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(Document document)
+    {
+        Compilation compilation = (await document.Project.GetCompilationAsync())!;
+        return (await compilation.WithAnalyzers(
+                ImmutableArray.Create<DiagnosticAnalyzer>(new AM004_MissingDestinationPropertyAnalyzer()))
+            .GetAnalyzerDiagnosticsAsync())
+            .OrderBy(d => d.Location.SourceSpan.Start)
+            .ToImmutableArray();
+    }
+}

--- a/tests/AutoMapperAnalyzer.Tests/DataIntegrity/AM006_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/DataIntegrity/AM006_CodeFixTests.cs
@@ -589,7 +589,7 @@ public class AM006_CodeFixTests
                                              {
                                                  public TestProfile()
                                                  {
-                                                     CreateMap<Source, Destination>().ForMember(dest => dest.Extra2, opt => opt.Ignore()).ForMember(dest => dest.Extra1, opt => opt.Ignore());
+                                                     CreateMap<Source, Destination>().ForMember(dest => dest.Extra1, opt => opt.Ignore()).ForMember(dest => dest.Extra2, opt => opt.Ignore());
                                                  }
                                              }
                                          }
@@ -606,7 +606,8 @@ public class AM006_CodeFixTests
 
         await CodeFixVerifier<AM006_UnmappedDestinationPropertyAnalyzer,
                 AM006_UnmappedDestinationPropertyCodeFixProvider>
-            .VerifyFixWithIterationsAsync(testCode, [diag1, diag2], expectedFixedCode, 2);
+            // Sibling recompute: Ignore-all clears both property-token diagnostics in one iteration.
+            .VerifyFixWithIterationsAsync(testCode, [diag1, diag2], expectedFixedCode, 1);
     }
 
     [Fact]
@@ -662,7 +663,7 @@ public class AM006_CodeFixTests
                                              {
                                                  public TestProfile()
                                                  {
-                                                     CreateMap<Source, Destination>().ForMember(dest => dest.Extra2, opt => opt.Ignore()).ForMember(dest => dest.Extra1, opt => opt.Ignore()).ReverseMap();
+                                                     CreateMap<Source, Destination>().ForMember(dest => dest.Extra1, opt => opt.Ignore()).ForMember(dest => dest.Extra2, opt => opt.Ignore()).ReverseMap();
                                                  }
                                              }
                                          }
@@ -679,7 +680,8 @@ public class AM006_CodeFixTests
 
         await CodeFixVerifier<AM006_UnmappedDestinationPropertyAnalyzer,
                 AM006_UnmappedDestinationPropertyCodeFixProvider>
-            .VerifyFixWithIterationsAsync(testCode, [forwardDiag1, forwardDiag2], expectedFixedCode, 2);
+            // Sibling recompute: Ignore-all clears both forward diagnostics in one iteration.
+            .VerifyFixWithIterationsAsync(testCode, [forwardDiag1, forwardDiag2], expectedFixedCode, 1);
     }
 
     [Fact]

--- a/tests/AutoMapperAnalyzer.Tests/DataIntegrity/AM006_SameDocumentSiblingAggregateTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/DataIntegrity/AM006_SameDocumentSiblingAggregateTests.cs
@@ -1,0 +1,150 @@
+using System.Collections.Immutable;
+using AutoMapperAnalyzer.Analyzers.DataIntegrity;
+using AutoMapperAnalyzer.Tests.Infrastructure;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+
+namespace AutoMapperAnalyzer.Tests.DataIntegrity;
+
+/// <summary>
+///     Same-document property-token AM006 diagnostics only put one diagnostic in the IDE
+///     CodeFixContext. Aggregates must recompute siblings (like AM011), not require multi-diag pile-up.
+/// </summary>
+public class AM006_SameDocumentSiblingAggregateTests
+{
+    private const string TwoUnmappedDestination = """
+                                                  using AutoMapper;
+
+                                                  namespace TestNamespace
+                                                  {
+                                                      public class Source
+                                                      {
+                                                          public string Name { get; set; }
+                                                      }
+
+                                                      public class Destination
+                                                      {
+                                                          public string Name { get; set; }
+                                                          public string Extra1 { get; set; }
+                                                          public string Extra2 { get; set; }
+                                                      }
+
+                                                      public class TestProfile : Profile
+                                                      {
+                                                          public TestProfile()
+                                                          {
+                                                              CreateMap<Source, Destination>();
+                                                          }
+                                                      }
+                                                  }
+                                                  """;
+
+    [Fact]
+    public async Task AM006_SinglePropertyTokenCaret_OffersIgnoreAll_ForSameDocumentSiblings()
+    {
+        Document document = CreateDocument(TwoUnmappedDestination);
+        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(document);
+        Assert.Equal(2, diagnostics.Length);
+
+        IReadOnlyList<CodeFixActionInspector.ActionInfo> actions =
+            await CodeFixActionInspector.GetActionsAsync(
+                document,
+                new AM006_UnmappedDestinationPropertyCodeFixProvider(),
+                diagnostics[0]);
+
+        Assert.Contains(actions, a => a.EquivalenceKey == "AM006_IgnoreAll" && a.Depth == 0);
+        Assert.Contains(
+            actions,
+            a => a.Depth == 0 && a.HasChildren &&
+                 a.Title.Contains("individual", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(actions, a => a.IsNested && a.EquivalenceKey != null &&
+                                      a.EquivalenceKey.StartsWith("AM006_Ignore_", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task AM006_IgnoreAll_FromSingleCaret_IgnoresEverySibling()
+    {
+        const string expectedFixedCode = """
+                                         using AutoMapper;
+
+                                         namespace TestNamespace
+                                         {
+                                             public class Source
+                                             {
+                                                 public string Name { get; set; }
+                                             }
+
+                                             public class Destination
+                                             {
+                                                 public string Name { get; set; }
+                                                 public string Extra1 { get; set; }
+                                                 public string Extra2 { get; set; }
+                                             }
+
+                                             public class TestProfile : Profile
+                                             {
+                                                 public TestProfile()
+                                                 {
+                                                     CreateMap<Source, Destination>().ForMember(dest => dest.Extra1, opt => opt.Ignore()).ForMember(dest => dest.Extra2, opt => opt.Ignore());
+                                                 }
+                                             }
+                                         }
+                                         """;
+
+        Document document = CreateDocument(TwoUnmappedDestination);
+        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(document);
+        Assert.Equal(2, diagnostics.Length);
+
+        Document fixedDocument = await CodeFixActionInspector.ApplyActionByKeyAsync(
+            document,
+            new AM006_UnmappedDestinationPropertyCodeFixProvider(),
+            ImmutableArray.Create(diagnostics[0]),
+            "AM006_IgnoreAll");
+
+        string updated = (await fixedDocument.GetTextAsync()).ToString();
+        Assert.Equal(
+            Normalize(expectedFixedCode),
+            Normalize(updated));
+        Assert.Empty(await GetDiagnosticsAsync(fixedDocument));
+    }
+
+    private static string Normalize(string text) =>
+        text.Replace("\r\n", "\n", StringComparison.Ordinal).Trim();
+
+    private static Document CreateDocument(string source)
+    {
+        var workspace = new AdhocWorkspace();
+        ProjectId projectId = ProjectId.CreateNewId();
+        DocumentId documentId = DocumentId.CreateNewId(projectId);
+        Solution solution = workspace.CurrentSolution
+            .AddProject(projectId, "AM006Sibling", "AM006Sibling", LanguageNames.CSharp)
+            .WithProjectCompilationOptions(projectId, new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+            .WithProjectParseOptions(projectId, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+
+        string trusted = (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") ?? string.Empty;
+        foreach (string path in trusted.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(path))
+            {
+                solution = solution.AddMetadataReference(projectId, MetadataReference.CreateFromFile(path));
+            }
+        }
+
+        solution = solution
+            .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(AutoMapper.Profile).Assembly.Location))
+            .AddDocument(documentId, "Test0.cs", SourceText.From(source));
+        return solution.GetDocument(documentId)!;
+    }
+
+    private static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(Document document)
+    {
+        Compilation compilation = (await document.Project.GetCompilationAsync())!;
+        return (await compilation.WithAnalyzers(
+                ImmutableArray.Create<DiagnosticAnalyzer>(new AM006_UnmappedDestinationPropertyAnalyzer()))
+            .GetAnalyzerDiagnosticsAsync())
+            .OrderBy(d => d.Location.SourceSpan.Start)
+            .ToImmutableArray();
+    }
+}


### PR DESCRIPTION
## Summary
- **AM004 / AM006** recompute live unmapped siblings from a single property-token caret
- Aggregates (Map-all / DoNotValidate-all / Ignore-all) no longer need multi-diagnostic pile-up
- AM006 shares `GetUnmappedDestinationProperties` with the analyzer
- Package **2.30.65**

## Impact
Meaningful UX: same-document lightbulbs get honest multi-property fixes like AM011.

## Validation
- Full suite net10.0: **1390** passed
- Codex: meaningful improvement, no actionable findings

## Release
Tag `v2.30.65` after merge.