### PR TITLE
fix: add ForPath remediation for performance diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+## [2.30.67] - 2026-07-15
+
+Performance `ForPath` fixer parity for AM031 and AM034–AM038.
+
+### Changed
+
+- **AM031 / AM034–AM038**: nested `ForPath` performance diagnostics now offer an executable `Ignore()` scaffold labelled for manual review.
+- **Conservative fixer boundary**: the action preserves the original nested destination selector and options parameter; caching remains `ForMember`-only because block-bodied expression trees do not compile, and convention removal remains withheld for nested paths.
+
+### Validation
+
+- Performance code-fix suite: **17** passed.
+- Clean-branch full suite: pending PR CI; local superset: **1428** passed, 0 skipped, 0 failed.
+
 ## [2.30.66] - 2026-07-13
 
 AM022 downstream cycle-breaker precision for intentional circular mappings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ Performance `ForPath` fixer parity for AM031 and AM034–AM038.
 
 ### Validation
 
-- Performance code-fix suite: **18** passed.
-- Clean-branch full suite: **1408** passed, 0 skipped, 0 failed.
+- Performance code-fix suite: **19** passed.
+- Clean-branch full suite: **1409** passed, 0 skipped, 0 failed.
 
 ## [2.30.66] - 2026-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Performance `ForPath` fixer parity for AM031 and AM034–AM038.
 ### Validation
 
 - Performance code-fix suite: **17** passed.
-- Clean-branch full suite: pending PR CI; local superset: **1428** passed, 0 skipped, 0 failed.
+- Clean-branch full suite: **1407** passed, 0 skipped, 0 failed.
 
 ## [2.30.66] - 2026-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ Performance `ForPath` fixer parity for AM031 and AM034–AM038.
 
 ### Validation
 
-- Performance code-fix suite: **19** passed.
-- Clean-branch full suite: **1409** passed, 0 skipped, 0 failed.
+- Performance code-fix suite: **20** passed.
+- Clean-branch full suite: **1410** passed, 0 skipped, 0 failed.
 
 ## [2.30.66] - 2026-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ Performance `ForPath` fixer parity for AM031 and AM034–AM038.
 
 ### Validation
 
-- Performance code-fix suite: **17** passed.
-- Clean-branch full suite: **1407** passed, 0 skipped, 0 failed.
+- Performance code-fix suite: **18** passed.
+- Clean-branch full suite: **1408** passed, 0 skipped, 0 failed.
 
 ## [2.30.66] - 2026-07-13
 

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ prevention*
 
 ---
 
-## 🎉 Latest Release: v2.30.66
+## 🎉 Latest Release: v2.30.67
 
-**AM022 downstream cycle-breaker precision**
+**Performance `ForPath` fixer parity**
 
 ✅ **Highlights**
 
-- Multi-map cycles respect downstream `MaxDepth`, `PreserveReferences`, and `ConvertUsing`.
-- Forward and reverse mapping directions remain independently analysed.
+- AM031 and AM034–AM038 now offer an executable Ignore scaffold for nested destination paths.
+- Caching stays `ForMember`-only and nested-path convention removal stays withheld.
 
 🧪 **Validation**
 
@@ -29,6 +29,7 @@ prevention*
 
 ### Recent Releases
 
+- **v2.30.67**: AM031 and AM034–AM038 add executable `ForPath` Ignore scaffolds while preserving conservative cache/removal boundaries.
 - **v2.30.66**: AM022 respects direction-aware downstream cycle breakers in multi-map recursion graphs.
 - **v2.30.65**: AM004/AM006 same-document sibling recompute for aggregates.
 - **v2.30.64**: AM001 property-token diagnostic placement + aggregate sibling recompute.
@@ -231,7 +232,7 @@ Install-Package AutoMapperAnalyzer.Analyzers
 ### Project File (For CI/CD)
 
 ```xml
-<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.66">
+<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.67">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 </PackageReference>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet Version](https://img.shields.io/nuget/v/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=NuGet)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=Downloads)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/georgepwall1991/automapper-analyser/ci.yml?style=flat-square&logo=github&label=Build)](https://github.com/georgepwall1991/automapper-analyser/actions)
-[![Tests](https://img.shields.io/badge/Tests-1408%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
+[![Tests](https://img.shields.io/badge/Tests-1409%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
 [![.NET](https://img.shields.io/badge/.NET-4.8+%20%7C%206.0+%20%7C%208.0+%20%7C%209.0+%20%7C%2010.0+-512BD4?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 [![Coverage](https://img.shields.io/codecov/c/github/georgepwall1991/automapper-analyser?style=flat-square&logo=codecov&label=Coverage)](https://codecov.io/gh/georgepwall1991/automapper-analyser)
@@ -25,7 +25,7 @@ prevention*
 
 🧪 **Validation**
 
-- Clean-branch full suite: **1408** passed, 0 skipped, 0 failed on `net10.0`.
+- Clean-branch full suite: **1409** passed, 0 skipped, 0 failed on `net10.0`.
 
 ### Recent Releases
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet Version](https://img.shields.io/nuget/v/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=NuGet)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=Downloads)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/georgepwall1991/automapper-analyser/ci.yml?style=flat-square&logo=github&label=Build)](https://github.com/georgepwall1991/automapper-analyser/actions)
-[![Tests](https://img.shields.io/badge/Tests-1409%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
+[![Tests](https://img.shields.io/badge/Tests-1410%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
 [![.NET](https://img.shields.io/badge/.NET-4.8+%20%7C%206.0+%20%7C%208.0+%20%7C%209.0+%20%7C%2010.0+-512BD4?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 [![Coverage](https://img.shields.io/codecov/c/github/georgepwall1991/automapper-analyser?style=flat-square&logo=codecov&label=Coverage)](https://codecov.io/gh/georgepwall1991/automapper-analyser)
@@ -25,7 +25,7 @@ prevention*
 
 🧪 **Validation**
 
-- Clean-branch full suite: **1409** passed, 0 skipped, 0 failed on `net10.0`.
+- Clean-branch full suite: **1410** passed, 0 skipped, 0 failed on `net10.0`.
 
 ### Recent Releases
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet Version](https://img.shields.io/nuget/v/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=NuGet)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=Downloads)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/georgepwall1991/automapper-analyser/ci.yml?style=flat-square&logo=github&label=Build)](https://github.com/georgepwall1991/automapper-analyser/actions)
-[![Tests](https://img.shields.io/badge/Tests-1401%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
+[![Tests](https://img.shields.io/badge/Tests-1407%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
 [![.NET](https://img.shields.io/badge/.NET-4.8+%20%7C%206.0+%20%7C%208.0+%20%7C%209.0+%20%7C%2010.0+-512BD4?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 [![Coverage](https://img.shields.io/codecov/c/github/georgepwall1991/automapper-analyser?style=flat-square&logo=codecov&label=Coverage)](https://codecov.io/gh/georgepwall1991/automapper-analyser)
@@ -25,7 +25,7 @@ prevention*
 
 🧪 **Validation**
 
-- Full solution test validation on `net10.0`.
+- Clean-branch full suite: **1407** passed, 0 skipped, 0 failed on `net10.0`.
 
 ### Recent Releases
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet Version](https://img.shields.io/nuget/v/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=NuGet)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=Downloads)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/georgepwall1991/automapper-analyser/ci.yml?style=flat-square&logo=github&label=Build)](https://github.com/georgepwall1991/automapper-analyser/actions)
-[![Tests](https://img.shields.io/badge/Tests-1407%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
+[![Tests](https://img.shields.io/badge/Tests-1408%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
 [![.NET](https://img.shields.io/badge/.NET-4.8+%20%7C%206.0+%20%7C%208.0+%20%7C%209.0+%20%7C%2010.0+-512BD4?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 [![Coverage](https://img.shields.io/codecov/c/github/georgepwall1991/automapper-analyser?style=flat-square&logo=codecov&label=Coverage)](https://codecov.io/gh/georgepwall1991/automapper-analyser)
@@ -25,7 +25,7 @@ prevention*
 
 🧪 **Validation**
 
-- Clean-branch full suite: **1407** passed, 0 skipped, 0 failed on `net10.0`.
+- Clean-branch full suite: **1408** passed, 0 skipped, 0 failed on `net10.0`.
 
 ### Recent Releases
 

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -306,7 +306,7 @@ Current local verification (**2026-07-15** against the **v2.30.67** release cand
 
 - Package version in `src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj`: **2.30.67**.
 - `dotnet build automapper-analyser.sln --configuration Release -warnaserror` passed: 0 warnings, 0 errors.
-- Clean-branch full suite: **1408** passed, 0 skipped, 0 failed.
+- Clean-branch full suite: **1409** passed, 0 skipped, 0 failed.
 - `dotnet run --project tools/AnalyzerVerifier/AnalyzerVerifier.csproj --configuration Release --no-build -- --check-catalog --check-snapshots` passed: rule catalog and sample diagnostics snapshot are up to date.
 - `git diff --check` passed.
 - Targeted `dotnet format whitespace` completed without diffs in the changed C# files; the repository-wide check still exposes pre-existing line-ending drift outside this slice.

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -306,7 +306,7 @@ Current local verification (**2026-07-15** against the **v2.30.67** release cand
 
 - Package version in `src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj`: **2.30.67**.
 - `dotnet build automapper-analyser.sln --configuration Release -warnaserror` passed: 0 warnings, 0 errors.
-- Clean-branch full suite: pending PR CI; local superset passed **1428** tests, 0 skipped, 0 failed.
+- Clean-branch full suite: **1407** passed, 0 skipped, 0 failed.
 - `dotnet run --project tools/AnalyzerVerifier/AnalyzerVerifier.csproj --configuration Release --no-build -- --check-catalog --check-snapshots` passed: rule catalog and sample diagnostics snapshot are up to date.
 - `git diff --check` passed.
 - Targeted `dotnet format whitespace` completed without diffs in the changed C# files; the repository-wide check still exposes pre-existing line-ending drift outside this slice.

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -1,12 +1,12 @@
 # Analyzer Health
 
-Reviewed: 2026-07-13 (AM022 downstream cycle-breaker precision prepared as **2.30.66**)
+Reviewed: 2026-07-15 (performance `ForPath` fixer parity prepared as **2.30.67**)
 
 This is a deliberately harsh health audit for the **21** implemented AutoMapper analyzer rule IDs in this repository (16 before the 2.30.62 performance split). Several rule IDs still expose multiple diagnostic descriptors, especially `AM002` and `AM022`; the scorecard rates the public rule ID as the user experiences it.
 
 Every implemented rule currently has an analyzer and a code fix provider. Scores are 1-5, where `5` means reference-quality and hard to improve, `3` means usable but meaningfully incomplete, and `1` means unreliable or underbuilt.
 
-**Ship status:** production-acceptable. **2.30.66** AM022 downstream cycle breakers; **2.30.65** AM004/AM006 sibling recompute; **2.30.64** AM001 property tokens; **2.30.63** AM022 graph-aware Ignore. Remaining min-health-3 surface is the performance fixer family (AM031/AM034–AM038). Full suite green; catalog/snapshots current.
+**Ship status:** production-acceptable. **2.30.67** performance `ForPath` Ignore scaffolds; **2.30.66** AM022 downstream cycle breakers; **2.30.65** AM004/AM006 sibling recompute; **2.30.64** AM001 property tokens. Every rule now has minimum health 4. Full suite green; catalog/snapshots current.
 
 ## Rubric
 
@@ -46,12 +46,12 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | AM030 | Invalid type converter implementation | Custom Conversions | Error | 4 | 4 | 4 | 4 | 4 | 3 | Low | Analyzer-only by design; AM001/AM020/AM021 own missing-converter mapping. Split from AM032/AM033 is clean in catalog and trust tests. Direct AM030 coverage includes empty implementation, wrong return type, missing `ResolutionContext`, and non-public `Convert` (each paired with the matching compiler error). |
 | AM032 | Type converter null handling | Custom Conversions | Warning | 4 | 4 | 4 | 5 | 4 | 4 | Low | Best-in-class null-guard detection with catalog `LikelyRewrite` trust. Recognizes `ThrowIfNull*`, switch/pattern/coalesce/conditional-access guards, and pure nullable→nullable source pass-through (`return source` / `=> source`). Residual: heuristic null-flow edge cases; the auto-fix still inserts `ArgumentNullException` (appropriate when a diagnostic fires for non-nullable destinations without intentional null handling). |
 | AM033 | Unused type converter | Custom Conversions | Info | 4 | 4 | 4 | 4 | 4 | 2 | Low | Unused-converter diagnostics now have their own Info rule ID and remain analyzer-only, and the shared converter code-fix provider no longer advertises AM033 as fixable. Usage analysis recognizes generic, instance, type-based including parenthesized/casted `typeof(...)` and simple explicit or implicit `Type` locals/fields/properties initialized from, expression-bodied to, or getter-bodied to `typeof(...)`, parameterless `Type` factory methods and local functions that expression-body or return `typeof(...)`, simple interface-typed locals/fields/properties, and DI/service-provider interface handles passed to `ConvertUsing(...)`. Product importance is intentionally lower because this is cleanup guidance. |
-| AM031 | Multiple enumeration | Performance | Warning | 4 | 4 | 3 | 5 | 4 | 4 | Low | Single-concept after 2.30.62 ID split (was multi-descriptor umbrella). Cache rewrite for ForMember multi-enum remains; ForPath analyzer-only; Scaffold trust. Residual: ForPath-safe rewrites + graph of smell breadth now lives on AM034–AM038. |
-| AM034 | Expensive operation in mapping | Performance | Warning | 4 | 4 | 3 | 5 | 4 | 4 | Low | Split from AM031 in 2.30.62. Shared analyzer/fixer; Ignore/Remove scaffold on ForMember only. Residual: heuristic smell catalog breadth. |
-| AM035 | Expensive computation in mapping | Performance | Warning | 4 | 4 | 3 | 4 | 4 | 3 | Low | Split from AM031 in 2.30.62. Narrower surface than AM034. |
-| AM036 | Sync-over-async in mapping | Performance | Warning | 4 | 4 | 3 | 5 | 4 | 4 | Low | Split from AM031 in 2.30.62. Task.Result/Wait/WaitAll/WaitAny/GetResult including source Task properties. |
-| AM037 | Complex LINQ in mapping | Performance | Warning | 4 | 4 | 3 | 4 | 4 | 3 | Low | Split from AM031 in 2.30.62. Real Enumerable/Queryable SelectMany gate. |
-| AM038 | Non-deterministic operation in mapping | Performance | Info | 4 | 4 | 3 | 5 | 4 | 3 | Low | Split from AM031 in 2.30.62. Info severity; scaffold fixes only. |
+| AM031 | Multiple enumeration | Performance | Warning | 4 | 4 | 4 | 5 | 4 | 4 | Low | Single-concept after 2.30.62 ID split (was multi-descriptor umbrella). **2.30.67**: ForMember keeps cache/Remove/Ignore actions; ForPath now offers an executable Ignore scaffold while cache and convention removal remain conservatively withheld. Scaffold trust. |
+| AM034 | Expensive operation in mapping | Performance | Warning | 4 | 4 | 4 | 5 | 4 | 4 | Low | Split from AM031 in 2.30.62. **2.30.67**: shared fixer offers Ignore on ForMember and ForPath, plus convention-safe Remove on ForMember. Residual: heuristic smell catalog breadth. |
+| AM035 | Expensive computation in mapping | Performance | Warning | 4 | 4 | 4 | 4 | 4 | 3 | Low | Split from AM031 in 2.30.62. Shared ForPath Ignore scaffold; narrower surface than AM034. |
+| AM036 | Sync-over-async in mapping | Performance | Warning | 4 | 4 | 4 | 5 | 4 | 4 | Low | Split from AM031 in 2.30.62. Task.Result/Wait/WaitAll/WaitAny/GetResult including source Task properties; shared ForPath Ignore scaffold. |
+| AM037 | Complex LINQ in mapping | Performance | Warning | 4 | 4 | 4 | 4 | 4 | 3 | Low | Split from AM031 in 2.30.62. Real Enumerable/Queryable SelectMany gate; shared ForPath Ignore scaffold. |
+| AM038 | Non-deterministic operation in mapping | Performance | Info | 4 | 4 | 4 | 5 | 4 | 3 | Low | Split from AM031 in 2.30.62. Info severity; ForMember/ForPath scaffold fixes. |
 | AM041 | Duplicate mapping registration | Configuration | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | Compilation-wide registry now peels parentheses in `GetReverseMapInvocation`, so `(CreateMap<S,D>()).ReverseMap()` registers reverse duplicates. SafeRewrite removal withholds chained/nested/arg-position config. Remaining risk is nuanced intentional override ordering. |
 | AM050 | Redundant MapFrom configuration | Configuration | Info | 4 | 4 | 4 | 4 | 4 | 2 | Low | Safe cleanup rule now requires proven source/destination type compatibility including nullable reference annotations, string literal and `nameof(...)`/constant `ForMember` members resolved through the effective mapping direction including `ReverseMap()` segments with direct reverse-map `nameof(...)`/const analyzer and code-fix coverage, parenthesized/typed lambda parameter shapes — `o.MapFrom((s) => s.Name)` and `o.MapFrom((Source s) => s.Name)` — with `ForMember`/`ForPath` code-fix parity, and parenthesized member bodies such as `s => (s.Name)`/`d => (d.Name)` alongside the simple `s => s.Name` shape. Multi-parameter parenthesized lambdas are intentionally ignored so AutoMapper's `(src, ctx) => ...` overload stays quiet. The automatic `ForMember`/`ForPath` removal code fix now withholds when the options lambda carries sibling configuration (`Condition`, `NullSubstitute`, `PreCondition`, `UseDestinationValue`, `Ignore`, etc.) so policy overrides cannot be silently dropped; simple-MapFrom shapes still receive the automatic action. Product importance remains low. |
 
@@ -71,21 +71,20 @@ Use this table as the hardening queue. Ranking = **Importance × (5 − min(Anal
 
 | Rank | Rule | Signal | Residual (evidence-backed) | Likely score move if closed |
 | --- | --- | --- | --- | --- |
-| 1 | **AM031 / AM034–AM038** | Fix=3 | Shared ForPath analyzer-only + Scaffold policy after ID split. Further smell breadth is diminishing returns. | Fix 3→4 only with ForPath-safe rewrites |
-| 2 | **AM001** | gap=4, min=4 | Property-token placement shipped 2.30.64. Residual: advanced conversion modelling only with user repros. | — |
-| 3 | **AM011** | gap=5, min=4 | Residual: primary single-property path still scaffolds defaults when fuzzy fails. | Fix stays 4 until less scaffold-heavy without lying |
-| 4 | **AM022** | gap=4, min=4 | Downstream global cycle breakers shipped 2.30.66. Member-level graph/dataflow refinements remain opportunistic. | FP 4→5 needs evidence-backed dataflow precision |
+| 1 | **AM011** | gap=5, min=4 | Primary single-property path still scaffolds defaults when fuzzy fails. | Fix stays 4 until less scaffold-heavy without lying |
+| 2 | **AM032** | gap=4, min=4 | Classic net48-safe if-throw; not destination-aware. | Fix 4→5 if destination-aware policies are safe |
+| 3 | **AM022** | gap=4, min=4 | Downstream global cycle breakers shipped 2.30.66. Member-level graph/dataflow refinements remain opportunistic. | FP 4→5 needs evidence-backed dataflow precision |
+| 4 | **AM001** | gap=4, min=4 | Property-token placement shipped 2.30.64. Residual: advanced conversion modelling only with user repros. | — |
 | 5 | **AM002** | gap=5, min=4 | Advanced generic/nullability-flow only — wait for real user FP/FN. | — until evidence |
-| 6 | **AM032** | gap=4, min=4 | Classic net48-safe if-throw; not destination-aware. | Fix 4→5 if destination-aware policies are safe |
-| 7 | **AM020 / AM021 / AM003** | gap=5/4 | Custom-collection / constructor-body insert structural limits. | Opportunistic |
-| 8 | **AM041 / AM050** | gap=4/2 | SafeRewrite nuance / low Importance. | Low ROI |
-| 9 | **AM033 / AM005 / AM030** | gap=2–3 | Importance-limited. | Product priority only |
+| 6 | **AM020 / AM021 / AM003** | gap=5/4 | Custom-collection / constructor-body insert structural limits. | Opportunistic |
+| 7 | **AM041 / AM050** | gap=4/2 | SafeRewrite nuance / low Importance. | Low ROI |
+| 8 | **AM033 / AM005 / AM030** | gap=2–3 | Importance-limited. | Product priority only |
 
 **Recommended next hardening batch:**
 
-1. **AM031/AM034–AM038 ForPath-safe rewrites** (Fix still 3)
+1. **AM011 less scaffold-heavy single-property fixes**
 2. **AM032 destination-aware null fix**
-3. **AM011 less scaffold-heavy single-property fixes**
+3. **AM022 member-level graph/dataflow precision only with a concrete repro**
 
 Do **not** open advanced AM001/AM002 conversion/nullability modelling without a filed false-positive/false-negative repro.
 
@@ -109,7 +108,7 @@ Active queue (also summarized in Working Base). Prefer one focus per hardening b
 - _AM022 graph-aware Ignore — resolved in 2.30.63._ Multi-type cycle edges offered for Ignore.
 - _AM022 downstream cycle-breaker precision — resolved in 2.30.66._ Multi-map traversal honours direction-specific `MaxDepth`, `PreserveReferences`, and `ConvertUsing`; False Positives 3→4.
 - _AM004 / AM006 same-document sibling recompute — resolved in 2.30.65._
-- **AM001 property-token diagnostic placement.** Still reports on `CreateMap` invocation span; data-integrity rules already land on property tokens.
+- _AM031 / AM034–AM038 `ForPath` fixer parity — resolved in 2.30.67._ Nested paths receive an executable Ignore scaffold; caching and convention removal remain safely withheld.
 - **AM032 destination-aware null fixes.** Emit stays classic net48 `if-throw`; not destination-nullability-aware. Analyzer ThrowIfNull* recognition is already strong.
 
 Resolved historical P2 (keep for audit trail):
@@ -122,7 +121,8 @@ Resolved historical P2 (keep for audit trail):
 - _AM050 sibling-config direct coverage — resolved in 2.30.26._
 - _AM041 `ForPath` chained-config test — resolved in 2.30.27._
 - _AM031 remove-`ForMember` safety — resolved in 2.30.28._
-- _AM004 / AM005 / AM006 / AM011 diagnostic placement — resolved in 2.30.32_ (AM001 placement still open above).
+- _AM004 / AM005 / AM006 / AM011 diagnostic placement — resolved in 2.30.32._
+- _AM001 property-token diagnostic placement — resolved in 2.30.64._
 - _AM011 honest Map-all / Scaffold-all — resolved in 2.30.59._
 - _AM001 Convert-all / Ignore-all multi-property UX — resolved in 2.30.60._
 - _AM022 MaxDepth title/order honesty — resolved in 2.30.59–2.30.61._
@@ -148,6 +148,12 @@ Still open (do not start without a repro or explicit product decision):
 - **AM022 / AM031 dataflow-grade heuristics.** High effort, diminishing returns until a concrete false-positive pattern is filed (prefer P2 ID-split / graph-Ignore first).
 - **AM020 constructor-body CreateMap insert.** Structural host limit; catalog `LikelyRewrite` already honest.
 
+
+## Reanalysis Changelog (2026-07-15 → 2.30.67 performance `ForPath` fixer parity)
+
+| Rules | Finding | Change | Score impact |
+| --- | --- | --- | --- |
+| AM031 / AM034–AM038 | Nested `ForPath` diagnostics had no executable remediation even though AutoMapper path options support Ignore | Preserve the original nested selector and options parameter while replacing only `MapFrom` with an Ignore scaffold; cache and Remove stay ForMember-only | Fix Strategy 3→4 |
 
 ## Reanalysis Changelog (2026-07-13 → 2.30.66 AM022 downstream cycle breakers)
 
@@ -219,7 +225,7 @@ Full rule+fixer reanalysis driven by four parallel subagent audits (Type Safety,
 | AM030 | ~5 direct tests in shared 146-test bucket. | Tests 4→3; tightened Notes. | AM030 Tests −1 |
 | AM032 | Null-flow heuristic + throw-only fix policy risk. | False Positives 4→3; tightened Notes. | AM032 False Positives −1 |
 
-## Fixer Trust Summary (v2.30.66)
+## Fixer Trust Summary (v2.30.67)
 
 | Rule | Fixable? | Catalog trust | Notes |
 | --- | --- | --- | --- |
@@ -233,8 +239,8 @@ Full rule+fixer reanalysis driven by four parallel subagent audits (Type Safety,
 | AM022 | Yes | Scaffold | `MaxDepth(2)` + graph-aware Ignore on cycle edges (manual review) |
 | AM030, AM033 | No | NoFix | Analyzer-only by design |
 | AM032 | Yes | LikelyRewrite | Inserts `ArgumentNullException` guard |
-| AM031 | Yes | Scaffold | Multiple enumeration; cache rewrite + Ignore/Remove on ForMember; ForPath analyzer-only |
-| AM034–AM038 | Partial | Scaffold | Shared performance fixer; ForMember Ignore/Remove scaffolds; ForPath analyzer-only |
+| AM031 | Yes | Scaffold | Multiple enumeration; cache rewrite + Ignore/Remove on ForMember; Ignore scaffold on ForPath |
+| AM034–AM038 | Yes | Scaffold | Shared performance fixer; ForMember Ignore/Remove scaffolds; ForPath Ignore scaffold |
 | AM041, AM050 | Yes | SafeRewrite | Conservative removal/withhold for chained config |
 
 ## Cross-Cutting Findings
@@ -264,7 +270,7 @@ Full rule+fixer reanalysis driven by four parallel subagent audits (Type Safety,
 - AM033 also treats any `ConvertUsing(...)` argument whose resolved type is the interface `ITypeConverter<TSource, TDestination>` itself as covering every declared concrete implementation of that interface pair. That closes the DI/service-provider false-positive class — for example `public TestProfile(ITypeConverter<string, DateTime> converter)` or `services.Resolve<ITypeConverter<string, DateTime>>()` — while declared converters whose `<TSource, TDestination>` pair is not referenced by any `ConvertUsing` call still report.
 - AM032 converter null-handling detection recognizes `ArgumentNullException.ThrowIfNull(source)`, `ArgumentException.ThrowIfNullOrEmpty(source)`, and `ArgumentException.ThrowIfNullOrWhiteSpace(source)` as explicit null guards on the converter's source parameter, closing the false-positive class where modern guard clauses replaced the older `if (source == null) throw ...` shape. Recognition also covers named-argument shapes such as `ThrowIfNull(argument: source)` and `ThrowIfNull(paramName: ..., argument: source)` so swapping or omitting optional labels does not re-introduce the false positive. Conditional access now suppresses only when it participates in a null guard such as `source?.Length is null`, `source?.Length is > 0`, `source?.Trim() == null`, `string.IsNullOrWhiteSpace(source?.Trim())`, `!(source?.Length > 0)`, `(source?.Length > 0) == false`, `(source?.Length > 0) is false`, or `(source?.Length).HasValue`, binds a pattern variable then checks that variable such as `source?.Length is var length && length > 0`, is stored in an initialized, split-assigned, or boolean guard local that is then null-guarded, `.HasValue`-guarded, relationally guarded before use, returned through a ternary fallback such as `trimmed is null ? string.Empty : trimmed`, or returned as a nullable-destination fallback after a positive local guard, feeds a null-tolerant TryParse fallback or success branch whose null-source path is source-free, passes conditional access to nullable parse provider/style arguments, guards a returning, throwing, ternary, switch expression, or switch statement path where null sources take a fallback path that does not use `source`, guards assignment to a fallback local that is returned after the branch including explicit `else` fallback assignments and harmless source-free statements before the fallback return, is paired with an explicit source-free fallback such as `source?.Trim() ?? string.Empty`, is coalesced through a simple local initialized from conditional access only when the fallback path is source-free, non-null, and the local has not been reassigned before the guard/fallback, is returned directly to a nullable destination, or is returned through a simple local initialized from the conditional access, including casted returns, branch returns, chained null-conditionals, and parenthesized local returns; guarded switch null arms/cases may fall through to later safe fallbacks when their `when` clauses are false, switch pattern-variable `when` guards such as `var length when length > 0` or `var length when length is null` are evaluated for null input in both switch expressions and switch statements, switch sections may break to later safe fallback returns, and null-excluding switch statements may fall through to later safe fallback returns. Standalone probes such as `_ = source?.Length` followed by unsafe source use, unsafe invocation or constructor arguments such as `DateTime.Parse(source?.Trim())`, `int.Parse(source?.Trim())`, `DateTime.Parse(trimmed)`, `new Uri(source?.Trim())`, or target-typed `new(source?.Trim())` in `Uri` converters, local guards that run after unsafe source use, member dereferences on maybe-null locals such as `trimmed.Length`, nested helper-only guards, coalesce fallbacks such as `source?.Trim() ?? source.Trim()`, `source?.Trim() ?? null`, or `source?.Trim() ?? null!`, coalesced guards whose null fallback enters an unsafe branch such as `(source?.Length ?? 1) > 0`, conditional fallback returns that can still fall through to unsafe source use, lifted inequality guards such as `source?.Length != 0 ? ... : ...`, conditional-access locals overwritten with unsafe source dereferences, nested local-function returns that do not represent the converter's return value, switch null arms/cases that still parse `source`, and reversed branches/null-comparison branches whose null path still parses `source` still trigger AM032.
 - AM032 named-argument guard recognition now applies across the `ThrowIfNull*` family, including `ArgumentException.ThrowIfNullOrEmpty(paramName: ..., argument: source)` and `ArgumentException.ThrowIfNullOrWhiteSpace(paramName: ..., argument: source)`.
-- AM031 now analyzes `ForPath(... MapFrom(...))` in addition to `ForMember` and reports nested destination labels such as `Stats.Total`; `ForPath` diagnostics intentionally withhold automatic fixes because the cache rewrite requires a statement-bodied lambda.
+- AM031 analyzes `ForPath(... MapFrom(...))` in addition to `ForMember` and reports nested destination labels such as `Stats.Total`; `ForPath` diagnostics offer an executable Ignore scaffold while cache and convention-removal actions remain withheld because expression-tree statement lambdas do not compile and nested-path convention equivalence is not proven.
 - AM031 multiple-enumeration tracking now also recognizes `Min`, `Max`, `Aggregate`, `LongCount`, `Single`, `SingleOrDefault`, `ToHashSet`, `ToDictionary`, and `ToLookup` as terminal enumeration calls, so shapes such as `src.Numbers.Min() + src.Numbers.Max()` or `src.Numbers.Single() + src.Numbers.ToHashSet().Count` now report instead of going silent. The whole enumeration-tracking set is gated on `System.Linq.Enumerable`/`System.Linq.Queryable` containing types so non-LINQ namesakes like `Math.Min`/`Math.Max` no longer false-positive, and lazy/intermediate operators (`Where`, `Select`, `OrderBy`, `GroupBy`, `Distinct`, …) intentionally stay off the terminal list.
 - AM031 complex `SelectMany` operation diagnostics are now gated on `System.Linq.Enumerable`/`System.Linq.Queryable` containing types, so user-defined `SelectMany` namesakes with nested selector invocations no longer false-positive.
 - AM031 expensive-computation detection now requires real `System.Linq.Enumerable.Range(...)`, so project-local `Enumerable.Range(...)` namesakes stay quiet.
@@ -296,17 +302,17 @@ Full rule+fixer reanalysis driven by four parallel subagent audits (Type Safety,
 
 Architecture-style coverage currently comes from analyzer/fixer tests, conflict ownership tests, helper tests, sample projects, documentation, the checked-in `RuleCatalog`, generated trust artifacts, package smoke tests, and the deterministic `tools/AnalyzerVerifier` checks.
 
-Current local verification (**2026-07-13** against the **v2.30.66** release candidate):
+Current local verification (**2026-07-15** against the **v2.30.67** release candidate):
 
-- Package version in `src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj`: **2.30.66**.
+- Package version in `src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj`: **2.30.67**.
 - `dotnet build automapper-analyser.sln --configuration Release -warnaserror` passed: 0 warnings, 0 errors.
-- `dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj --configuration Release --no-build --framework net10.0` passed: **1401** passed, 0 skipped, 0 failed (~15 s).
+- Clean-branch full suite: pending PR CI; local superset passed **1428** tests, 0 skipped, 0 failed.
 - `dotnet run --project tools/AnalyzerVerifier/AnalyzerVerifier.csproj --configuration Release --no-build -- --check-catalog --check-snapshots` passed: rule catalog and sample diagnostics snapshot are up to date.
 - `git diff --check` passed.
 - Targeted `dotnet format whitespace` completed without diffs in the changed C# files; the repository-wide check still exposes pre-existing line-ending drift outside this slice.
 - Sample project emits AM0xx when analyzers run (`-p:RunAnalyzersDuringBuild=true`); local untracked `Directory.Build.props` (if present) may skip analyzers during CLI builds — unit tests + AnalyzerVerifier remain the verification source of truth.
 - Approximate list-tests name hits (not exclusive filters; for trend only): AM001 57, AM002 83, AM003 61, AM004 87, AM005 34, AM006 43, AM011 45, AM020 97, AM021 64, AM022 53, AM030/32/33 bucket 152, AM031 292, AM041 35, AM050 48, RuleCatalog 10.
-- Release metadata is synchronized for `v2.30.66`; tag/publication follows the merged PR.
+- Release metadata is synchronized for `v2.30.67`; tag/publication follows the merged PR.
 - Historical baseline (2026-07-06 @ `b138fa8` / v2.30.55): **1352** tests green — superseded; do not use for planning.
 - The trust-first pass removed active skipped tests, added drift validation, and moved intentional analyzer-test warnings into an explicit test-project warning baseline.
 - `/usr/local/share/dotnet/dotnet --list-runtimes` shows only .NET 10 runtimes in this local environment, so broader multi-TFM runtime verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -306,7 +306,7 @@ Current local verification (**2026-07-15** against the **v2.30.67** release cand
 
 - Package version in `src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj`: **2.30.67**.
 - `dotnet build automapper-analyser.sln --configuration Release -warnaserror` passed: 0 warnings, 0 errors.
-- Clean-branch full suite: **1407** passed, 0 skipped, 0 failed.
+- Clean-branch full suite: **1408** passed, 0 skipped, 0 failed.
 - `dotnet run --project tools/AnalyzerVerifier/AnalyzerVerifier.csproj --configuration Release --no-build -- --check-catalog --check-snapshots` passed: rule catalog and sample diagnostics snapshot are up to date.
 - `git diff --check` passed.
 - Targeted `dotnet format whitespace` completed without diffs in the changed C# files; the repository-wide check still exposes pre-existing line-ending drift outside this slice.

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -306,7 +306,7 @@ Current local verification (**2026-07-15** against the **v2.30.67** release cand
 
 - Package version in `src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj`: **2.30.67**.
 - `dotnet build automapper-analyser.sln --configuration Release -warnaserror` passed: 0 warnings, 0 errors.
-- Clean-branch full suite: **1409** passed, 0 skipped, 0 failed.
+- Clean-branch full suite: **1410** passed, 0 skipped, 0 failed.
 - `dotnet run --project tools/AnalyzerVerifier/AnalyzerVerifier.csproj --configuration Release --no-build -- --check-catalog --check-snapshots` passed: rule catalog and sample diagnostics snapshot are up to date.
 - `git diff --check` passed.
 - Targeted `dotnet format whitespace` completed without diffs in the changed C# files; the repository-wide check still exposes pre-existing line-ending drift outside this slice.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -725,7 +725,7 @@ dotnet pack --configuration Release
 
 # Test package locally
 cd test-install/NetCoreTest
-dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.66-local
+dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.67-local
 ```
 
 ---
@@ -909,4 +909,4 @@ dotnet build
 
 **Last Updated**: 2026-05-14
 **Maintainer**: George Wall
-**Version**: 2.30.66
+**Version**: 2.30.67

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -112,8 +112,8 @@ The AutoMapper Roslyn Analyzer project uses GitHub Actions for continuous integr
 ### Package Versioning
 
 - **Format**: Major.Minor.Patch (SemVer)
-- **Current**: 2.30.66
-- **Pre-release**: 2.30.66-preview, 2.30.66-beta
+- **Current**: 2.30.67
+- **Pre-release**: 2.30.67-preview, 2.30.67-beta
 
 ## 🔧 Configuration
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -43,7 +43,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.66">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.67">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -67,7 +67,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.66">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.67">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -86,7 +86,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="14.0.0" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.66">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.67">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -218,7 +218,7 @@ public class Destination
 
 2. **Verify Package Installation**
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.66">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.67">
      <PrivateAssets>all</PrivateAssets>
      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -280,4 +280,4 @@ This guide ensures smooth installation and usage across all supported .NET frame
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.66
+**Version**: 2.30.67

--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -1248,7 +1248,7 @@ CreateMap<Source, Destination>()
 
 **Code Fix 1: Cache Collection Enumeration**
 
-AM031 offers this executable rewrite only for `ForMember` mappings when the repeated enumeration is rooted in the source mapping parameter, including nested source paths such as `src.Customer.Orders`. Captured fields, injected services, other closure values, and `ForPath` diagnostics stay analyzer-only because the analyzer cannot safely decide where those values should be cached or because the generated statement lambda would not compile for expression-tree `ForPath.MapFrom`.
+AM031 offers this executable cache rewrite only for `ForMember` mappings when the repeated enumeration is rooted in the source mapping parameter, including nested source paths such as `src.Customer.Orders`. Captured fields, injected services, and other closure values do not receive the cache action. `ForPath` diagnostics instead offer `ForPath(..., opt => opt.Ignore())` as an executable scaffold labelled for manual review; caching remains withheld because a generated statement lambda would not compile for expression-tree `ForPath.MapFrom`.
 
 ```csharp
 CreateMap<Source, Destination>()
@@ -1303,7 +1303,7 @@ public class MappingProfile : Profile
 
 #### Solutions
 
-Prefer precomputing outside the map. Automatic actions on `ForMember` are scaffold-level: Ignore (manual review) or Remove when the MapFrom is a direct convention-equivalent member pass-through. `ForPath` is analyzer-only.
+Prefer precomputing outside the map. Automatic actions on `ForMember` are scaffold-level: Ignore (manual review) or Remove when the MapFrom is a direct convention-equivalent member pass-through. `ForPath` offers an executable Ignore scaffold while preserving the nested destination selector; caching and convention removal remain withheld.
 
 #### Detected Patterns (summary)
 
@@ -1602,7 +1602,7 @@ using System.Diagnostics.CodeAnalysis;
 
 1. **Check package reference**:
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.66">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.67">
        <PrivateAssets>all</PrivateAssets>
        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -1641,5 +1641,5 @@ If analyzer slows down builds:
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.66
+**Version**: 2.30.67
 **Maintainer**: George Wall

--- a/docs/RULE_CATALOG.md
+++ b/docs/RULE_CATALOG.md
@@ -2,7 +2,7 @@
 
 This file is generated from `RuleCatalog`.
 
-Package version: `2.30.66`
+Package version: `2.30.67`
 
 | Rule ID | Descriptor Title | Severity | Category | Analyzer | Code Fix | Trust | Sample | Docs |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,3 +1,15 @@
+## Release 2.30.67
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
+### Removed Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
 ## Release 2.30.66
 
 ### New Rules

--- a/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
+++ b/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
@@ -17,7 +17,7 @@
         <!-- Fallback for local builds: 2.0.YYYYMMDD-local -->
         <MajorVersion>2</MajorVersion>
         <MinorVersion>30</MinorVersion>
-        <PatchVersion>66</PatchVersion>
+        <PatchVersion>67</PatchVersion>
         <BuildNumber Condition="'$(BuildNumber)' == ''"
         >$([System.DateTime]::Now.ToString('yyyyMMdd'))
         </BuildNumber
@@ -32,9 +32,9 @@
         <RepositoryUrl>https://github.com/georgepwall1991/automapper-analyser</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-                <PackageReleaseNotes>Version 2.30.66 - AM022 downstream cycle-breaker precision
-- Multi-map recursion traversal respects downstream MaxDepth, PreserveReferences, and ConvertUsing
-- Cycle-breaker ownership is semantic, direction-aware, and conservative for duplicate registrations
+                <PackageReleaseNotes>Version 2.30.67 - Performance ForPath fixer parity
+- AM031 and AM034-AM038 offer an executable ForPath Ignore scaffold
+- Nested destination selectors are preserved while caching and removal remain ForMember-only
 </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>

--- a/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningCodeFixProvider.cs
@@ -379,7 +379,7 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
         return SyntaxFactory.InvocationExpression(
             SyntaxFactory.MemberAccessExpression(
                 SyntaxKind.SimpleMemberAccessExpression,
-                SyntaxFactory.IdentifierName(optionsParameter.ValueText),
+                SyntaxFactory.IdentifierName(optionsParameter),
                 SyntaxFactory.IdentifierName("Ignore")));
     }
 

--- a/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningCodeFixProvider.cs
@@ -103,6 +103,16 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
 
         if (!IsForMemberInvocation(destinationConfigurationInvocation))
         {
+            if (GetPreviousInvocation(destinationConfigurationInvocation) != null)
+            {
+                RegisterIgnoreMappingFix(
+                    context,
+                    operationContext.Root,
+                    destinationConfigurationInvocation,
+                    propertyName!,
+                    relatedDiagnostics);
+            }
+
             return;
         }
 
@@ -129,7 +139,7 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
         // Ignore/Remove rewrite the ForMember link; only register when the peel target exists
         // so the lightbulb never advertises a silent no-op.
         // Best-first order: Cache (above) → Remove convention ForMember → Ignore last.
-        if (GetInvocationWithoutForMember(destinationConfigurationInvocation) != null)
+        if (GetPreviousInvocation(destinationConfigurationInvocation) != null)
         {
             if (await CanUseConventionMappingAsync(
                     context.Document,
@@ -172,7 +182,7 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
     private void RegisterIgnoreMappingFix(
         CodeFixContext context,
         SyntaxNode root,
-        InvocationExpressionSyntax forMemberInvocation,
+        InvocationExpressionSyntax destinationConfigurationInvocation,
         string propertyName,
         ImmutableArray<Diagnostic> diagnostics)
     {
@@ -182,7 +192,7 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
                 cancellationToken => ReplaceWithIgnoreAsync(
                     context.Document,
                     root,
-                    forMemberInvocation,
+                    destinationConfigurationInvocation,
                     propertyName,
                     cancellationToken),
                 $"AM031_Ignore_{propertyName}"),
@@ -307,22 +317,70 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
     private Task<Document> ReplaceWithIgnoreAsync(
         Document document,
         SyntaxNode root,
-        InvocationExpressionSyntax forMemberInvocation,
+        InvocationExpressionSyntax destinationConfigurationInvocation,
         string propertyName,
         CancellationToken cancellationToken)
     {
-        InvocationExpressionSyntax? previousInvocation = GetInvocationWithoutForMember(forMemberInvocation);
+        InvocationExpressionSyntax? previousInvocation = GetPreviousInvocation(destinationConfigurationInvocation);
         if (previousInvocation == null)
         {
             return Task.FromResult(document);
         }
 
-        InvocationExpressionSyntax ignoreInvocation =
-            CodeFixSyntaxHelper.CreateForMemberWithIgnore(previousInvocation, propertyName)
-                .WithTriviaFrom(forMemberInvocation);
+        InvocationExpressionSyntax? ignoreInvocation = IsForMemberInvocation(destinationConfigurationInvocation)
+            ? CodeFixSyntaxHelper.CreateForMemberWithIgnore(previousInvocation, propertyName)
+            : ReplaceOptionsWithIgnore(destinationConfigurationInvocation);
 
-        SyntaxNode newRoot = root.ReplaceNode(forMemberInvocation, ignoreInvocation);
+        if (ignoreInvocation == null)
+        {
+            return Task.FromResult(document);
+        }
+
+        ignoreInvocation = ignoreInvocation.WithTriviaFrom(destinationConfigurationInvocation);
+
+        SyntaxNode newRoot = root.ReplaceNode(destinationConfigurationInvocation, ignoreInvocation);
         return Task.FromResult(document.WithSyntaxRoot(newRoot));
+    }
+
+    private static InvocationExpressionSyntax? ReplaceOptionsWithIgnore(
+        InvocationExpressionSyntax destinationConfigurationInvocation)
+    {
+        if (destinationConfigurationInvocation.ArgumentList.Arguments.Count < 2)
+        {
+            return null;
+        }
+
+        ArgumentSyntax optionsArgument = destinationConfigurationInvocation.ArgumentList.Arguments[1];
+        LambdaExpressionSyntax? ignoreLambda = optionsArgument.Expression switch
+        {
+            SimpleLambdaExpressionSyntax simpleLambda => simpleLambda.WithBody(
+                CreateIgnoreInvocation(simpleLambda.Parameter.Identifier)),
+            ParenthesizedLambdaExpressionSyntax { ParameterList.Parameters.Count: 1 } parenthesizedLambda =>
+                parenthesizedLambda.WithBody(
+                    CreateIgnoreInvocation(parenthesizedLambda.ParameterList.Parameters[0].Identifier)),
+            _ => null
+        };
+
+        if (ignoreLambda == null)
+        {
+            return null;
+        }
+
+        ArgumentSyntax ignoreArgument = optionsArgument.WithExpression(
+            ignoreLambda.WithTriviaFrom(optionsArgument.Expression));
+
+        return destinationConfigurationInvocation.WithArgumentList(
+            destinationConfigurationInvocation.ArgumentList.WithArguments(
+                destinationConfigurationInvocation.ArgumentList.Arguments.Replace(optionsArgument, ignoreArgument)));
+    }
+
+    private static InvocationExpressionSyntax CreateIgnoreInvocation(SyntaxToken optionsParameter)
+    {
+        return SyntaxFactory.InvocationExpression(
+            SyntaxFactory.MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                SyntaxFactory.IdentifierName(optionsParameter.ValueText),
+                SyntaxFactory.IdentifierName("Ignore")));
     }
 
     private Task<Document> RemoveForMemberAsync(
@@ -331,7 +389,7 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
         InvocationExpressionSyntax forMemberInvocation,
         CancellationToken cancellationToken)
     {
-        InvocationExpressionSyntax? previousInvocation = GetInvocationWithoutForMember(forMemberInvocation);
+        InvocationExpressionSyntax? previousInvocation = GetPreviousInvocation(forMemberInvocation);
         if (previousInvocation == null)
         {
             return Task.FromResult(document);
@@ -398,9 +456,10 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
         return Task.FromResult(document.WithSyntaxRoot(newRoot));
     }
 
-    private static InvocationExpressionSyntax? GetInvocationWithoutForMember(InvocationExpressionSyntax forMemberToRemove)
+    private static InvocationExpressionSyntax? GetPreviousInvocation(
+        InvocationExpressionSyntax destinationConfigurationInvocation)
     {
-        return forMemberToRemove.Expression is MemberAccessExpressionSyntax
+        return destinationConfigurationInvocation.Expression is MemberAccessExpressionSyntax
         {
             Expression: InvocationExpressionSyntax previousInvocation
         }

--- a/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Performance/AM031_PerformanceWarningCodeFixProvider.cs
@@ -103,14 +103,20 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
 
         if (!IsForMemberInvocation(destinationConfigurationInvocation))
         {
-            if (GetPreviousInvocation(destinationConfigurationInvocation) != null)
+            InvocationExpressionSyntax? ignoreInvocation =
+                GetPreviousInvocation(destinationConfigurationInvocation) != null
+                    ? ReplaceOptionsWithIgnore(destinationConfigurationInvocation)
+                    : null;
+
+            if (ignoreInvocation != null)
             {
                 RegisterIgnoreMappingFix(
                     context,
                     operationContext.Root,
                     destinationConfigurationInvocation,
                     propertyName!,
-                    relatedDiagnostics);
+                    relatedDiagnostics,
+                    ignoreInvocation);
             }
 
             return;
@@ -184,7 +190,8 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
         SyntaxNode root,
         InvocationExpressionSyntax destinationConfigurationInvocation,
         string propertyName,
-        ImmutableArray<Diagnostic> diagnostics)
+        ImmutableArray<Diagnostic> diagnostics,
+        InvocationExpressionSyntax? replacementInvocation = null)
     {
         context.RegisterCodeFix(
             CodeAction.Create(
@@ -194,6 +201,7 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
                     root,
                     destinationConfigurationInvocation,
                     propertyName,
+                    replacementInvocation,
                     cancellationToken),
                 $"AM031_Ignore_{propertyName}"),
             diagnostics);
@@ -319,6 +327,7 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
         SyntaxNode root,
         InvocationExpressionSyntax destinationConfigurationInvocation,
         string propertyName,
+        InvocationExpressionSyntax? replacementInvocation,
         CancellationToken cancellationToken)
     {
         InvocationExpressionSyntax? previousInvocation = GetPreviousInvocation(destinationConfigurationInvocation);
@@ -327,14 +336,8 @@ public class AM031_PerformanceWarningCodeFixProvider : AutoMapperCodeFixProvider
             return Task.FromResult(document);
         }
 
-        InvocationExpressionSyntax? ignoreInvocation = IsForMemberInvocation(destinationConfigurationInvocation)
-            ? CodeFixSyntaxHelper.CreateForMemberWithIgnore(previousInvocation, propertyName)
-            : ReplaceOptionsWithIgnore(destinationConfigurationInvocation);
-
-        if (ignoreInvocation == null)
-        {
-            return Task.FromResult(document);
-        }
+        InvocationExpressionSyntax ignoreInvocation = replacementInvocation
+            ?? CodeFixSyntaxHelper.CreateForMemberWithIgnore(previousInvocation, propertyName);
 
         ignoreInvocation = ignoreInvocation.WithTriviaFrom(destinationConfigurationInvocation);
 

--- a/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
@@ -130,7 +130,7 @@ public static class RuleCatalog
     /// <summary>
     ///     Current package version used by docs/package drift tests.
     /// </summary>
-    public const string CurrentPackageVersion = "2.30.66";
+    public const string CurrentPackageVersion = "2.30.67";
 
     /// <summary>
     ///     Implemented rules, grouped by public diagnostic ID.

--- a/tests/AutoMapperAnalyzer.Tests/Performance/AM031_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Performance/AM031_CodeFixTests.cs
@@ -570,7 +570,6 @@ public class AM031_CodeFixTests
             StringComparison.Ordinal);
     }
 
-
     [Fact]
     public async Task PerformanceFixer_ShouldPreserveEscapedForPathOptionsParameter()
     {
@@ -617,6 +616,60 @@ public class AM031_CodeFixTests
 
         Assert.Contains(
             ".ForPath(dest => dest.Stats.Score, @event => @event.Ignore())",
+            updatedCode,
+            StringComparison.Ordinal);
+
+        Document updatedDocument = CreateDocument(updatedCode);
+        Compilation compilation = (await updatedDocument.Project.GetCompilationAsync())!;
+        Assert.Empty(compilation.GetDiagnostics().Where(item => item.Severity == DiagnosticSeverity.Error));
+    }
+
+    [Fact]
+    public async Task PerformanceFixer_ShouldPreserveParenthesizedForPathOptionsParameter()
+    {
+        const string source = """
+                              using AutoMapper;
+
+                              namespace TestNamespace
+                              {
+                                  public class Source
+                                  {
+                                      public int Score { get; set; }
+                                  }
+
+                                  public class StatsDto
+                                  {
+                                      public int Score { get; set; }
+                                  }
+
+                                  public class Destination
+                                  {
+                                      public StatsDto Stats { get; set; } = new();
+                                  }
+
+                                  public class TestProfile : Profile
+                                  {
+                                      public TestProfile()
+                                      {
+                                          CreateMap<Source, Destination>()
+                                              .ForPath(dest => dest.Stats.Score, (options) => options.MapFrom(src => src.Score));
+                                      }
+                                  }
+                              }
+                              """;
+
+        Document document = CreateDocument(source);
+        Diagnostic diagnostic = await CreateDiagnosticAtSourceLambdaAsync(
+            document,
+            AM031_PerformanceWarningAnalyzer.ExpensiveOperationInMapFromRule,
+            "ExpensiveOperation",
+            "Stats.Score");
+
+        CodeAction ignoreAction = Assert.Single(await RegisterActionsAsync(document, diagnostic));
+        string updatedCode = await ApplyActionAsync(ignoreAction, document);
+
+        Assert.Contains(
+            ".ForPath(dest => dest.Stats.Score, (options) => options.Ignore())",
             updatedCode,
             StringComparison.Ordinal);
 

--- a/tests/AutoMapperAnalyzer.Tests/Performance/AM031_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Performance/AM031_CodeFixTests.cs
@@ -440,7 +440,7 @@ public class AM031_CodeFixTests
     }
 
     [Fact]
-    public async Task AM031_ShouldNotRegisterFixes_ForForPathMultipleEnumeration()
+    public async Task AM031_ShouldOfferIgnoreOnly_ForForPathMultipleEnumeration()
     {
         const string source = """
                               using AutoMapper;
@@ -486,7 +486,153 @@ public class AM031_CodeFixTests
             "Numbers");
 
         List<CodeAction> actions = await RegisterActionsAsync(document, diagnostic);
-        Assert.Empty(actions);
+
+        CodeAction ignoreAction = Assert.Single(actions);
+        Assert.Contains("Ignore mapping for 'Stats.Total'", ignoreAction.Title, StringComparison.Ordinal);
+        Assert.DoesNotContain(actions, action => action.Title.Contains("Cache", StringComparison.Ordinal));
+        Assert.DoesNotContain(actions, action => action.Title.Contains("Remove", StringComparison.Ordinal));
+
+        string updatedCode = await ApplyActionAsync(ignoreAction, document);
+        Assert.Contains(
+            ".ForPath(dest => dest.Stats.Total, opt => opt.Ignore())",
+            updatedCode,
+            StringComparison.Ordinal);
+
+        Document updatedDocument = CreateDocument(updatedCode);
+        Compilation compilation = (await updatedDocument.Project.GetCompilationAsync())!;
+        Assert.Empty(compilation.GetDiagnostics().Where(item => item.Severity == DiagnosticSeverity.Error));
+    }
+
+    [Theory]
+    [InlineData("AM034", "ExpensiveOperation")]
+    [InlineData("AM035", "ExpensiveComputation")]
+    [InlineData("AM036", "TaskResult")]
+    [InlineData("AM037", "ComplexLinq")]
+    [InlineData("AM038", "NonDeterministic")]
+    public async Task PerformanceFixer_ShouldOfferForPathIgnore_ForEverySharedRule(
+        string diagnosticId,
+        string issueType)
+    {
+        const string source = """
+                              using AutoMapper;
+
+                              namespace TestNamespace
+                              {
+                                  public class Source
+                                  {
+                                      public int Score { get; set; }
+                                  }
+
+                                  public class StatsDto
+                                  {
+                                      public int Score { get; set; }
+                                  }
+
+                                  public class Destination
+                                  {
+                                      public StatsDto Stats { get; set; } = new();
+                                  }
+
+                                  public class TestProfile : Profile
+                                  {
+                                      public TestProfile()
+                                      {
+                                          CreateMap<Source, Destination>()
+                                              .ForPath(dest => dest.Stats.Score, options => options.MapFrom(src => src.Score));
+                                      }
+                                  }
+                              }
+                              """;
+
+        Document document = CreateDocument(source);
+        var descriptor = new DiagnosticDescriptor(
+            diagnosticId,
+            "Synthetic performance diagnostic",
+            "Synthetic performance diagnostic",
+            "AutoMapper.Performance",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+        Diagnostic diagnostic = await CreateDiagnosticAtSourceLambdaAsync(
+            document,
+            descriptor,
+            issueType,
+            "Stats.Score");
+
+        List<CodeAction> actions = await RegisterActionsAsync(document, diagnostic);
+
+        CodeAction ignoreAction = Assert.Single(actions);
+        Assert.Contains("Ignore mapping for 'Stats.Score'", ignoreAction.Title, StringComparison.Ordinal);
+
+        string updatedCode = await ApplyActionAsync(ignoreAction, document);
+        Assert.Contains(
+            ".ForPath(dest => dest.Stats.Score, options => options.Ignore())",
+            updatedCode,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PerformanceFixer_ShouldOfferOneForPathIgnore_WhenDiagnosticsShareTheLambda()
+    {
+        const string source = """
+                              using AutoMapper;
+                              using System;
+                              using System.Collections.Generic;
+                              using System.Linq;
+
+                              namespace TestNamespace
+                              {
+                                  public class Source
+                                  {
+                                      public List<int> Numbers { get; set; } = new();
+                                  }
+
+                                  public class StatsDto
+                                  {
+                                      public int Total { get; set; }
+                                  }
+
+                                  public class Destination
+                                  {
+                                      public StatsDto Stats { get; set; } = new();
+                                  }
+
+                                  public class TestProfile : Profile
+                                  {
+                                      public TestProfile()
+                                      {
+                                          CreateMap<Source, Destination>()
+                                              .ForPath(dest => dest.Stats.Total, opt => opt.MapFrom(src => src.Numbers.Sum() + src.Numbers.Average() + DateTime.Now.Year));
+                                      }
+                                  }
+                              }
+                              """;
+
+        Document document = CreateDocument(source);
+        Diagnostic multipleEnumeration = await CreateDiagnosticAtSourceLambdaAsync(
+            document,
+            AM031_PerformanceWarningAnalyzer.MultipleEnumerationRule,
+            "MultipleEnumeration",
+            "Stats.Total",
+            "Numbers",
+            "Stats.Total",
+            "Numbers");
+        Diagnostic nonDeterministic = await CreateDiagnosticAtSourceLambdaAsync(
+            document,
+            AM031_PerformanceWarningAnalyzer.NonDeterministicOperationRule,
+            "NonDeterministic",
+            "Stats.Total",
+            null,
+            "Stats.Total",
+            "DateTime.Now");
+
+        List<CodeAction> actions = await RegisterActionsAsync(document, multipleEnumeration, nonDeterministic);
+
+        CodeAction ignoreAction = Assert.Single(actions);
+        string updatedCode = await ApplyActionAsync(ignoreAction, document);
+        Assert.Contains(
+            ".ForPath(dest => dest.Stats.Total, opt => opt.Ignore())",
+            updatedCode,
+            StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/AutoMapperAnalyzer.Tests/Performance/AM031_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Performance/AM031_CodeFixTests.cs
@@ -679,6 +679,56 @@ public class AM031_CodeFixTests
     }
 
     [Fact]
+    public async Task PerformanceFixer_ShouldWithholdForPathIgnore_ForMethodGroupOptions()
+    {
+        const string source = """
+                              using AutoMapper;
+
+                              namespace TestNamespace
+                              {
+                                  public class Source
+                                  {
+                                      public int Score { get; set; }
+                                  }
+
+                                  public class StatsDto
+                                  {
+                                      public int Score { get; set; }
+                                  }
+
+                                  public class Destination
+                                  {
+                                      public StatsDto Stats { get; set; } = new();
+                                  }
+
+                                  public class TestProfile : Profile
+                                  {
+                                      private static void ConfigurePath(
+                                          IPathConfigurationExpression<Source, Destination, int> options) =>
+                                          options.MapFrom(src => src.Score);
+
+                                      public TestProfile()
+                                      {
+                                          CreateMap<Source, Destination>()
+                                              .ForPath(dest => dest.Stats.Score, ConfigurePath);
+                                      }
+                                  }
+                              }
+                              """;
+
+        Document document = CreateDocument(source);
+        Diagnostic diagnostic = await CreateDiagnosticAtSourceLambdaAsync(
+            document,
+            AM031_PerformanceWarningAnalyzer.ExpensiveOperationInMapFromRule,
+            "ExpensiveOperation",
+            "Stats.Score");
+
+        List<CodeAction> actions = await RegisterActionsAsync(document, diagnostic);
+
+        Assert.Empty(actions);
+    }
+
+    [Fact]
     public async Task PerformanceFixer_ShouldOfferOneForPathIgnore_WhenDiagnosticsShareTheLambda()
     {
         const string source = """

--- a/tests/AutoMapperAnalyzer.Tests/Performance/AM031_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Performance/AM031_CodeFixTests.cs
@@ -570,6 +570,61 @@ public class AM031_CodeFixTests
             StringComparison.Ordinal);
     }
 
+
+    [Fact]
+    public async Task PerformanceFixer_ShouldPreserveEscapedForPathOptionsParameter()
+    {
+        const string source = """
+                              using AutoMapper;
+
+                              namespace TestNamespace
+                              {
+                                  public class Source
+                                  {
+                                      public int Score { get; set; }
+                                  }
+
+                                  public class StatsDto
+                                  {
+                                      public int Score { get; set; }
+                                  }
+
+                                  public class Destination
+                                  {
+                                      public StatsDto Stats { get; set; } = new();
+                                  }
+
+                                  public class TestProfile : Profile
+                                  {
+                                      public TestProfile()
+                                      {
+                                          CreateMap<Source, Destination>()
+                                              .ForPath(dest => dest.Stats.Score, @event => @event.MapFrom(src => src.Score));
+                                      }
+                                  }
+                              }
+                              """;
+
+        Document document = CreateDocument(source);
+        Diagnostic diagnostic = await CreateDiagnosticAtSourceLambdaAsync(
+            document,
+            AM031_PerformanceWarningAnalyzer.ExpensiveOperationInMapFromRule,
+            "ExpensiveOperation",
+            "Stats.Score");
+
+        CodeAction ignoreAction = Assert.Single(await RegisterActionsAsync(document, diagnostic));
+        string updatedCode = await ApplyActionAsync(ignoreAction, document);
+
+        Assert.Contains(
+            ".ForPath(dest => dest.Stats.Score, @event => @event.Ignore())",
+            updatedCode,
+            StringComparison.Ordinal);
+
+        Document updatedDocument = CreateDocument(updatedCode);
+        Compilation compilation = (await updatedDocument.Project.GetCompilationAsync())!;
+        Assert.Empty(compilation.GetDiagnostics().Where(item => item.Severity == DiagnosticSeverity.Error));
+    }
+
     [Fact]
     public async Task PerformanceFixer_ShouldOfferOneForPathIgnore_WhenDiagnosticsShareTheLambda()
     {


### PR DESCRIPTION
## Summary
- offer an executable `ForPath(..., opt => opt.Ignore())` scaffold for AM031 and AM034–AM038
- preserve nested destination selectors and both simple/parenthesized options-lambda syntax, including escaped identifiers
- withhold unsupported method-group options instead of advertising a no-op action
- keep caching and convention removal limited to safe `ForMember` shapes
- synchronize 2.30.67 release, rule, catalog, compatibility, and analyzer-health metadata

## Impact
This closes the zero-remediation gap for nested-path performance diagnostics with an AutoMapper-supported executable scaffold. It remains conservative: expression-tree caching and unproven nested-path convention removal are still withheld.

## Validation
- red regression confirmed the previous `ForPath` action list was empty
- performance code-fix suite: 20 passed
- clean-branch CI: 1,410 passed, 0 skipped, 0 failed
- local superset full suite: 1,431 passed, 0 skipped, 0 failed
- Release build: 0 warnings, 0 errors
- AnalyzerVerifier catalog, snapshot, and compatibility checks: current
- package smoke: net8.0, net9.0, and net10.0 passed
- Codecov patch coverage: 90.91%
- escaped-identifier review finding fixed with compilation coverage; thread resolved
- targeted whitespace verification: clean
- Slopwatch: 0 issues in changed C# and tests
