### PR TITLE
fix: keep AM011 single-property fixes honest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+## [2.30.68] - 2026-07-15
+
+AM011 single-property fixer trust hardening.
+
+### Changed
+
+- **AM011**: single-property diagnostics no longer manufacture required domain data with `string.Empty`, `0`, `false`, or `default` when no unique fuzzy source-property match exists.
+- **Explicit fallback**: the fixer keeps a unique fuzzy mapping as the primary action and otherwise offers only the clearly labelled Ignore action for manual review. Aggregate Scaffold-all remains available for intentionally reviewing several missing members together.
+
+### Validation
+
+- AM011 analyzer and code-fix suite: **45** passed.
+- Clean-branch full suite: **1410** passed, 0 skipped, 0 failed.
+
 ## [2.30.67] - 2026-07-15
 
 Performance `ForPath` fixer parity for AM031 and AM034–AM038.

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ prevention*
 
 ---
 
-## 🎉 Latest Release: v2.30.67
+## 🎉 Latest Release: v2.30.68
 
-**Performance `ForPath` fixer parity**
+**AM011 single-property fixer trust hardening**
 
 ✅ **Highlights**
 
-- AM031 and AM034–AM038 now offer an executable Ignore scaffold for nested destination paths.
-- Caching stays `ForMember`-only and nested-path convention removal stays withheld.
+- AM011 no longer invents required values such as `string.Empty`, `0`, or `false` when no unique fuzzy source match exists.
+- Unique fuzzy mappings stay primary; otherwise the only single-property fallback is the explicit Ignore action for manual review.
 
 🧪 **Validation**
 
@@ -29,6 +29,7 @@ prevention*
 
 ### Recent Releases
 
+- **v2.30.68**: AM011 single-property fixes stop manufacturing required domain data when no unique fuzzy source match exists.
 - **v2.30.67**: AM031 and AM034–AM038 add executable `ForPath` Ignore scaffolds while preserving conservative cache/removal boundaries.
 - **v2.30.66**: AM022 respects direction-aware downstream cycle breakers in multi-map recursion graphs.
 - **v2.30.65**: AM004/AM006 same-document sibling recompute for aggregates.
@@ -232,7 +233,7 @@ Install-Package AutoMapperAnalyzer.Analyzers
 ### Project File (For CI/CD)
 
 ```xml
-<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.67">
+<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.68">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 </PackageReference>

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -1,12 +1,12 @@
 # Analyzer Health
 
-Reviewed: 2026-07-15 (performance `ForPath` fixer parity prepared as **2.30.67**)
+Reviewed: 2026-07-15 (AM011 single-property fixer trust hardening prepared as **2.30.68**)
 
 This is a deliberately harsh health audit for the **21** implemented AutoMapper analyzer rule IDs in this repository (16 before the 2.30.62 performance split). Several rule IDs still expose multiple diagnostic descriptors, especially `AM002` and `AM022`; the scorecard rates the public rule ID as the user experiences it.
 
 Every implemented rule currently has an analyzer and a code fix provider. Scores are 1-5, where `5` means reference-quality and hard to improve, `3` means usable but meaningfully incomplete, and `1` means unreliable or underbuilt.
 
-**Ship status:** production-acceptable. **2.30.67** performance `ForPath` Ignore scaffolds; **2.30.66** AM022 downstream cycle breakers; **2.30.65** AM004/AM006 sibling recompute; **2.30.64** AM001 property tokens. Every rule now has minimum health 4. Full suite green; catalog/snapshots current.
+**Ship status:** production-acceptable. **2.30.68** AM011 single-property fixer honesty; **2.30.67** performance `ForPath` Ignore scaffolds; **2.30.66** AM022 downstream cycle breakers; **2.30.65** AM004/AM006 sibling recompute. Every rule now has minimum health 4. Full suite green; catalog/snapshots current.
 
 ## Rubric
 
@@ -39,7 +39,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | AM004 | Source property has no corresponding destination property | Data Integrity | Warning | 4 | 4 | 5 | 5 | 5 | 5 | Low | Unique-best fuzzy, reverse-map, property-token placement. **Fix Strategy 5 (2.30.65)**: same-document sibling recompute offers Map-all/DoNotValidate-all from one property-token caret. Catalog Scaffold remains accurate. |
 | AM005 | Property names differ only in casing | Data Integrity | Warning | 4 | 4 | 4 | 4 | 4 | 3 | Low | Focused and reasonably conservative with explicit mapping including direct string literal/`nameof(...)`/const destination-member forms and typed-lambda selectors including typed top-level `ForPath`, semantic string/`nameof(...)` source-member ignores, custom construction/conversion suppression, reverse-map, source-property diagnostic placement including positional-record source parameters, metadata-backed fixer routing from property-token diagnostics, executable fixer tests, and rule-prefixed code-action equivalence keys; rule docs now match shipped Warning severity/category metadata and the recommended warning configuration. |
 | AM006 | Destination property is not mapped | Data Integrity | Info | 4 | 4 | 5 | 5 | 4 | 4 | Low | Non-required counterpart to AM011. **Fix Strategy 5 (2.30.65)**: same-document sibling recompute for Map-all/Ignore-all from one property-token caret. Shared unmapped-destination helper with analyzer. |
-| AM011 | Required destination property is not mapped | Data Integrity | Error | 4 | 5 | 4 | 5 | 5 | 5 | Low | Important runtime-failure guardrail; per-property fuzzy now resolves ReverseMap types (same as aggregate). Fix Strategy 4: Map-all only when every property has unique fuzzy; mixed/default bulk uses honest Scaffold-all + (manual review); Ignore-all labeled manual review; stale diagnostics withhold. Residual: primary single-property path still scaffolds defaults. |
+| AM011 | Required destination property is not mapped | Data Integrity | Error | 4 | 5 | 4 | 5 | 5 | 5 | Low | Important runtime-failure guardrail; per-property fuzzy resolves ReverseMap types. **2.30.68**: single-property fixes map only a unique compatible fuzzy source; otherwise the sole fallback is explicit Ignore, never fabricated required data. Aggregate Map-all stays unique-fuzzy-only; mixed/default bulk remains honest Scaffold-all + manual review; stale diagnostics withhold. |
 | AM020 | Nested object mapping configuration missing | Complex Mappings | Warning | 4 | 4 | 4 | 5 | 5 | 5 | Low | Reference analyzer; fixer now shares public+internal property discovery with the analyzer (internal nested CreateMap fix covered). Catalog trust is `LikelyRewrite` (constructor-body insertion remains a structural limit). |
 | AM021 | Collection element type incompatibility | Complex Mappings | Warning | 4 | 4 | 4 | 5 | 4 | 4 | Low | Defers fully when AM003 owns container incompatibility (shared helper). Same-container element mismatches, dictionary axes, reverse gaps, and implicit element conversions remain AM021. List simple Select rewrites now refuse non-compiling Parse destinations (string-source gate matches dictionaries). |
 | AM022 | Infinite recursion risk | Complex Mappings | Warning | 4 | 4 | 4 | 5 | 4 | 4 | Low | Requires configured nested CreateMap chains for indirect cycles; strong semantic suppressions. **2.30.66**: direction-aware graph traversal stops at downstream `MaxDepth`, `PreserveReferences`, and `ConvertUsing` maps, with all-registrations protection for ambiguous duplicates. Catalog `Scaffold` matches hard-coded `MaxDepth(2)` policy; graph-edge Ignore remains manual review. |
@@ -71,20 +71,19 @@ Use this table as the hardening queue. Ranking = **Importance × (5 − min(Anal
 
 | Rank | Rule | Signal | Residual (evidence-backed) | Likely score move if closed |
 | --- | --- | --- | --- | --- |
-| 1 | **AM011** | gap=5, min=4 | Primary single-property path still scaffolds defaults when fuzzy fails. | Fix stays 4 until less scaffold-heavy without lying |
-| 2 | **AM032** | gap=4, min=4 | Classic net48-safe if-throw; not destination-aware. | Fix 4→5 if destination-aware policies are safe |
-| 3 | **AM022** | gap=4, min=4 | Downstream global cycle breakers shipped 2.30.66. Member-level graph/dataflow refinements remain opportunistic. | FP 4→5 needs evidence-backed dataflow precision |
-| 4 | **AM001** | gap=4, min=4 | Property-token placement shipped 2.30.64. Residual: advanced conversion modelling only with user repros. | — |
-| 5 | **AM002** | gap=5, min=4 | Advanced generic/nullability-flow only — wait for real user FP/FN. | — until evidence |
-| 6 | **AM020 / AM021 / AM003** | gap=5/4 | Custom-collection / constructor-body insert structural limits. | Opportunistic |
-| 7 | **AM041 / AM050** | gap=4/2 | SafeRewrite nuance / low Importance. | Low ROI |
-| 8 | **AM033 / AM005 / AM030** | gap=2–3 | Importance-limited. | Product priority only |
+| 1 | **AM032** | gap=4, min=4 | Classic net48-safe if-throw; not destination-aware. | Fix 4→5 if destination-aware policies are safe |
+| 2 | **AM022** | gap=4, min=4 | Downstream global cycle breakers shipped 2.30.66. Member-level graph/dataflow refinements remain opportunistic. | FP 4→5 needs evidence-backed dataflow precision |
+| 3 | **AM001** | gap=4, min=4 | Property-token placement shipped 2.30.64. Residual: advanced conversion modelling only with user repros. | — |
+| 4 | **AM002** | gap=5, min=4 | Advanced generic/nullability-flow only — wait for real user FP/FN. | — until evidence |
+| 5 | **AM020 / AM021 / AM003** | gap=5/4 | Custom-collection / constructor-body insert structural limits. | Opportunistic |
+| 6 | **AM041 / AM050** | gap=4/2 | SafeRewrite nuance / low Importance. | Low ROI |
+| 7 | **AM033 / AM005 / AM030** | gap=2–3 | Importance-limited. | Product priority only |
 
 **Recommended next hardening batch:**
 
-1. **AM011 less scaffold-heavy single-property fixes**
-2. **AM032 destination-aware null fix**
-3. **AM022 member-level graph/dataflow precision only with a concrete repro**
+1. **AM032 destination-aware null fix**
+2. **AM022 member-level graph/dataflow precision only with a concrete repro**
+3. **Monitor sweep** if neither has a concrete safe product boundary
 
 Do **not** open advanced AM001/AM002 conversion/nullability modelling without a filed false-positive/false-negative repro.
 
@@ -109,6 +108,7 @@ Active queue (also summarized in Working Base). Prefer one focus per hardening b
 - _AM022 downstream cycle-breaker precision — resolved in 2.30.66._ Multi-map traversal honours direction-specific `MaxDepth`, `PreserveReferences`, and `ConvertUsing`; False Positives 3→4.
 - _AM004 / AM006 same-document sibling recompute — resolved in 2.30.65._
 - _AM031 / AM034–AM038 `ForPath` fixer parity — resolved in 2.30.67._ Nested paths receive an executable Ignore scaffold; caching and convention removal remain safely withheld.
+- _AM011 single-property fixer honesty — resolved in 2.30.68._ Unique compatible fuzzy mappings remain primary; otherwise the fixer offers explicit Ignore instead of manufacturing required domain data.
 - **AM032 destination-aware null fixes.** Emit stays classic net48 `if-throw`; not destination-nullability-aware. Analyzer ThrowIfNull* recognition is already strong.
 
 Resolved historical P2 (keep for audit trail):
@@ -148,6 +148,12 @@ Still open (do not start without a repro or explicit product decision):
 - **AM022 / AM031 dataflow-grade heuristics.** High effort, diminishing returns until a concrete false-positive pattern is filed (prefer P2 ID-split / graph-Ignore first).
 - **AM020 constructor-body CreateMap insert.** Structural host limit; catalog `LikelyRewrite` already honest.
 
+
+## Reanalysis Changelog (2026-07-15 → 2.30.68 AM011 single-property fixer honesty)
+
+| Rules | Finding | Change | Score impact |
+| --- | --- | --- | --- |
+| AM011 | When no unique fuzzy source existed, the primary single-property action manufactured `string.Empty`, numeric zero, `false`, or `default` for a required destination member | Keep unique compatible fuzzy mappings; otherwise expose only explicit Ignore for manual review. Aggregate Scaffold-all remains clearly labelled for multi-property review | No numeric move; closes an action-selection trust residual without overstating automation |
 
 ## Reanalysis Changelog (2026-07-15 → 2.30.67 performance `ForPath` fixer parity)
 
@@ -225,14 +231,14 @@ Full rule+fixer reanalysis driven by four parallel subagent audits (Type Safety,
 | AM030 | ~5 direct tests in shared 146-test bucket. | Tests 4→3; tightened Notes. | AM030 Tests −1 |
 | AM032 | Null-flow heuristic + throw-only fix policy risk. | False Positives 4→3; tightened Notes. | AM032 False Positives −1 |
 
-## Fixer Trust Summary (v2.30.67)
+## Fixer Trust Summary (v2.30.68)
 
 | Rule | Fixable? | Catalog trust | Notes |
 | --- | --- | --- | --- |
 | AM001 | Yes | LikelyRewrite | Conversion fixes when pattern known (`Parse`); ignore-only for speculative conversions |
 | AM002 | Partial | Scaffold | Error descriptor only; Info (`NonNullableToNullable`) is analyzer-only |
 | AM003 | Yes | LikelyRewrite | Executable container rewrites including element Select for immutable destinations |
-| AM004–AM006, AM011 | Yes | Scaffold / LikelyRewrite | Aggregate + nested submenu for 2+ properties (AM004/006/011) |
+| AM004–AM006, AM011 | Yes | Scaffold / LikelyRewrite | AM011 single-property maps only unique fuzzy matches and otherwise offers Ignore; aggregate + nested submenu remains for 2+ properties |
 | AM005 | Yes | LikelyRewrite | Single explicit `ForMember` rewrite; keyword-escaped source |
 | AM020 | Yes | LikelyRewrite | Adds missing `CreateMap<,>()` pairs; public+internal property parity |
 | AM021 | Yes | LikelyRewrite | Executable `ToDictionary`/Select rewrites; Parse gated to string sources |
@@ -296,15 +302,15 @@ Full rule+fixer reanalysis driven by four parallel subagent audits (Type Safety,
 - Analyzer ownership is a real strength. The conflict tests and shared helpers make `AM001`/`AM002`/`AM003`/`AM020`/`AM021` boundaries much healthier than a file-count audit would suggest.
 - The project now has a checked-in `RuleCatalog` health contract plus generated `docs/RULE_CATALOG.md` and sample diagnostic snapshots that tie rule IDs to descriptors, fixers, docs anchors, sample paths, and descriptor-aware fixer trust levels.
 - Diagnostic placement has been tightened for high-volume data-integrity rules (`AM004`, `AM005`, `AM006`, and `AM011`) so diagnostics land on the offending source/destination property token while preserving mapping-invocation metadata for code-fix routing. Configuration and heuristic rules still report at mapping invocations or mapping lambdas when that is the actionable anchor.
-- Several fixers intentionally produce advisory/default mapping scaffolds. That is fine, and docs/code-action titles now distinguish "safe executable rewrite" from "starter mapping the developer must review."
+- Several fixers intentionally produce advisory/default mapping scaffolds. Those remain clearly labelled for manual review; AM011 no longer uses a fabricated default as a single-property primary action.
 
 ## Verification Baseline
 
 Architecture-style coverage currently comes from analyzer/fixer tests, conflict ownership tests, helper tests, sample projects, documentation, the checked-in `RuleCatalog`, generated trust artifacts, package smoke tests, and the deterministic `tools/AnalyzerVerifier` checks.
 
-Current local verification (**2026-07-15** against the **v2.30.67** release candidate):
+Current local verification (**2026-07-15** against the **v2.30.68** release candidate):
 
-- Package version in `src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj`: **2.30.67**.
+- Package version in `src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj`: **2.30.68**.
 - `dotnet build automapper-analyser.sln --configuration Release -warnaserror` passed: 0 warnings, 0 errors.
 - Clean-branch full suite: **1410** passed, 0 skipped, 0 failed.
 - `dotnet run --project tools/AnalyzerVerifier/AnalyzerVerifier.csproj --configuration Release --no-build -- --check-catalog --check-snapshots` passed: rule catalog and sample diagnostics snapshot are up to date.
@@ -312,7 +318,7 @@ Current local verification (**2026-07-15** against the **v2.30.67** release cand
 - Targeted `dotnet format whitespace` completed without diffs in the changed C# files; the repository-wide check still exposes pre-existing line-ending drift outside this slice.
 - Sample project emits AM0xx when analyzers run (`-p:RunAnalyzersDuringBuild=true`); local untracked `Directory.Build.props` (if present) may skip analyzers during CLI builds — unit tests + AnalyzerVerifier remain the verification source of truth.
 - Approximate list-tests name hits (not exclusive filters; for trend only): AM001 57, AM002 83, AM003 61, AM004 87, AM005 34, AM006 43, AM011 45, AM020 97, AM021 64, AM022 53, AM030/32/33 bucket 152, AM031 292, AM041 35, AM050 48, RuleCatalog 10.
-- Release metadata is synchronized for `v2.30.67`; tag/publication follows the merged PR.
+- Release metadata is synchronized for `v2.30.68`; tag/publication follows the merged PR.
 - Historical baseline (2026-07-06 @ `b138fa8` / v2.30.55): **1352** tests green — superseded; do not use for planning.
 - The trust-first pass removed active skipped tests, added drift validation, and moved intentional analyzer-test warnings into an explicit test-project warning baseline.
 - `/usr/local/share/dotnet/dotnet --list-runtimes` shows only .NET 10 runtimes in this local environment, so broader multi-TFM runtime verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -725,7 +725,7 @@ dotnet pack --configuration Release
 
 # Test package locally
 cd test-install/NetCoreTest
-dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.67-local
+dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.68-local
 ```
 
 ---
@@ -909,4 +909,4 @@ dotnet build
 
 **Last Updated**: 2026-05-14
 **Maintainer**: George Wall
-**Version**: 2.30.67
+**Version**: 2.30.68

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -112,8 +112,8 @@ The AutoMapper Roslyn Analyzer project uses GitHub Actions for continuous integr
 ### Package Versioning
 
 - **Format**: Major.Minor.Patch (SemVer)
-- **Current**: 2.30.67
-- **Pre-release**: 2.30.67-preview, 2.30.67-beta
+- **Current**: 2.30.68
+- **Pre-release**: 2.30.68-preview, 2.30.68-beta
 
 ## 🔧 Configuration
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -43,7 +43,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.67">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.68">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -67,7 +67,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.67">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.68">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -86,7 +86,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="14.0.0" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.67">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.68">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -218,7 +218,7 @@ public class Destination
 
 2. **Verify Package Installation**
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.67">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.68">
      <PrivateAssets>all</PrivateAssets>
      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -280,4 +280,4 @@ This guide ensures smooth installation and usage across all supported .NET frame
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.67
+**Version**: 2.30.68

--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -605,7 +605,7 @@ CreateMap<Source, Destination>()
     .ForMember(dest => dest.Email, opt => opt.MapFrom(src => "noreply@example.com"));
 ```
 
-Use this only when the default value is valid domain data. The code fix may generate a compilable starter value such as `string.Empty`, `0`, or `false`, but required members usually deserve an intentional source mapping.
+Use this only when the default value is valid domain data. This is a user-authored policy decision: the single-property code fix does not manufacture a starter value for a required member.
 
 **Option 3: Configure With ForPath**
 
@@ -627,7 +627,7 @@ public class Destination
 }
 ```
 
-**Manual Review Boundary**: The fixer can suggest a unique fuzzy source-property match or add a default-value mapping. If you choose to ignore a required member, verify that another construction path initializes it or that leaving it unset is intentional.
+**Manual Review Boundary**: For one missing required property, the fixer suggests a mapping only when there is a unique compatible fuzzy source-property match; otherwise it offers only the explicit Ignore action. It does not fabricate `string.Empty`, `0`, `false`, or `default` as required domain data. For several missing required properties, aggregate Scaffold-all remains a clearly labelled manual-review action. If you choose Ignore, verify that another construction path initializes the member or that leaving it unset is intentional.
 
 #### Configuration
 
@@ -1602,7 +1602,7 @@ using System.Diagnostics.CodeAnalysis;
 
 1. **Check package reference**:
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.67">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.68">
        <PrivateAssets>all</PrivateAssets>
        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -1641,5 +1641,5 @@ If analyzer slows down builds:
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.67
+**Version**: 2.30.68
 **Maintainer**: George Wall

--- a/docs/RULE_CATALOG.md
+++ b/docs/RULE_CATALOG.md
@@ -2,7 +2,7 @@
 
 This file is generated from `RuleCatalog`.
 
-Package version: `2.30.67`
+Package version: `2.30.68`
 
 | Rule ID | Descriptor Title | Severity | Category | Analyzer | Code Fix | Trust | Sample | Docs |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,3 +1,15 @@
+## Release 2.30.68
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
+### Removed Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
 ## Release 2.30.67
 
 ### New Rules

--- a/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
+++ b/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
@@ -17,7 +17,7 @@
         <!-- Fallback for local builds: 2.0.YYYYMMDD-local -->
         <MajorVersion>2</MajorVersion>
         <MinorVersion>30</MinorVersion>
-        <PatchVersion>67</PatchVersion>
+        <PatchVersion>68</PatchVersion>
         <BuildNumber Condition="'$(BuildNumber)' == ''"
         >$([System.DateTime]::Now.ToString('yyyyMMdd'))
         </BuildNumber
@@ -32,9 +32,9 @@
         <RepositoryUrl>https://github.com/georgepwall1991/automapper-analyser</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-                <PackageReleaseNotes>Version 2.30.67 - Performance ForPath fixer parity
-- AM031 and AM034-AM038 offer an executable ForPath Ignore scaffold
-- Nested destination selectors are preserved while caching and removal remain ForMember-only
+                <PackageReleaseNotes>Version 2.30.68 - AM011 single-property fixer trust hardening
+- AM011 no longer manufactures required domain data when no unique fuzzy source match exists
+- Unique fuzzy mappings remain primary; Ignore is the explicit manual-review fallback
 </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>

--- a/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM011_UnmappedRequiredPropertyCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM011_UnmappedRequiredPropertyCodeFixProvider.cs
@@ -61,14 +61,17 @@ public class AM011_UnmappedRequiredPropertyCodeFixProvider : AutoMapperCodeFixPr
 
             if (unmappedRequiredProperties.Count < 2 || !processedInvocations.Add(invocation.Span))
             {
-                (CodeAction primary, CodeAction ignore) = BuildPerPropertyActions(
+                (CodeAction? primary, CodeAction ignore) = BuildPerPropertyActions(
                     context.Document,
                     operationContext.Root,
                     operationContext.SemanticModel,
                     invocation,
-                    diagnosticProperty.Name,
-                    diagnosticProperty.Type.ToDisplayString());
-                context.RegisterCodeFix(primary, diagnostic);
+                    diagnosticProperty.Name);
+                if (primary != null)
+                {
+                    context.RegisterCodeFix(primary, diagnostic);
+                }
+
                 context.RegisterCodeFix(ignore, diagnostic);
                 continue;
             }
@@ -82,17 +85,20 @@ public class AM011_UnmappedRequiredPropertyCodeFixProvider : AutoMapperCodeFixPr
             var perPropertySubMenus = new List<CodeAction>();
             foreach (IPropertySymbol property in unmappedRequiredProperties)
             {
-                (CodeAction primary, CodeAction ignore) = BuildPerPropertyActions(
+                (CodeAction? primary, CodeAction ignore) = BuildPerPropertyActions(
                     context.Document,
                     operationContext.Root,
                     operationContext.SemanticModel,
                     invocation,
-                    property.Name,
-                    property.Type.ToDisplayString());
+                    property.Name);
+
+                ImmutableArray<CodeAction> propertyActions = primary == null
+                    ? [ignore]
+                    : [primary, ignore];
 
                 perPropertySubMenus.Add(CodeAction.Create(
                     $"Required property '{property.Name}'",
-                    ImmutableArray.Create(primary, ignore),
+                    propertyActions,
                     isInlinable: false));
             }
 
@@ -105,13 +111,12 @@ public class AM011_UnmappedRequiredPropertyCodeFixProvider : AutoMapperCodeFixPr
         }
     }
 
-    private (CodeAction Primary, CodeAction Ignore) BuildPerPropertyActions(
+    private (CodeAction? Primary, CodeAction Ignore) BuildPerPropertyActions(
         Document document,
         SyntaxNode root,
         SemanticModel semanticModel,
         InvocationExpressionSyntax invocation,
-        string propertyName,
-        string propertyType)
+        string propertyName)
     {
         // Resolve types through ReverseMap the same way aggregate fixes do, so reverse-direction
         // per-property fuzzy suggestions work when the diagnostic anchors on ReverseMap().
@@ -133,8 +138,10 @@ public class AM011_UnmappedRequiredPropertyCodeFixProvider : AutoMapperCodeFixPr
             }
         }
 
-        // Option 1 (primary): fuzzy match if found, else default value.
-        CodeAction primary;
+        // Offer an executable mapping only when a unique compatible fuzzy source exists.
+        // Otherwise require the developer to make the explicit manual-review Ignore choice
+        // instead of manufacturing required domain data with string.Empty/0/false.
+        CodeAction? primary = null;
         if (bestFuzzyMatch != null)
         {
             string fuzzyName = bestFuzzyMatch.Name;
@@ -146,18 +153,8 @@ public class AM011_UnmappedRequiredPropertyCodeFixProvider : AutoMapperCodeFixPr
                     CodeFixSyntaxHelper.CreateForMemberWithMapFrom(invocation, propertyName, sourceExpression)),
                 $"AM011_FuzzyMatch_{propertyName}_{fuzzyName}");
         }
-        else
-        {
-            string defaultValue = TypeConversionHelper.GetDefaultValueForType(propertyType);
-            primary = CodeAction.Create(
-                $"Scaffold default mapping for '{propertyName}' ({defaultValue})",
-                _ => ReplaceNodeAsync(
-                    document, root, invocation,
-                    CodeFixSyntaxHelper.CreateForMemberWithMapFrom(invocation, propertyName, defaultValue)),
-                $"AM011_DefaultValue_{propertyName}");
-        }
 
-        // Option 2 (fallback): Ignore.
+        // Explicit fallback: Ignore.
         CodeAction ignore = CodeAction.Create(
             $"Ignore required property '{propertyName}' (manual review)",
             _ => ReplaceNodeAsync(

--- a/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
@@ -130,7 +130,7 @@ public static class RuleCatalog
     /// <summary>
     ///     Current package version used by docs/package drift tests.
     /// </summary>
-    public const string CurrentPackageVersion = "2.30.67";
+    public const string CurrentPackageVersion = "2.30.68";
 
     /// <summary>
     ///     Implemented rules, grouped by public diagnostic ID.

--- a/tests/AutoMapperAnalyzer.Tests/DataIntegrity/AM011_AggregateCodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/DataIntegrity/AM011_AggregateCodeFixTests.cs
@@ -368,7 +368,10 @@ public class AM011_AggregateCodeFixTests
         // Per-property fixes are nested under the parent, never duplicated at the top level.
         Assert.DoesNotContain(
             actions,
-            a => a.Depth == 0 && a.EquivalenceKey != null && a.EquivalenceKey.StartsWith("AM011_Ignore_", StringComparison.Ordinal));
+            a => a.Depth == 0 &&
+                 !a.HasChildren &&
+                 a.EquivalenceKey != null &&
+                 a.EquivalenceKey.StartsWith("AM011_Ignore_", StringComparison.Ordinal));
         Assert.Contains(actions, a => a.IsNested && a.EquivalenceKey == "AM011_Ignore_Alpha");
         Assert.Contains(actions, a => a.IsNested && a.EquivalenceKey == "AM011_Ignore_Beta");
         Assert.Contains(actions, a => a.IsNested && a.EquivalenceKey == "AM011_Ignore_Gamma");
@@ -415,8 +418,12 @@ public class AM011_AggregateCodeFixTests
                 single);
 
         Assert.DoesNotContain(actions, a => a.EquivalenceKey is "AM011_MapAll" or "AM011_ScaffoldAll" or "AM011_IgnoreAll");
-        // Degenerate case stays a flat per-property choice: scaffold default + ignore.
-        Assert.Equal(2, CodeFixActionInspector.TopLevelCount(actions));
+        CodeFixActionInspector.ActionInfo action = Assert.Single(actions);
+        Assert.Equal("AM011_Ignore_Alpha", action.EquivalenceKey);
+        Assert.Contains("manual review", action.Title, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(actions, item =>
+            item.EquivalenceKey != null &&
+            item.EquivalenceKey.StartsWith("AM011_DefaultValue_", StringComparison.Ordinal));
     }
 
     private static async Task AssertAggregateClearsAllAsync(

--- a/tests/AutoMapperAnalyzer.Tests/DataIntegrity/AM011_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/DataIntegrity/AM011_CodeFixTests.cs
@@ -9,7 +9,7 @@ namespace AutoMapperAnalyzer.Tests.DataIntegrity;
 public class AM011_CodeFixTests
 {
     [Fact]
-    public async Task AM011_ShouldAddDefaultValueMapping()
+    public async Task AM011_ShouldOfferIgnore_WhenNoFuzzyStringMatch()
     {
         const string testCode = """
 
@@ -63,7 +63,7 @@ public class AM011_CodeFixTests
                                              {
                                                  public TestProfile()
                                                  {
-                                                     CreateMap<Source, Destination>().ForMember(dest => dest.RequiredField, opt => opt.MapFrom(src => string.Empty));
+                                                     CreateMap<Source, Destination>().ForMember(dest => dest.RequiredField, opt => opt.Ignore());
                                                  }
                                              }
                                          }
@@ -76,11 +76,11 @@ public class AM011_CodeFixTests
                     .WithLocation(16, 32)
                     .WithArguments("RequiredField"),
                 expectedFixedCode,
-                0); // Primary fix: default value (no fuzzy match)
+                0); // No proven source match: require an explicit manual-review Ignore.
     }
 
     [Fact]
-    public async Task AM011_ShouldAddConstantValueMapping()
+    public async Task AM011_ShouldOfferIgnore_WhenNoFuzzyNumericMatch()
     {
         const string testCode = """
 
@@ -130,7 +130,7 @@ public class AM011_CodeFixTests
                                              {
                                                  public TestProfile()
                                                  {
-                                                     CreateMap<Source, Destination>().ForMember(dest => dest.RequiredNumber, opt => opt.MapFrom(src => 0));
+                                                     CreateMap<Source, Destination>().ForMember(dest => dest.RequiredNumber, opt => opt.Ignore());
                                                  }
                                              }
                                          }
@@ -143,11 +143,11 @@ public class AM011_CodeFixTests
                     .WithLocation(14, 29)
                     .WithArguments("RequiredNumber"),
                 expectedFixedCode,
-                0); // Primary fix: default value (0 for int)
+                0); // No proven source match: do not manufacture a numeric default.
     }
 
     [Fact]
-    public async Task AM011_ShouldAddCustomLogicMapping()
+    public async Task AM011_ShouldOfferIgnore_WhenNoFuzzySourceExists()
     {
         const string testCode = """
 
@@ -197,7 +197,7 @@ public class AM011_CodeFixTests
                                              {
                                                  public TestProfile()
                                                  {
-                                                     CreateMap<Source, Destination>().ForMember(dest => dest.RequiredField, opt => opt.MapFrom(src => string.Empty));
+                                                     CreateMap<Source, Destination>().ForMember(dest => dest.RequiredField, opt => opt.Ignore());
                                                  }
                                              }
                                          }
@@ -210,11 +210,11 @@ public class AM011_CodeFixTests
                     .WithLocation(14, 32)
                     .WithArguments("RequiredField"),
                 expectedBulkFixedCode,
-                0); // Primary fix: default value
+                0); // No proven source match: require an explicit manual-review Ignore.
     }
 
     [Fact]
-    public async Task AM011_ShouldAddSourcePropertySuggestionComment()
+    public async Task AM011_ShouldOfferIgnore_WhenSourceNameIsNotFuzzy()
     {
         const string testCode = """
 
@@ -264,7 +264,7 @@ public class AM011_CodeFixTests
                                              {
                                                  public TestProfile()
                                                  {
-                                                     CreateMap<Source, Destination>().ForMember(dest => dest.RequiredDescription, opt => opt.MapFrom(src => string.Empty));
+                                                     CreateMap<Source, Destination>().ForMember(dest => dest.RequiredDescription, opt => opt.Ignore());
                                                  }
                                              }
                                          }
@@ -277,7 +277,7 @@ public class AM011_CodeFixTests
                     .WithLocation(14, 32)
                     .WithArguments("RequiredDescription"),
                 expectedFixedCode,
-                0); // Primary fix: default value
+                0); // Distant names are not enough evidence to invent a mapping.
     }
 
     [Fact]
@@ -354,7 +354,7 @@ public class AM011_CodeFixTests
     }
 
     [Fact]
-    public async Task AM011_ShouldHandleRequiredBoolProperty()
+    public async Task AM011_ShouldIgnoreRequiredBool_WhenNoFuzzyMatch()
     {
         const string testCode = """
                                 using AutoMapper;
@@ -402,7 +402,7 @@ public class AM011_CodeFixTests
                                              {
                                                  public TestProfile()
                                                  {
-                                                     CreateMap<Source, Destination>().ForMember(dest => dest.RequiredFlag, opt => opt.MapFrom(src => false));
+                                                     CreateMap<Source, Destination>().ForMember(dest => dest.RequiredFlag, opt => opt.Ignore());
                                                  }
                                              }
                                          }
@@ -415,11 +415,11 @@ public class AM011_CodeFixTests
                     .WithLocation(13, 30)
                     .WithArguments("RequiredFlag"),
                 expectedFixedCode,
-                0); // Primary fix: default value (false for bool)
+                0); // No proven source match: do not manufacture false.
     }
 
     [Fact]
-    public async Task AM011_ShouldHandleRequiredDecimalProperty()
+    public async Task AM011_ShouldIgnoreRequiredDecimal_WhenNoFuzzyMatch()
     {
         const string testCode = """
                                 using AutoMapper;
@@ -467,7 +467,7 @@ public class AM011_CodeFixTests
                                              {
                                                  public TestProfile()
                                                  {
-                                                     CreateMap<Source, Destination>().ForMember(dest => dest.RequiredPrice, opt => opt.MapFrom(src => 0m));
+                                                     CreateMap<Source, Destination>().ForMember(dest => dest.RequiredPrice, opt => opt.Ignore());
                                                  }
                                              }
                                          }
@@ -480,11 +480,11 @@ public class AM011_CodeFixTests
                     .WithLocation(13, 33)
                     .WithArguments("RequiredPrice"),
                 expectedFixedCode,
-                0); // Primary fix: default value (0m for decimal)
+                0); // No proven source match: do not manufacture a decimal default.
     }
 
     [Fact]
-    public async Task AM011_ShouldSuppressFuzzyMatch_WhenBestCandidateIsAmbiguous()
+    public async Task AM011_ShouldWithholdDefaultScaffold_WhenBestCandidateIsAmbiguous()
     {
         const string testCode = """
 
@@ -534,7 +534,7 @@ public class AM011_CodeFixTests
                                              {
                                                  public TestProfile()
                                                  {
-                                                     CreateMap<Source, Destination>().ForMember(dest => dest.Email, opt => opt.MapFrom(src => string.Empty));
+                                                     CreateMap<Source, Destination>().ForMember(dest => dest.Email, opt => opt.Ignore());
                                                  }
                                              }
                                          }
@@ -547,7 +547,7 @@ public class AM011_CodeFixTests
                     .WithLocation(14, 32)
                     .WithArguments("Email"),
                 expectedFixedCode,
-                0);
+                0); // No unique fuzzy match: require an explicit manual-review Ignore.
     }
 
     [Fact]


### PR DESCRIPTION
## Verdict

AM011 no longer manufactures required domain values when it cannot prove a source mapping.

## What changed

- preserve the unique compatible fuzzy-source action
- otherwise expose only the explicit Ignore fallback for manual review
- keep aggregate Scaffold-all for deliberately reviewing several missing required members
- synchronize v2.30.68 package metadata, rule docs, catalog, changelog, and analyzer health

## TDD evidence

- red: the single-property no-match test exposed both default and Ignore actions
- red: the ambiguous fuzzy test applied `string.Empty`
- green: AM011 analyzer/code-fix suite — 45 passed
- green: clean-branch expected full suite — 1,410 tests

## Local verification

- Release build: 0 warnings, 0 errors
- local superset: 1,431 passed, 0 skipped, 0 failed
- catalog, snapshots, and compatibility docs current
- packed `AutoMapperAnalyzer.Analyzers.2.30.68.nupkg`
- net10/AutoMapper 14 healthy consumer builds cleanly
- broken consumer fails specifically with AM001
- Slopwatch: no findings in changed implementation/tests

The local Claude cross-review was intentionally not invoked per project direction.