### PR TITLE
fix: respect downstream AM022 cycle breakers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+## [2.30.66] - 2026-07-13
+
+AM022 downstream cycle-breaker precision for intentional circular mappings.
+
+### Changed
+
+- **AM022**: multi-map recursion traversal now stops when a downstream mapping direction is explicitly bounded by `MaxDepth`, preserves object identity with `PreserveReferences`, or owns construction through `ConvertUsing`.
+- **AM022 directionality**: fluent or same-block local configuration after `ReverseMap()` constrains only the reverse mapping direction; semantic AutoMapper ownership prevents lookalike methods from suppressing diagnostics.
+- **Duplicate registrations**: ambiguous mapping pairs suppress recursion only when every registration for that direction is explicitly constrained.
+
+### Validation
+
+- AM022 analyzer and code-fix suite: **66** passed.
+- Full suite on `net10.0`: **1401** passed, 0 skipped, 0 failed.
+
 ## [2.30.65] - 2026-07-08
 
 AM004/AM006 same-document sibling recompute for aggregate code actions.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet Version](https://img.shields.io/nuget/v/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=NuGet)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=Downloads)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/georgepwall1991/automapper-analyser/ci.yml?style=flat-square&logo=github&label=Build)](https://github.com/georgepwall1991/automapper-analyser/actions)
-[![Tests](https://img.shields.io/badge/Tests-1390%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
+[![Tests](https://img.shields.io/badge/Tests-1401%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
 [![.NET](https://img.shields.io/badge/.NET-4.8+%20%7C%206.0+%20%7C%208.0+%20%7C%209.0+%20%7C%2010.0+-512BD4?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 [![Coverage](https://img.shields.io/codecov/c/github/georgepwall1991/automapper-analyser?style=flat-square&logo=codecov&label=Coverage)](https://codecov.io/gh/georgepwall1991/automapper-analyser)
@@ -14,14 +14,14 @@ prevention*
 
 ---
 
-## 🎉 Latest Release: v2.30.65
+## 🎉 Latest Release: v2.30.66
 
-**AM004/AM006 same-document sibling recompute**
+**AM022 downstream cycle-breaker precision**
 
 ✅ **Highlights**
 
-- **AM004 / AM006**: aggregates from a single property-token caret.
-- Live unmapped-set recompute matches analyzer ownership.
+- Multi-map cycles respect downstream `MaxDepth`, `PreserveReferences`, and `ConvertUsing`.
+- Forward and reverse mapping directions remain independently analysed.
 
 🧪 **Validation**
 
@@ -29,6 +29,7 @@ prevention*
 
 ### Recent Releases
 
+- **v2.30.66**: AM022 respects direction-aware downstream cycle breakers in multi-map recursion graphs.
 - **v2.30.65**: AM004/AM006 same-document sibling recompute for aggregates.
 - **v2.30.64**: AM001 property-token diagnostic placement + aggregate sibling recompute.
 - **v2.30.63**: AM022 graph-aware Ignore for multi-type cycles.
@@ -230,7 +231,7 @@ Install-Package AutoMapperAnalyzer.Analyzers
 ### Project File (For CI/CD)
 
 ```xml
-<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.65">
+<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.66">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 </PackageReference>

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -1,12 +1,12 @@
 # Analyzer Health
 
-Reviewed: 2026-07-08 (AM031 ID split shipped as **2.30.62**; prior re-eval was 2.30.61 @ `7b419dc`)
+Reviewed: 2026-07-13 (AM022 downstream cycle-breaker precision prepared as **2.30.66**)
 
 This is a deliberately harsh health audit for the **21** implemented AutoMapper analyzer rule IDs in this repository (16 before the 2.30.62 performance split). Several rule IDs still expose multiple diagnostic descriptors, especially `AM002` and `AM022`; the scorecard rates the public rule ID as the user experiences it.
 
 Every implemented rule currently has an analyzer and a code fix provider. Scores are 1-5, where `5` means reference-quality and hard to improve, `3` means usable but meaningfully incomplete, and `1` means unreliable or underbuilt.
 
-**Ship status:** production-acceptable. **2.30.65** AM004/AM006 sibling recompute; **2.30.64** AM001 property tokens; **2.30.63** AM022; **2.30.62** AM031 split multi-concept ID into AM031 + AM034–AM038. Remaining highest residual is **AM022** (FP/Fix min 3). Full suite green; catalog/snapshots current.
+**Ship status:** production-acceptable. **2.30.66** AM022 downstream cycle breakers; **2.30.65** AM004/AM006 sibling recompute; **2.30.64** AM001 property tokens; **2.30.63** AM022 graph-aware Ignore. Remaining min-health-3 surface is the performance fixer family (AM031/AM034–AM038). Full suite green; catalog/snapshots current.
 
 ## Rubric
 
@@ -42,7 +42,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | AM011 | Required destination property is not mapped | Data Integrity | Error | 4 | 5 | 4 | 5 | 5 | 5 | Low | Important runtime-failure guardrail; per-property fuzzy now resolves ReverseMap types (same as aggregate). Fix Strategy 4: Map-all only when every property has unique fuzzy; mixed/default bulk uses honest Scaffold-all + (manual review); Ignore-all labeled manual review; stale diagnostics withhold. Residual: primary single-property path still scaffolds defaults. |
 | AM020 | Nested object mapping configuration missing | Complex Mappings | Warning | 4 | 4 | 4 | 5 | 5 | 5 | Low | Reference analyzer; fixer now shares public+internal property discovery with the analyzer (internal nested CreateMap fix covered). Catalog trust is `LikelyRewrite` (constructor-body insertion remains a structural limit). |
 | AM021 | Collection element type incompatibility | Complex Mappings | Warning | 4 | 4 | 4 | 5 | 4 | 4 | Low | Defers fully when AM003 owns container incompatibility (shared helper). Same-container element mismatches, dictionary axes, reverse gaps, and implicit element conversions remain AM021. List simple Select rewrites now refuse non-compiling Parse destinations (string-source gate matches dictionaries). |
-| AM022 | Infinite recursion risk | Complex Mappings | Warning | 4 | 3 | 4 | 5 | 4 | 4 | Low | Requires configured nested CreateMap chains for indirect cycles; strong suppressions. Catalog `Scaffold` matches hard-coded `MaxDepth(2)` policy; lightbulb title now says scaffold (review depth). **Fix Strategy 4** (2.30.63): Ignore uses analyzer graph edges for multi-type cycles. Residual: intentional circular DTOs and analyzer graph FP heuristics (FP still 3). |
+| AM022 | Infinite recursion risk | Complex Mappings | Warning | 4 | 4 | 4 | 5 | 4 | 4 | Low | Requires configured nested CreateMap chains for indirect cycles; strong semantic suppressions. **2.30.66**: direction-aware graph traversal stops at downstream `MaxDepth`, `PreserveReferences`, and `ConvertUsing` maps, with all-registrations protection for ambiguous duplicates. Catalog `Scaffold` matches hard-coded `MaxDepth(2)` policy; graph-edge Ignore remains manual review. |
 | AM030 | Invalid type converter implementation | Custom Conversions | Error | 4 | 4 | 4 | 4 | 4 | 3 | Low | Analyzer-only by design; AM001/AM020/AM021 own missing-converter mapping. Split from AM032/AM033 is clean in catalog and trust tests. Direct AM030 coverage includes empty implementation, wrong return type, missing `ResolutionContext`, and non-public `Convert` (each paired with the matching compiler error). |
 | AM032 | Type converter null handling | Custom Conversions | Warning | 4 | 4 | 4 | 5 | 4 | 4 | Low | Best-in-class null-guard detection with catalog `LikelyRewrite` trust. Recognizes `ThrowIfNull*`, switch/pattern/coalesce/conditional-access guards, and pure nullable→nullable source pass-through (`return source` / `=> source`). Residual: heuristic null-flow edge cases; the auto-fix still inserts `ArgumentNullException` (appropriate when a diagnostic fires for non-nullable destinations without intentional null handling). |
 | AM033 | Unused type converter | Custom Conversions | Info | 4 | 4 | 4 | 4 | 4 | 2 | Low | Unused-converter diagnostics now have their own Info rule ID and remain analyzer-only, and the shared converter code-fix provider no longer advertises AM033 as fixable. Usage analysis recognizes generic, instance, type-based including parenthesized/casted `typeof(...)` and simple explicit or implicit `Type` locals/fields/properties initialized from, expression-bodied to, or getter-bodied to `typeof(...)`, parameterless `Type` factory methods and local functions that expression-body or return `typeof(...)`, simple interface-typed locals/fields/properties, and DI/service-provider interface handles passed to `ConvertUsing(...)`. Product importance is intentionally lower because this is cleanup guidance. |
@@ -71,22 +71,21 @@ Use this table as the hardening queue. Ranking = **Importance × (5 − min(Anal
 
 | Rank | Rule | Signal | Residual (evidence-backed) | Likely score move if closed |
 | --- | --- | --- | --- | --- |
-| 1 | **AM022** | gap=4, min=3 (FP) | Graph-aware Ignore shipped 2.30.63. Residual: intentional circular DTO FP (FP=3). | FP 3→4 needs intentional-cycle suppressions |
+| 1 | **AM031 / AM034–AM038** | Fix=3 | Shared ForPath analyzer-only + Scaffold policy after ID split. Further smell breadth is diminishing returns. | Fix 3→4 only with ForPath-safe rewrites |
 | 2 | **AM001** | gap=4, min=4 | Property-token placement shipped 2.30.64. Residual: advanced conversion modelling only with user repros. | — |
-| 3 | **AM004 / AM006** | gap=5/4 | Aggregate Map-all / DoNotValidate-all / Ignore-all need multi-diagnostic **group** context; same-document single-property lightbulbs do not recompute siblings the way AM011 does. Catalog Scaffold remains correct. | Fix 4→5 if same-document sibling recompute matches AM011 without inventing mappings |
-| 4 | **AM031 / AM034–AM038** | Fix=3 | Shared ForPath analyzer-only + Scaffold policy after ID split. Further smell breadth is diminishing returns. | Fix 3→4 only with ForPath-safe rewrites |
-| 5 | **AM011** | gap=5, min=4 | Residual: primary single-property path still scaffolds defaults when fuzzy fails. | Fix stays 4 until less scaffold-heavy without lying |
-| 6 | **AM002** | gap=5, min=4 | Advanced generic/nullability-flow only — wait for real user FP/FN. | — until evidence |
-| 7 | **AM032** | gap=4, min=4 | Classic net48-safe if-throw; not destination-aware. | Fix 4→5 if destination-aware policies are safe |
-| 8 | **AM020 / AM021 / AM003** | gap=5/4 | Custom-collection / constructor-body insert structural limits. | Opportunistic |
-| 9 | **AM041 / AM050** | gap=4/2 | SafeRewrite nuance / low Importance. | Low ROI |
-| 10 | **AM033 / AM005 / AM030** | gap=2–3 | Importance-limited. | Product priority only |
+| 3 | **AM011** | gap=5, min=4 | Residual: primary single-property path still scaffolds defaults when fuzzy fails. | Fix stays 4 until less scaffold-heavy without lying |
+| 4 | **AM022** | gap=4, min=4 | Downstream global cycle breakers shipped 2.30.66. Member-level graph/dataflow refinements remain opportunistic. | FP 4→5 needs evidence-backed dataflow precision |
+| 5 | **AM002** | gap=5, min=4 | Advanced generic/nullability-flow only — wait for real user FP/FN. | — until evidence |
+| 6 | **AM032** | gap=4, min=4 | Classic net48-safe if-throw; not destination-aware. | Fix 4→5 if destination-aware policies are safe |
+| 7 | **AM020 / AM021 / AM003** | gap=5/4 | Custom-collection / constructor-body insert structural limits. | Opportunistic |
+| 8 | **AM041 / AM050** | gap=4/2 | SafeRewrite nuance / low Importance. | Low ROI |
+| 9 | **AM033 / AM005 / AM030** | gap=2–3 | Importance-limited. | Product priority only |
 
 **Recommended next hardening batch:**
 
-1. **AM022 intentional-cycle FP**
+1. **AM031/AM034–AM038 ForPath-safe rewrites** (Fix still 3)
 2. **AM032 destination-aware null fix**
-3. **AM031/AM034–AM038 ForPath-safe rewrites** (Fix still 3)
+3. **AM011 less scaffold-heavy single-property fixes**
 
 Do **not** open advanced AM001/AM002 conversion/nullability modelling without a filed false-positive/false-negative repro.
 
@@ -107,7 +106,8 @@ The Planning Shortlist above summarises overall rule priority; this backlog is t
 Active queue (also summarized in Working Base). Prefer one focus per hardening batch:
 
 - _AM031 ID split — resolved in 2.30.62._ AM031 multi-enum; AM034–AM038 independent IDs.
-- _AM022 graph-aware Ignore — resolved in 2.30.63._ Multi-type cycle edges offered for Ignore. Residual: intentional circular-DTO FP (FP=3).
+- _AM022 graph-aware Ignore — resolved in 2.30.63._ Multi-type cycle edges offered for Ignore.
+- _AM022 downstream cycle-breaker precision — resolved in 2.30.66._ Multi-map traversal honours direction-specific `MaxDepth`, `PreserveReferences`, and `ConvertUsing`; False Positives 3→4.
 - _AM004 / AM006 same-document sibling recompute — resolved in 2.30.65._
 - **AM001 property-token diagnostic placement.** Still reports on `CreateMap` invocation span; data-integrity rules already land on property tokens.
 - **AM032 destination-aware null fixes.** Emit stays classic net48 `if-throw`; not destination-nullability-aware. Analyzer ThrowIfNull* recognition is already strong.
@@ -148,6 +148,12 @@ Still open (do not start without a repro or explicit product decision):
 - **AM022 / AM031 dataflow-grade heuristics.** High effort, diminishing returns until a concrete false-positive pattern is filed (prefer P2 ID-split / graph-Ignore first).
 - **AM020 constructor-body CreateMap insert.** Structural host limit; catalog `LikelyRewrite` already honest.
 
+
+## Reanalysis Changelog (2026-07-13 → 2.30.66 AM022 downstream cycle breakers)
+
+| Rules | Finding | Change | Score impact |
+| --- | --- | --- | --- |
+| AM022 | Root maps still warned when a downstream map already bounded or owned recursion | Direction-aware registry metadata stops traversal at semantic `MaxDepth`, `PreserveReferences`, and `ConvertUsing` edges, including direct same-block local configuration; ambiguous duplicates require every registration to be constrained | False Positives 3→4 |
 
 ## Reanalysis Changelog (2026-07-08 → 2.30.65 AM004/AM006 sibling recompute)
 
@@ -213,7 +219,7 @@ Full rule+fixer reanalysis driven by four parallel subagent audits (Type Safety,
 | AM030 | ~5 direct tests in shared 146-test bucket. | Tests 4→3; tightened Notes. | AM030 Tests −1 |
 | AM032 | Null-flow heuristic + throw-only fix policy risk. | False Positives 4→3; tightened Notes. | AM032 False Positives −1 |
 
-## Fixer Trust Summary (v2.30.65)
+## Fixer Trust Summary (v2.30.66)
 
 | Rule | Fixable? | Catalog trust | Notes |
 | --- | --- | --- | --- |
@@ -290,17 +296,17 @@ Full rule+fixer reanalysis driven by four parallel subagent audits (Type Safety,
 
 Architecture-style coverage currently comes from analyzer/fixer tests, conflict ownership tests, helper tests, sample projects, documentation, the checked-in `RuleCatalog`, generated trust artifacts, package smoke tests, and the deterministic `tools/AnalyzerVerifier` checks.
 
-Current local verification (**2026-07-08** against shipping **v2.30.62** (AM031 ID split)):
+Current local verification (**2026-07-13** against the **v2.30.66** release candidate):
 
-- Package version in `src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj`: **2.30.62**.
+- Package version in `src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj`: **2.30.66**.
 - `dotnet build automapper-analyser.sln --configuration Release -warnaserror` passed: 0 warnings, 0 errors.
-- `dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --configuration Release --no-build --framework net10.0` passed: **1381** passed, 0 skipped, 0 failed (~28 s).
+- `dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --configuration Release --no-build --framework net10.0` passed: **1401** passed, 0 skipped, 0 failed (~15 s).
 - `dotnet run --project tools/AnalyzerVerifier/AnalyzerVerifier.csproj --configuration Release --no-build -- --check-catalog --check-snapshots` passed: rule catalog and sample diagnostics snapshot are up to date.
 - `git diff --check` passed.
-- `dotnet format automapper-analyser.sln --verify-no-changes --no-restore` completed without format diffs.
+- Targeted `dotnet format whitespace` completed without diffs in the changed C# files; the repository-wide check still exposes pre-existing line-ending drift outside this slice.
 - Sample project emits AM0xx when analyzers run (`-p:RunAnalyzersDuringBuild=true`); local untracked `Directory.Build.props` (if present) may skip analyzers during CLI builds — unit tests + AnalyzerVerifier remain the verification source of truth.
 - Approximate list-tests name hits (not exclusive filters; for trend only): AM001 57, AM002 83, AM003 61, AM004 87, AM005 34, AM006 43, AM011 45, AM020 97, AM021 64, AM022 53, AM030/32/33 bucket 152, AM031 292, AM041 35, AM050 48, RuleCatalog 10.
-- Tags present through `v2.30.61` on `main`; `v2.30.62` ships this pass.
+- Release metadata is synchronized for `v2.30.66`; tag/publication follows the merged PR.
 - Historical baseline (2026-07-06 @ `b138fa8` / v2.30.55): **1352** tests green — superseded; do not use for planning.
 - The trust-first pass removed active skipped tests, added drift validation, and moved intentional analyzer-test warnings into an explicit test-project warning baseline.
 - `/usr/local/share/dotnet/dotnet --list-runtimes` shows only .NET 10 runtimes in this local environment, so broader multi-TFM runtime verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -725,7 +725,7 @@ dotnet pack --configuration Release
 
 # Test package locally
 cd test-install/NetCoreTest
-dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.65-local
+dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.66-local
 ```
 
 ---
@@ -909,4 +909,4 @@ dotnet build
 
 **Last Updated**: 2026-05-14
 **Maintainer**: George Wall
-**Version**: 2.30.65
+**Version**: 2.30.66

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -112,8 +112,8 @@ The AutoMapper Roslyn Analyzer project uses GitHub Actions for continuous integr
 ### Package Versioning
 
 - **Format**: Major.Minor.Patch (SemVer)
-- **Current**: 2.30.65
-- **Pre-release**: 2.30.65-preview, 2.30.65-beta
+- **Current**: 2.30.66
+- **Pre-release**: 2.30.66-preview, 2.30.66-beta
 
 ## 🔧 Configuration
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -43,7 +43,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.65">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.66">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -67,7 +67,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.65">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.66">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -86,7 +86,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="14.0.0" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.65">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.66">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -218,7 +218,7 @@ public class Destination
 
 2. **Verify Package Installation**
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.65">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.66">
      <PrivateAssets>all</PrivateAssets>
      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -280,4 +280,4 @@ This guide ensures smooth installation and usage across all supported .NET frame
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.65
+**Version**: 2.30.66

--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -972,7 +972,10 @@ recursive member path is actually convention-mapped and each indirect nested typ
 that AutoMapper can use for recursion. Ignoring the top-level recursive destination member with
 `ForMember(..., opt => opt.Ignore())` or `ForPath(..., opt => opt.Ignore())` suppresses the diagnostic. Forward
 `MaxDepth`, `PreserveReferences`, and `ConvertUsing` configuration also suppress AM022 because those mapping shapes
-own recursion behavior explicitly. Helper methods named `Ignore` are not treated as suppression unless they resolve to
+own recursion behavior explicitly. For indirect cycles, the traversal honours these cycle breakers on downstream
+`CreateMap` registrations as well as the root map, including direct same-block calls through a local mapping variable,
+while preserving configuration direction around `ReverseMap()`.
+Helper methods named `Ignore` or cycle-breaker names are not treated as suppression unless they resolve to
 AutoMapper's member-configuration `Ignore()` method. Built-in framework types such as `System.Guid` stay out of
 graph recursion analysis, but user-defined types with the same short names are still analyzed.
 
@@ -1599,7 +1602,7 @@ using System.Diagnostics.CodeAnalysis;
 
 1. **Check package reference**:
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.65">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.66">
        <PrivateAssets>all</PrivateAssets>
        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -1638,5 +1641,5 @@ If analyzer slows down builds:
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.65
+**Version**: 2.30.66
 **Maintainer**: George Wall

--- a/docs/RULE_CATALOG.md
+++ b/docs/RULE_CATALOG.md
@@ -2,7 +2,7 @@
 
 This file is generated from `RuleCatalog`.
 
-Package version: `2.30.65`
+Package version: `2.30.66`
 
 | Rule ID | Descriptor Title | Severity | Category | Analyzer | Code Fix | Trust | Sample | Docs |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,3 +1,15 @@
+## Release 2.30.66
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
+### Removed Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
 ## Release 2.30.65
 
 ### New Rules

--- a/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
+++ b/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
@@ -17,7 +17,7 @@
         <!-- Fallback for local builds: 2.0.YYYYMMDD-local -->
         <MajorVersion>2</MajorVersion>
         <MinorVersion>30</MinorVersion>
-        <PatchVersion>65</PatchVersion>
+        <PatchVersion>66</PatchVersion>
         <BuildNumber Condition="'$(BuildNumber)' == ''"
         >$([System.DateTime]::Now.ToString('yyyyMMdd'))
         </BuildNumber
@@ -32,9 +32,9 @@
         <RepositoryUrl>https://github.com/georgepwall1991/automapper-analyser</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-                <PackageReleaseNotes>Version 2.30.65 - AM004/AM006 same-document sibling recompute
-- Map-all / DoNotValidate-all / Ignore-all from a single property-token caret
-- Recompute uses live analyzer unmapped sets (AM011-style)
+                <PackageReleaseNotes>Version 2.30.66 - AM022 downstream cycle-breaker precision
+- Multi-map recursion traversal respects downstream MaxDepth, PreserveReferences, and ConvertUsing
+- Cycle-breaker ownership is semantic, direction-aware, and conservative for duplicate registrations
 </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>

--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM022_InfiniteRecursionAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM022_InfiniteRecursionAnalyzer.cs
@@ -392,6 +392,12 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
+        // A downstream map that owns or bounds recursion terminates this graph path.
+        if (createMapRegistry.IsCycleConstrained(currentSourceType, currentDestinationType))
+        {
+            return false;
+        }
+
         string typePairKey = GetTypePairKey(currentSourceType, currentDestinationType);
         if (visited.Contains(typePairKey))
         {

--- a/src/AutoMapperAnalyzer.Analyzers/Helpers/CreateMapRegistry.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Helpers/CreateMapRegistry.cs
@@ -12,6 +12,8 @@ namespace AutoMapperAnalyzer.Analyzers.Helpers;
 internal sealed class CreateMapRegistry
 {
     private static readonly ConditionalWeakTable<Compilation, CreateMapRegistry> Cache = new();
+    private static readonly ImmutableHashSet<string> CycleBreakerMethodNames =
+        ImmutableHashSet.Create(StringComparer.Ordinal, "MaxDepth", "PreserveReferences", "ConvertUsing");
 
     private readonly Dictionary<InvocationExpressionSyntax, (string Source, string Dest, Location Location)>
         _duplicates;
@@ -43,6 +45,35 @@ internal sealed class CreateMapRegistry
         }
 
         return false;
+    }
+
+    /// <summary>
+    ///     Checks whether every registration for a mapping direction explicitly constrains recursive traversal.
+    /// </summary>
+    public bool IsCycleConstrained(ITypeSymbol? source, ITypeSymbol? destination)
+    {
+        if (source == null || destination == null)
+        {
+            return false;
+        }
+
+        bool found = false;
+        foreach (MappingInfo mapping in _mappings)
+        {
+            if (!SymbolEqualityComparer.Default.Equals(mapping.Source, source) ||
+                !SymbolEqualityComparer.Default.Equals(mapping.Destination, destination))
+            {
+                continue;
+            }
+
+            found = true;
+            if (!mapping.IsCycleConstrained)
+            {
+                return false;
+            }
+        }
+
+        return found;
     }
 
     /// <summary>
@@ -104,41 +135,48 @@ internal sealed class CreateMapRegistry
                     AutoMapperAnalysisHelpers.GetCreateMapTypeArguments(invocation, semanticModel);
                 if (sourceType != null && destType != null)
                 {
+                    InvocationExpressionSyntax? reverseMapInvocation =
+                        AutoMapperAnalysisHelpers.GetReverseMapInvocation(invocation);
                     mappings.Add(new MappingInfo
                     {
                         Source = sourceType,
                         Destination = destType,
                         Location = invocation.GetLocation(),
                         Node = invocation,
-                        IsReverseMap = false
+                        IsReverseMap = false,
+                        IsCycleConstrained = HasCycleBreaker(
+                            invocation,
+                            reverseMapInvocation,
+                            semanticModel,
+                            reverseDirection: false)
                     });
 
                     // Check for ReverseMap()
-                    if (AutoMapperAnalysisHelpers.HasReverseMap(invocation))
+                    if (reverseMapInvocation != null)
                     {
-                        InvocationExpressionSyntax? reverseMapInvocation =
-                            AutoMapperAnalysisHelpers.GetReverseMapInvocation(invocation);
-                        if (reverseMapInvocation != null)
+                        Location loc;
+                        if (reverseMapInvocation.Expression is MemberAccessExpressionSyntax ma)
                         {
-                            Location loc;
-                            if (reverseMapInvocation.Expression is MemberAccessExpressionSyntax ma)
-                            {
-                                loc = ma.Name.GetLocation();
-                            }
-                            else
-                            {
-                                loc = reverseMapInvocation.GetLocation();
-                            }
-
-                            mappings.Add(new MappingInfo
-                            {
-                                Source = destType,
-                                Destination = sourceType,
-                                Location = loc,
-                                Node = reverseMapInvocation,
-                                IsReverseMap = true
-                            });
+                            loc = ma.Name.GetLocation();
                         }
+                        else
+                        {
+                            loc = reverseMapInvocation.GetLocation();
+                        }
+
+                        mappings.Add(new MappingInfo
+                        {
+                            Source = destType,
+                            Destination = sourceType,
+                            Location = loc,
+                            Node = reverseMapInvocation,
+                            IsReverseMap = true,
+                            IsCycleConstrained = HasCycleBreaker(
+                                invocation,
+                                reverseMapInvocation,
+                                semanticModel,
+                                reverseDirection: true)
+                        });
                     }
                 }
             }
@@ -196,6 +234,116 @@ internal sealed class CreateMapRegistry
         return type.Name;
     }
 
+    private static bool HasCycleBreaker(
+        InvocationExpressionSyntax createMapInvocation,
+        InvocationExpressionSyntax? reverseMapInvocation,
+        SemanticModel semanticModel,
+        bool reverseDirection)
+    {
+        for (SyntaxNode? parent = createMapInvocation.Parent; parent != null; parent = parent.Parent)
+        {
+            if (parent is not InvocationExpressionSyntax chainedCall)
+            {
+                continue;
+            }
+
+            bool appliesToReverseDirection = reverseMapInvocation != null &&
+                                             reverseMapInvocation.Ancestors().Contains(chainedCall);
+            if (appliesToReverseDirection != reverseDirection)
+            {
+                continue;
+            }
+
+            foreach (string methodName in CycleBreakerMethodNames)
+            {
+                if (MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(chainedCall, semanticModel, methodName))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return HasDeferredCycleBreaker(
+            createMapInvocation,
+            reverseMapInvocation,
+            semanticModel,
+            reverseDirection);
+    }
+
+    private static bool HasDeferredCycleBreaker(
+        InvocationExpressionSyntax createMapInvocation,
+        InvocationExpressionSyntax? reverseMapInvocation,
+        SemanticModel semanticModel,
+        bool reverseDirection)
+    {
+        VariableDeclaratorSyntax? declarator = createMapInvocation.Ancestors()
+            .OfType<VariableDeclaratorSyntax>()
+            .FirstOrDefault();
+        if (declarator?.Initializer == null ||
+            declarator.Parent?.Parent is not LocalDeclarationStatementSyntax declaration ||
+            declaration.Parent is not BlockSyntax block ||
+            semanticModel.GetDeclaredSymbol(declarator) is not ILocalSymbol mappingLocal)
+        {
+            return false;
+        }
+
+        bool localRepresentsReverseDirection = reverseMapInvocation != null;
+        foreach (ExpressionStatementSyntax statement in block.Statements
+                     .OfType<ExpressionStatementSyntax>()
+                     .Where(candidate => candidate.SpanStart > declaration.SpanStart))
+        {
+            foreach (InvocationExpressionSyntax candidate in statement.Expression.DescendantNodesAndSelf()
+                         .OfType<InvocationExpressionSyntax>())
+            {
+                if (!IsCycleBreaker(candidate, semanticModel) ||
+                    candidate.Expression is not MemberAccessExpressionSyntax memberAccess ||
+                    !ReferencesLocal(memberAccess.Expression, mappingLocal, semanticModel))
+                {
+                    continue;
+                }
+
+                bool followsReverseMap = memberAccess.Expression.DescendantNodesAndSelf()
+                    .OfType<InvocationExpressionSyntax>()
+                    .Any(invocation => MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(
+                        invocation,
+                        semanticModel,
+                        "ReverseMap"));
+                bool appliesToReverseDirection = localRepresentsReverseDirection || followsReverseMap;
+                if (appliesToReverseDirection == reverseDirection)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsCycleBreaker(InvocationExpressionSyntax invocation, SemanticModel semanticModel)
+    {
+        foreach (string methodName in CycleBreakerMethodNames)
+        {
+            if (MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(invocation, semanticModel, methodName))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ReferencesLocal(
+        ExpressionSyntax expression,
+        ILocalSymbol mappingLocal,
+        SemanticModel semanticModel)
+    {
+        return expression.DescendantNodesAndSelf()
+            .OfType<IdentifierNameSyntax>()
+            .Any(identifier => SymbolEqualityComparer.Default.Equals(
+                semanticModel.GetSymbolInfo(identifier).Symbol,
+                mappingLocal));
+    }
+
     internal struct MappingInfo
     {
         public ITypeSymbol Source;
@@ -203,6 +351,7 @@ internal sealed class CreateMapRegistry
         public Location Location;
         public InvocationExpressionSyntax Node;
         public bool IsReverseMap;
+        public bool IsCycleConstrained;
     }
 
     private class MappingComparer : IEqualityComparer<(ITypeSymbol Source, ITypeSymbol Destination)>

--- a/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
@@ -130,7 +130,7 @@ public static class RuleCatalog
     /// <summary>
     ///     Current package version used by docs/package drift tests.
     /// </summary>
-    public const string CurrentPackageVersion = "2.30.65";
+    public const string CurrentPackageVersion = "2.30.66";
 
     /// <summary>
     ///     Implemented rules, grouped by public diagnostic ID.

--- a/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM022_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM022_CodeFixTests.cs
@@ -70,7 +70,6 @@ public class AM022_CodeFixTests
                                              }
                                          }
                                          """;
-
         await CodeFixVerifier<AM022_InfiniteRecursionAnalyzer, AM022_InfiniteRecursionCodeFixProvider>
             .VerifyFixAsync(
                 testCode,
@@ -251,7 +250,7 @@ public class AM022_CodeFixTests
                                         public TestProfile()
                                         {
                                             CreateMap<SourceParent, DestParent>();
-                                            CreateMap<SourceChild, DestChild>().MaxDepth(2);
+                                            CreateMap<SourceChild, DestChild>();
                                         }
                                     }
                                 }
@@ -287,19 +286,34 @@ public class AM022_CodeFixTests
                                                  public TestProfile()
                                                  {
                                                      CreateMap<SourceParent, DestParent>().MaxDepth(2);
-                                                     CreateMap<SourceChild, DestChild>().MaxDepth(2);
+                                                     CreateMap<SourceChild, DestChild>();
                                                  }
                                              }
                                          }
                                          """;
 
+        string expectedBatchFixedCode = expectedFixedCode.Replace(
+            "CreateMap<SourceChild, DestChild>();",
+            "CreateMap<SourceChild, DestChild>().MaxDepth(2);");
+
         await CodeFixVerifier<AM022_InfiniteRecursionAnalyzer, AM022_InfiniteRecursionCodeFixProvider>
             .VerifyFixAsync(
                 testCode,
-                new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule)
-                    .WithLocation(29, 13)
-                    .WithArguments("SourceParent", "DestParent"),
-                expectedFixedCode);
+                new[]
+                {
+                    new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule)
+                        .WithLocation(29, 13)
+                        .WithArguments("SourceParent", "DestParent"),
+                    new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule)
+                        .WithLocation(30, 13)
+                        .WithArguments("SourceChild", "DestChild")
+                },
+                expectedFixedCode,
+                codeActionIndex: null,
+                incrementalIterations: 1,
+                fixAllIterations: 1,
+                remainingDiagnostics: null,
+                batchFixedSource: expectedBatchFixedCode);
     }
 
     [Fact]
@@ -364,7 +378,6 @@ public class AM022_CodeFixTests
                                              }
                                          }
                                          """;
-
         // Index 0: MaxDepth first (Ignore second)
         await CodeFixVerifier<AM022_InfiniteRecursionAnalyzer, AM022_InfiniteRecursionCodeFixProvider>
             .VerifyFixAsync(
@@ -602,8 +615,8 @@ public class AM022_CodeFixTests
                                         public TestProfile()
                                         {
                                             CreateMap<SourceA, DestA>();
-                                            CreateMap<SourceB, DestB>().MaxDepth(2);
-                                            CreateMap<SourceC, DestC>().MaxDepth(2);
+                                            CreateMap<SourceB, DestB>();
+                                            CreateMap<SourceC, DestC>();
                                         }
                                     }
                                 }
@@ -655,21 +668,43 @@ public class AM022_CodeFixTests
                                                  public TestProfile()
                                                  {
                                                      CreateMap<SourceA, DestA>().MaxDepth(2);
-                                                     CreateMap<SourceB, DestB>().MaxDepth(2);
-                                                     CreateMap<SourceC, DestC>().MaxDepth(2);
+                                                     CreateMap<SourceB, DestB>();
+                                                     CreateMap<SourceC, DestC>();
                                                  }
                                              }
                                          }
                                          """;
 
+        string expectedBatchFixedCode = expectedFixedCode
+            .Replace(
+                "CreateMap<SourceB, DestB>();",
+                "CreateMap<SourceB, DestB>().MaxDepth(2);")
+            .Replace(
+                "CreateMap<SourceC, DestC>();",
+                "CreateMap<SourceC, DestC>().MaxDepth(2);");
+
         // Circular chain A→B→C→A detected as infinite recursion risk
         await CodeFixVerifier<AM022_InfiniteRecursionAnalyzer, AM022_InfiniteRecursionCodeFixProvider>
             .VerifyFixAsync(
                 testCode,
-                new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule)
-                    .WithLocation(45, 13)
-                    .WithArguments("SourceA", "DestA"),
-                expectedFixedCode);
+                new[]
+                {
+                    new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule)
+                        .WithLocation(45, 13)
+                        .WithArguments("SourceA", "DestA"),
+                    new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule)
+                        .WithLocation(46, 13)
+                        .WithArguments("SourceB", "DestB"),
+                    new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule)
+                        .WithLocation(47, 13)
+                        .WithArguments("SourceC", "DestC")
+                },
+                expectedFixedCode,
+                codeActionIndex: null,
+                incrementalIterations: 1,
+                fixAllIterations: 1,
+                remainingDiagnostics: null,
+                batchFixedSource: expectedBatchFixedCode);
     }
 
     [Fact]
@@ -721,10 +756,9 @@ public class AM022_CodeFixTests
                                     {
                                         public TestProfile()
                                         {
-                                            // B/C already scaffolded so only A reports — isolates graph-aware Ignore.
                                             CreateMap<SourceA, DestA>();
-                                            CreateMap<SourceB, DestB>().MaxDepth(2);
-                                            CreateMap<SourceC, DestC>().MaxDepth(2);
+                                            CreateMap<SourceB, DestB>();
+                                            CreateMap<SourceC, DestC>();
                                         }
                                     }
                                 }
@@ -775,24 +809,35 @@ public class AM022_CodeFixTests
                                              {
                                                  public TestProfile()
                                                  {
-                                                     // B/C already scaffolded so only A reports — isolates graph-aware Ignore.
                                                      CreateMap<SourceA, DestA>().ForMember(dest => dest.BReference, opt => opt.Ignore());
-                                                     CreateMap<SourceB, DestB>().MaxDepth(2);
-                                                     CreateMap<SourceC, DestC>().MaxDepth(2);
+                                                     CreateMap<SourceB, DestB>().ForMember(dest => dest.CReference, opt => opt.Ignore());
+                                                     CreateMap<SourceC, DestC>().ForMember(dest => dest.AReference, opt => opt.Ignore());
                                                  }
                                              }
                                          }
                                          """;
 
-        // Index 0 MaxDepth, index 1 Ignore graph edge BReference (not a dest self-ref).
+        // Index 0 MaxDepth, index 1 Ignore graph edge BReference (not a destination self-ref).
         await CodeFixVerifier<AM022_InfiniteRecursionAnalyzer, AM022_InfiniteRecursionCodeFixProvider>
             .VerifyFixAsync(
                 testCode,
-                new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule)
-                    .WithLocation(46, 13)
-                    .WithArguments("SourceA", "DestA"),
+                new[]
+                {
+                    new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule)
+                        .WithLocation(45, 13)
+                        .WithArguments("SourceA", "DestA"),
+                    new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule)
+                        .WithLocation(46, 13)
+                        .WithArguments("SourceB", "DestB"),
+                    new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule)
+                        .WithLocation(47, 13)
+                        .WithArguments("SourceC", "DestC")
+                },
                 expectedFixedCode,
-                1);
+                codeActionIndex: 1,
+                incrementalIterations: 3,
+                fixAllIterations: 3,
+                remainingDiagnostics: null);
     }
 
     [Fact]
@@ -837,7 +882,7 @@ public class AM022_CodeFixTests
                                         public TestProfile()
                                         {
                                             CreateMap<SourceA, DestA>();
-                                            CreateMap<SourceB, DestB>().MaxDepth(2);
+                                            CreateMap<SourceB, DestB>();
                                         }
                                     }
                                 }
@@ -879,7 +924,7 @@ public class AM022_CodeFixTests
                                                  public TestProfile()
                                                  {
                                                      CreateMap<SourceA, DestA>().ForMember(dest => dest.BReference, opt => opt.Ignore()).ForMember(dest => dest.Parent, opt => opt.Ignore());
-                                                     CreateMap<SourceB, DestB>().MaxDepth(2);
+                                                     CreateMap<SourceB, DestB>().ForMember(dest => dest.AReference, opt => opt.Ignore());
                                                  }
                                              }
                                          }
@@ -889,11 +934,20 @@ public class AM022_CodeFixTests
         await CodeFixVerifier<AM022_InfiniteRecursionAnalyzer, AM022_InfiniteRecursionCodeFixProvider>
             .VerifyFixAsync(
                 testCode,
-                new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.SelfReferencingTypeRule)
-                    .WithLocation(35, 13)
-                    .WithArguments("SourceA", "DestA"),
+                new[]
+                {
+                    new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.SelfReferencingTypeRule)
+                        .WithLocation(35, 13)
+                        .WithArguments("SourceA", "DestA"),
+                    new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule)
+                        .WithLocation(36, 13)
+                        .WithArguments("SourceB", "DestB")
+                },
                 expectedFixedCode,
-                1);
+                codeActionIndex: 1,
+                incrementalIterations: 2,
+                fixAllIterations: 2,
+                remainingDiagnostics: null);
     }
 
     [Fact]

--- a/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM022_InfiniteRecursionTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM022_InfiniteRecursionTests.cs
@@ -1553,4 +1553,411 @@ public class AM022_InfiniteRecursionTests
                 "DestPerson")
             .RunAsync();
     }
+
+    [Theory]
+    [InlineData(".PreserveReferences()")]
+    [InlineData(".MaxDepth(2)")]
+    [InlineData(".ConvertUsing((SourceB source) => new DestB())")]
+    [InlineData(".ConvertUsing<SourceBConverter>()")]
+    public async Task AM022_ShouldNotReportDiagnostic_WhenDownstreamCycleMapIsConstrained(string cycleBreaker)
+    {
+        string testCode = $$"""
+                            using AutoMapper;
+
+                            namespace TestNamespace
+                            {
+                                public class SourceA
+                                {
+                                    public SourceB Child { get; set; }
+                                }
+
+                                public class SourceB
+                                {
+                                    public SourceA Owner { get; set; }
+                                }
+
+                                public class DestA
+                                {
+                                    public DestB Child { get; set; }
+                                }
+
+                                public class DestB
+                                {
+                                    public DestA Owner { get; set; }
+                                }
+
+                                public sealed class SourceBConverter : ITypeConverter<SourceB, DestB>
+                                {
+                                    public DestB Convert(SourceB source, DestB destination, ResolutionContext context) =>
+                                        new();
+                                }
+
+                                public class TestProfile : Profile
+                                {
+                                    public TestProfile()
+                                    {
+                                        CreateMap<SourceA, DestA>();
+                                        CreateMap<SourceB, DestB>(){{cycleBreaker}};
+                                    }
+                                }
+                            }
+                            """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM022_InfiniteRecursionAnalyzer>()
+            .WithSource(testCode)
+            .ExpectNoDiagnostics()
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM022_ShouldNotReportDiagnostic_WhenDownstreamCycleMapIsConstrainedInLaterStatement()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class SourceA
+                                    {
+                                        public SourceB Child { get; set; }
+                                    }
+
+                                    public class SourceB
+                                    {
+                                        public SourceA Owner { get; set; }
+                                    }
+
+                                    public class DestA
+                                    {
+                                        public DestB Child { get; set; }
+                                    }
+
+                                    public class DestB
+                                    {
+                                        public DestA Owner { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<SourceA, DestA>();
+                                            var downstreamMap = CreateMap<SourceB, DestB>();
+                                            downstreamMap.MaxDepth(2);
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM022_InfiniteRecursionAnalyzer>()
+            .WithSource(testCode)
+            .ExpectNoDiagnostics()
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM022_ShouldReportDiagnostic_WhenDeferredCycleBreakerAppliesOnlyAfterReverseMap()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class SourceA
+                                    {
+                                        public SourceB Child { get; set; }
+                                    }
+
+                                    public class SourceB
+                                    {
+                                        public SourceA Owner { get; set; }
+                                    }
+
+                                    public class DestA
+                                    {
+                                        public DestB Child { get; set; }
+                                    }
+
+                                    public class DestB
+                                    {
+                                        public DestA Owner { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<SourceA, DestA>();
+                                            var downstreamMap = CreateMap<SourceB, DestB>();
+                                            downstreamMap.ReverseMap().PreserveReferences();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM022_InfiniteRecursionAnalyzer>()
+            .WithSource(testCode)
+            .ExpectDiagnostic(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule, 29, 13, "SourceA", "DestA")
+            .ExpectDiagnostic(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule, 30, 33, "SourceB", "DestB")
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM022_ShouldReportDiagnostic_WhenDownstreamCycleMapIsConstrainedOnlyAfterReverseMap()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class SourceA
+                                    {
+                                        public SourceB Child { get; set; }
+                                    }
+
+                                    public class SourceB
+                                    {
+                                        public SourceA Owner { get; set; }
+                                    }
+
+                                    public class DestA
+                                    {
+                                        public DestB Child { get; set; }
+                                    }
+
+                                    public class DestB
+                                    {
+                                        public DestA Owner { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<SourceA, DestA>();
+                                            CreateMap<SourceB, DestB>()
+                                                .ReverseMap()
+                                                .PreserveReferences();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM022_InfiniteRecursionAnalyzer>()
+            .WithSource(testCode)
+            .ExpectDiagnostic(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule, 29, 13, "SourceA", "DestA")
+            .ExpectDiagnostic(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule, 30, 13, "SourceB", "DestB")
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM022_ShouldNotReportDiagnostic_WhenReverseDownstreamCycleMapIsConstrainedAfterReverseMap()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class SourceA
+                                    {
+                                        public SourceB Child { get; set; }
+                                    }
+
+                                    public class SourceB
+                                    {
+                                        public SourceA Owner { get; set; }
+                                    }
+
+                                    public class DestA
+                                    {
+                                        public DestB Child { get; set; }
+                                    }
+
+                                    public class DestB
+                                    {
+                                        public DestA Owner { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<DestA, SourceA>();
+                                            CreateMap<SourceB, DestB>()
+                                                .ReverseMap()
+                                                .PreserveReferences();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM022_InfiniteRecursionAnalyzer>()
+            .WithSource(testCode)
+            .ExpectNoDiagnostics()
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM022_ShouldReportDiagnostic_WhenDownstreamCycleBreakerIsNotAutoMapperMethod()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class SourceA
+                                    {
+                                        public SourceB Child { get; set; }
+                                    }
+
+                                    public class SourceB
+                                    {
+                                        public SourceA Owner { get; set; }
+                                    }
+
+                                    public class DestA
+                                    {
+                                        public DestB Child { get; set; }
+                                    }
+
+                                    public class DestB
+                                    {
+                                        public DestA Owner { get; set; }
+                                    }
+
+                                    public sealed class CustomMappingExpression
+                                    {
+                                        public CustomMappingExpression PreserveReferences() => this;
+                                    }
+
+                                    public static class CustomMappingExtensions
+                                    {
+                                        public static CustomMappingExpression Custom<TSource, TDestination>(
+                                            this IMappingExpression<TSource, TDestination> mapping) =>
+                                            new();
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<SourceA, DestA>();
+                                            CreateMap<SourceB, DestB>()
+                                                .Custom()
+                                                .PreserveReferences();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM022_InfiniteRecursionAnalyzer>()
+            .WithSource(testCode)
+            .ExpectDiagnostic(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule, 41, 13, "SourceA", "DestA")
+            .ExpectDiagnostic(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule, 42, 13, "SourceB", "DestB")
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM022_ShouldReportDiagnostic_WhenOnlyOneDuplicateDownstreamMapIsConstrained()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class SourceA
+                                    {
+                                        public SourceB Child { get; set; }
+                                    }
+
+                                    public class SourceB
+                                    {
+                                        public SourceA Owner { get; set; }
+                                    }
+
+                                    public class DestA
+                                    {
+                                        public DestB Child { get; set; }
+                                    }
+
+                                    public class DestB
+                                    {
+                                        public DestA Owner { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<SourceA, DestA>();
+                                            CreateMap<SourceB, DestB>()
+                                                .PreserveReferences();
+                                            CreateMap<SourceB, DestB>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM022_InfiniteRecursionAnalyzer>()
+            .WithSource(testCode)
+            .ExpectDiagnostic(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule, 29, 13, "SourceA", "DestA")
+            .ExpectDiagnostic(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule, 32, 13, "SourceB", "DestB")
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM022_ShouldReportDiagnostic_WhenOnlyLastDuplicateDownstreamMapIsConstrained()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class SourceA
+                                    {
+                                        public SourceB Child { get; set; }
+                                    }
+
+                                    public class SourceB
+                                    {
+                                        public SourceA Owner { get; set; }
+                                    }
+
+                                    public class DestA
+                                    {
+                                        public DestB Child { get; set; }
+                                    }
+
+                                    public class DestB
+                                    {
+                                        public DestA Owner { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<SourceA, DestA>();
+                                            CreateMap<SourceB, DestB>();
+                                            CreateMap<SourceB, DestB>()
+                                                .PreserveReferences();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM022_InfiniteRecursionAnalyzer>()
+            .WithSource(testCode)
+            .ExpectDiagnostic(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule, 29, 13, "SourceA", "DestA")
+            .ExpectDiagnostic(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule, 30, 13, "SourceB", "DestB")
+            .RunAsync();
+    }
 }

--- a/tests/AutoMapperAnalyzer.Tests/Infrastructure/CodeFixVerifier.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Infrastructure/CodeFixVerifier.cs
@@ -51,7 +51,8 @@ internal static class CodeFixVerifier<TAnalyzer, TCodeFix>
     }
 
     public static async Task VerifyFixAsync(string source, DiagnosticResult[] expectedDiagnostics, string fixedSource,
-        int? codeActionIndex, int? incrementalIterations, int? fixAllIterations, DiagnosticResult[]? remainingDiagnostics = null)
+        int? codeActionIndex, int? incrementalIterations, int? fixAllIterations,
+        DiagnosticResult[]? remainingDiagnostics = null, string? batchFixedSource = null)
     {
         var test = new CSharpCodeFixTest<TAnalyzer, TCodeFix, LineEndingAgnosticVerifier>
         {
@@ -60,6 +61,11 @@ internal static class CodeFixVerifier<TAnalyzer, TCodeFix>
             ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
             CodeActionIndex = codeActionIndex
         };
+        if (batchFixedSource != null)
+        {
+            test.BatchFixedCode = batchFixedSource;
+        }
+
         ConfigureNonLocalDiagnosticSupport(test);
 
         AddAutoMapperReferences(test.TestState);


### PR DESCRIPTION
## Summary
- stop AM022 graph traversal at direction-specific downstream MaxDepth, PreserveReferences, and ConvertUsing mappings
- recognize direct same-block configuration through local mapping variables while keeping ReverseMap directionality and semantic AutoMapper ownership
- conservatively require every duplicate registration to be constrained and align multi-map code-fix fixtures
- prepare package metadata and documentation for v2.30.66

## Validation
- focused AM022 analyzer and code-fix suite: 66 passed
- Release build with warnings as errors: 0 warnings, 0 errors
- full net10.0 suite: 1,401 passed, 0 skipped, 0 failed
- AnalyzerVerifier catalog and snapshot checks: current
- targeted dotnet format verification: clean
- independent Claude Sonnet review: NO ACTIONABLE FINDINGS