### PR TITLE
fix: make AM032 null fixes destination-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+## [2.30.69] - 2026-07-16
+
+AM032 destination-aware null-fix policy.
+
+### Changed
+
+- **AM032 nullable destinations**: converters whose destination return type is semantically proven nullable now offer `return null` as the primary null guard, while retaining the existing exception guard as an explicit alternative.
+- **Conservative boundary**: non-nullable, oblivious, and otherwise unproven destination types remain throw-only. Both generated forms compile for the supported net48 consumer baseline.
+
+### Validation
+
+- AM030/AM032 code-fix suite: **18** passed.
+- Clean-branch full suite: **1414** passed, 0 skipped, 0 failed.
+
 ## [2.30.68] - 2026-07-15
 
 AM011 single-property fixer trust hardening.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet Version](https://img.shields.io/nuget/v/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=NuGet)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=Downloads)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/georgepwall1991/automapper-analyser/ci.yml?style=flat-square&logo=github&label=Build)](https://github.com/georgepwall1991/automapper-analyser/actions)
-[![Tests](https://img.shields.io/badge/Tests-1410%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
+[![Tests](https://img.shields.io/badge/Tests-1414%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
 [![.NET](https://img.shields.io/badge/.NET-4.8+%20%7C%206.0+%20%7C%208.0+%20%7C%209.0+%20%7C%2010.0+-512BD4?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 [![Coverage](https://img.shields.io/codecov/c/github/georgepwall1991/automapper-analyser?style=flat-square&logo=codecov&label=Coverage)](https://codecov.io/gh/georgepwall1991/automapper-analyser)
@@ -14,21 +14,22 @@ prevention*
 
 ---
 
-## 🎉 Latest Release: v2.30.68
+## 🎉 Latest Release: v2.30.69
 
-**AM011 single-property fixer trust hardening**
+**AM032 destination-aware null-fix policy**
 
 ✅ **Highlights**
 
-- AM011 no longer invents required values such as `string.Empty`, `0`, or `false` when no unique fuzzy source match exists.
-- Unique fuzzy mappings stay primary; otherwise the only single-property fallback is the explicit Ignore action for manual review.
+- Proven nullable destinations offer null propagation first and retain the exception guard as an explicit alternative.
+- Non-nullable, oblivious, and unproven destinations remain conservatively throw-only.
 
 🧪 **Validation**
 
-- Clean-branch full suite: **1410** passed, 0 skipped, 0 failed on `net10.0`.
+- Clean-branch full suite: **1414** passed, 0 skipped, 0 failed on `net10.0`.
 
 ### Recent Releases
 
+- **v2.30.69**: AM032 makes nullable-destination null propagation primary while retaining the throw policy.
 - **v2.30.68**: AM011 single-property fixes stop manufacturing required domain data when no unique fuzzy source match exists.
 - **v2.30.67**: AM031 and AM034–AM038 add executable `ForPath` Ignore scaffolds while preserving conservative cache/removal boundaries.
 - **v2.30.66**: AM022 respects direction-aware downstream cycle breakers in multi-map recursion graphs.
@@ -233,7 +234,7 @@ Install-Package AutoMapperAnalyzer.Analyzers
 ### Project File (For CI/CD)
 
 ```xml
-<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.68">
+<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.69">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 </PackageReference>

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -1,12 +1,12 @@
 # Analyzer Health
 
-Reviewed: 2026-07-15 (AM011 single-property fixer trust hardening prepared as **2.30.68**)
+Reviewed: 2026-07-16 (AM032 destination-aware null-fix policy prepared as **2.30.69**)
 
 This is a deliberately harsh health audit for the **21** implemented AutoMapper analyzer rule IDs in this repository (16 before the 2.30.62 performance split). Several rule IDs still expose multiple diagnostic descriptors, especially `AM002` and `AM022`; the scorecard rates the public rule ID as the user experiences it.
 
 Every implemented rule currently has an analyzer and a code fix provider. Scores are 1-5, where `5` means reference-quality and hard to improve, `3` means usable but meaningfully incomplete, and `1` means unreliable or underbuilt.
 
-**Ship status:** production-acceptable. **2.30.68** AM011 single-property fixer honesty; **2.30.67** performance `ForPath` Ignore scaffolds; **2.30.66** AM022 downstream cycle breakers; **2.30.65** AM004/AM006 sibling recompute. Every rule now has minimum health 4. Full suite green; catalog/snapshots current.
+**Ship status:** production-acceptable. **2.30.69** AM032 destination-aware null fixes; **2.30.68** AM011 single-property fixer honesty; **2.30.67** performance `ForPath` Ignore scaffolds; **2.30.66** AM022 downstream cycle breakers. Every rule now has minimum health 4. Full suite green; catalog/snapshots current.
 
 ## Rubric
 
@@ -44,7 +44,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | AM021 | Collection element type incompatibility | Complex Mappings | Warning | 4 | 4 | 4 | 5 | 4 | 4 | Low | Defers fully when AM003 owns container incompatibility (shared helper). Same-container element mismatches, dictionary axes, reverse gaps, and implicit element conversions remain AM021. List simple Select rewrites now refuse non-compiling Parse destinations (string-source gate matches dictionaries). |
 | AM022 | Infinite recursion risk | Complex Mappings | Warning | 4 | 4 | 4 | 5 | 4 | 4 | Low | Requires configured nested CreateMap chains for indirect cycles; strong semantic suppressions. **2.30.66**: direction-aware graph traversal stops at downstream `MaxDepth`, `PreserveReferences`, and `ConvertUsing` maps, with all-registrations protection for ambiguous duplicates. Catalog `Scaffold` matches hard-coded `MaxDepth(2)` policy; graph-edge Ignore remains manual review. |
 | AM030 | Invalid type converter implementation | Custom Conversions | Error | 4 | 4 | 4 | 4 | 4 | 3 | Low | Analyzer-only by design; AM001/AM020/AM021 own missing-converter mapping. Split from AM032/AM033 is clean in catalog and trust tests. Direct AM030 coverage includes empty implementation, wrong return type, missing `ResolutionContext`, and non-public `Convert` (each paired with the matching compiler error). |
-| AM032 | Type converter null handling | Custom Conversions | Warning | 4 | 4 | 4 | 5 | 4 | 4 | Low | Best-in-class null-guard detection with catalog `LikelyRewrite` trust. Recognizes `ThrowIfNull*`, switch/pattern/coalesce/conditional-access guards, and pure nullable→nullable source pass-through (`return source` / `=> source`). Residual: heuristic null-flow edge cases; the auto-fix still inserts `ArgumentNullException` (appropriate when a diagnostic fires for non-nullable destinations without intentional null handling). |
+| AM032 | Type converter null handling | Custom Conversions | Warning | 4 | 4 | 5 | 5 | 4 | 4 | Low | Best-in-class null-guard detection with catalog `LikelyRewrite` trust. Recognizes `ThrowIfNull*`, switch/pattern/coalesce/conditional-access guards, and nullable pass-through. **Fix Strategy 5 (2.30.69)**: proven nullable destinations offer return-null first plus the retained throw policy; non-nullable, oblivious, and unproven destinations remain throw-only. Residual analyzer work is heuristic null-flow only and requires a concrete repro. |
 | AM033 | Unused type converter | Custom Conversions | Info | 4 | 4 | 4 | 4 | 4 | 2 | Low | Unused-converter diagnostics now have their own Info rule ID and remain analyzer-only, and the shared converter code-fix provider no longer advertises AM033 as fixable. Usage analysis recognizes generic, instance, type-based including parenthesized/casted `typeof(...)` and simple explicit or implicit `Type` locals/fields/properties initialized from, expression-bodied to, or getter-bodied to `typeof(...)`, parameterless `Type` factory methods and local functions that expression-body or return `typeof(...)`, simple interface-typed locals/fields/properties, and DI/service-provider interface handles passed to `ConvertUsing(...)`. Product importance is intentionally lower because this is cleanup guidance. |
 | AM031 | Multiple enumeration | Performance | Warning | 4 | 4 | 4 | 5 | 4 | 4 | Low | Single-concept after 2.30.62 ID split (was multi-descriptor umbrella). **2.30.67**: ForMember keeps cache/Remove/Ignore actions; ForPath now offers an executable Ignore scaffold while cache and convention removal remain conservatively withheld. Scaffold trust. |
 | AM034 | Expensive operation in mapping | Performance | Warning | 4 | 4 | 4 | 5 | 4 | 4 | Low | Split from AM031 in 2.30.62. **2.30.67**: shared fixer offers Ignore on ForMember and ForPath, plus convention-safe Remove on ForMember. Residual: heuristic smell catalog breadth. |
@@ -71,19 +71,17 @@ Use this table as the hardening queue. Ranking = **Importance × (5 − min(Anal
 
 | Rank | Rule | Signal | Residual (evidence-backed) | Likely score move if closed |
 | --- | --- | --- | --- | --- |
-| 1 | **AM032** | gap=4, min=4 | Classic net48-safe if-throw; not destination-aware. | Fix 4→5 if destination-aware policies are safe |
-| 2 | **AM022** | gap=4, min=4 | Downstream global cycle breakers shipped 2.30.66. Member-level graph/dataflow refinements remain opportunistic. | FP 4→5 needs evidence-backed dataflow precision |
-| 3 | **AM001** | gap=4, min=4 | Property-token placement shipped 2.30.64. Residual: advanced conversion modelling only with user repros. | — |
-| 4 | **AM002** | gap=5, min=4 | Advanced generic/nullability-flow only — wait for real user FP/FN. | — until evidence |
-| 5 | **AM020 / AM021 / AM003** | gap=5/4 | Custom-collection / constructor-body insert structural limits. | Opportunistic |
-| 6 | **AM041 / AM050** | gap=4/2 | SafeRewrite nuance / low Importance. | Low ROI |
-| 7 | **AM033 / AM005 / AM030** | gap=2–3 | Importance-limited. | Product priority only |
+| 1 | **AM022** | gap=4, min=4 | Downstream global cycle breakers shipped 2.30.66. Member-level graph/dataflow refinements remain opportunistic. | FP 4→5 needs evidence-backed dataflow precision |
+| 2 | **AM001** | gap=4, min=4 | Property-token placement shipped 2.30.64. Residual: advanced conversion modelling only with user repros. | — |
+| 3 | **AM002** | gap=5, min=4 | Advanced generic/nullability-flow only — wait for real user FP/FN. | — until evidence |
+| 4 | **AM020 / AM021 / AM003** | gap=5/4 | Custom-collection / constructor-body insert structural limits. | Opportunistic |
+| 5 | **AM041 / AM050** | gap=4/2 | SafeRewrite nuance / low Importance. | Low ROI |
+| 6 | **AM033 / AM005 / AM030** | gap=2–3 | Importance-limited. | Product priority only |
 
 **Recommended next hardening batch:**
 
-1. **AM032 destination-aware null fix**
-2. **AM022 member-level graph/dataflow precision only with a concrete repro**
-3. **Monitor sweep** if neither has a concrete safe product boundary
+1. **AM022 member-level graph/dataflow precision only with a concrete repro**
+2. **Monitor sweep** for a new evidence-backed residual
 
 Do **not** open advanced AM001/AM002 conversion/nullability modelling without a filed false-positive/false-negative repro.
 
@@ -109,7 +107,7 @@ Active queue (also summarized in Working Base). Prefer one focus per hardening b
 - _AM004 / AM006 same-document sibling recompute — resolved in 2.30.65._
 - _AM031 / AM034–AM038 `ForPath` fixer parity — resolved in 2.30.67._ Nested paths receive an executable Ignore scaffold; caching and convention removal remain safely withheld.
 - _AM011 single-property fixer honesty — resolved in 2.30.68._ Unique compatible fuzzy mappings remain primary; otherwise the fixer offers explicit Ignore instead of manufacturing required domain data.
-- **AM032 destination-aware null fixes.** Emit stays classic net48 `if-throw`; not destination-nullability-aware. Analyzer ThrowIfNull* recognition is already strong.
+- _AM032 destination-aware null fixes — resolved in 2.30.69._ Proven nullable destinations offer return-null first and retain throw; non-nullable and unproven destinations remain throw-only.
 
 Resolved historical P2 (keep for audit trail):
 
@@ -148,6 +146,12 @@ Still open (do not start without a repro or explicit product decision):
 - **AM022 / AM031 dataflow-grade heuristics.** High effort, diminishing returns until a concrete false-positive pattern is filed (prefer P2 ID-split / graph-Ignore first).
 - **AM020 constructor-body CreateMap insert.** Structural host limit; catalog `LikelyRewrite` already honest.
 
+
+## Reanalysis Changelog (2026-07-16 → 2.30.69 AM032 destination-aware null-fix policy)
+
+| Rules | Finding | Change | Score impact |
+| --- | --- | --- | --- |
+| AM032 | The fixer always inserted an exception guard even when the converter destination was semantically nullable | Offer return-null first for proven nullable reference and `Nullable<T>` destinations, retain throw as an explicit alternative, and keep non-nullable/oblivious/unproven destinations throw-only | Fix Strategy 4→5 |
 
 ## Reanalysis Changelog (2026-07-15 → 2.30.68 AM011 single-property fixer honesty)
 
@@ -231,7 +235,7 @@ Full rule+fixer reanalysis driven by four parallel subagent audits (Type Safety,
 | AM030 | ~5 direct tests in shared 146-test bucket. | Tests 4→3; tightened Notes. | AM030 Tests −1 |
 | AM032 | Null-flow heuristic + throw-only fix policy risk. | False Positives 4→3; tightened Notes. | AM032 False Positives −1 |
 
-## Fixer Trust Summary (v2.30.68)
+## Fixer Trust Summary (v2.30.69)
 
 | Rule | Fixable? | Catalog trust | Notes |
 | --- | --- | --- | --- |
@@ -244,7 +248,7 @@ Full rule+fixer reanalysis driven by four parallel subagent audits (Type Safety,
 | AM021 | Yes | LikelyRewrite | Executable `ToDictionary`/Select rewrites; Parse gated to string sources |
 | AM022 | Yes | Scaffold | `MaxDepth(2)` + graph-aware Ignore on cycle edges (manual review) |
 | AM030, AM033 | No | NoFix | Analyzer-only by design |
-| AM032 | Yes | LikelyRewrite | Inserts `ArgumentNullException` guard |
+| AM032 | Yes | LikelyRewrite | Proven nullable destinations: return-null primary + throw alternative; all other destinations: throw-only |
 | AM031 | Yes | Scaffold | Multiple enumeration; cache rewrite + Ignore/Remove on ForMember; Ignore scaffold on ForPath |
 | AM034–AM038 | Yes | Scaffold | Shared performance fixer; ForMember Ignore/Remove scaffolds; ForPath Ignore scaffold |
 | AM041, AM050 | Yes | SafeRewrite | Conservative removal/withhold for chained config |
@@ -308,17 +312,17 @@ Full rule+fixer reanalysis driven by four parallel subagent audits (Type Safety,
 
 Architecture-style coverage currently comes from analyzer/fixer tests, conflict ownership tests, helper tests, sample projects, documentation, the checked-in `RuleCatalog`, generated trust artifacts, package smoke tests, and the deterministic `tools/AnalyzerVerifier` checks.
 
-Current local verification (**2026-07-15** against the **v2.30.68** release candidate):
+Current local verification (**2026-07-16** against the **v2.30.69** release candidate):
 
-- Package version in `src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj`: **2.30.68**.
+- Package version in `src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj`: **2.30.69**.
 - `dotnet build automapper-analyser.sln --configuration Release -warnaserror` passed: 0 warnings, 0 errors.
-- Clean-branch full suite: **1410** passed, 0 skipped, 0 failed.
+- Clean-branch full suite: **1414** passed, 0 skipped, 0 failed.
 - `dotnet run --project tools/AnalyzerVerifier/AnalyzerVerifier.csproj --configuration Release --no-build -- --check-catalog --check-snapshots` passed: rule catalog and sample diagnostics snapshot are up to date.
 - `git diff --check` passed.
 - Targeted `dotnet format whitespace` completed without diffs in the changed C# files; the repository-wide check still exposes pre-existing line-ending drift outside this slice.
 - Sample project emits AM0xx when analyzers run (`-p:RunAnalyzersDuringBuild=true`); local untracked `Directory.Build.props` (if present) may skip analyzers during CLI builds — unit tests + AnalyzerVerifier remain the verification source of truth.
-- Approximate list-tests name hits (not exclusive filters; for trend only): AM001 57, AM002 83, AM003 61, AM004 87, AM005 34, AM006 43, AM011 45, AM020 97, AM021 64, AM022 53, AM030/32/33 bucket 152, AM031 292, AM041 35, AM050 48, RuleCatalog 10.
-- Release metadata is synchronized for `v2.30.68`; tag/publication follows the merged PR.
+- Approximate list-tests name hits (not exclusive filters; for trend only): AM001 57, AM002 83, AM003 61, AM004 87, AM005 34, AM006 43, AM011 45, AM020 97, AM021 64, AM022 53, AM030/32/33 bucket 156, AM031 292, AM041 35, AM050 48, RuleCatalog 10.
+- Release metadata is synchronized for `v2.30.69`; tag/publication follows the merged PR.
 - Historical baseline (2026-07-06 @ `b138fa8` / v2.30.55): **1352** tests green — superseded; do not use for planning.
 - The trust-first pass removed active skipped tests, added drift validation, and moved intentional analyzer-test warnings into an explicit test-project warning baseline.
 - `/usr/local/share/dotnet/dotnet --list-runtimes` shows only .NET 10 runtimes in this local environment, so broader multi-TFM runtime verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -725,7 +725,7 @@ dotnet pack --configuration Release
 
 # Test package locally
 cd test-install/NetCoreTest
-dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.68-local
+dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.69-local
 ```
 
 ---
@@ -909,4 +909,4 @@ dotnet build
 
 **Last Updated**: 2026-05-14
 **Maintainer**: George Wall
-**Version**: 2.30.68
+**Version**: 2.30.69

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -112,8 +112,8 @@ The AutoMapper Roslyn Analyzer project uses GitHub Actions for continuous integr
 ### Package Versioning
 
 - **Format**: Major.Minor.Patch (SemVer)
-- **Current**: 2.30.68
-- **Pre-release**: 2.30.68-preview, 2.30.68-beta
+- **Current**: 2.30.69
+- **Pre-release**: 2.30.69-preview, 2.30.69-beta
 
 ## 🔧 Configuration
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -43,7 +43,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.68">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.69">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -67,7 +67,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.68">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.69">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -86,7 +86,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="14.0.0" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.68">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.69">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -218,7 +218,7 @@ public class Destination
 
 2. **Verify Package Installation**
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.68">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.69">
      <PrivateAssets>all</PrivateAssets>
      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -280,4 +280,4 @@ This guide ensures smooth installation and usage across all supported .NET frame
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.68
+**Version**: 2.30.69

--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -1150,13 +1150,19 @@ public class StringToIntConverter : ITypeConverter<string?, int>
 
 #### Code Fix
 
-For nullable-source converters, AM032 offers an executable fix that inserts:
+For nullable-source converters with a non-nullable or unproven destination, AM032 offers an executable exception guard:
 
 ```csharp
 if (source == null) throw new global::System.ArgumentNullException(nameof(source));
 ```
 
-The generated guard is fully qualified so the fixer does not add, reorder, or duplicate `using System` directives.
+When the converter destination is semantically proven nullable (`T?` or an annotated nullable reference), the primary action instead preserves null:
+
+```csharp
+if (source == null) return null;
+```
+
+The exception guard remains available as a secondary explicit policy. Oblivious reference types and other destinations whose nullability is not proven stay throw-only. Both forms are net48-safe; the exception guard is fully qualified so the fixer does not add, reorder, or duplicate `using System` directives.
 
 #### Configuration
 
@@ -1602,7 +1608,7 @@ using System.Diagnostics.CodeAnalysis;
 
 1. **Check package reference**:
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.68">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.69">
        <PrivateAssets>all</PrivateAssets>
        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -1641,5 +1647,5 @@ If analyzer slows down builds:
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.68
+**Version**: 2.30.69
 **Maintainer**: George Wall

--- a/docs/RULE_CATALOG.md
+++ b/docs/RULE_CATALOG.md
@@ -2,7 +2,7 @@
 
 This file is generated from `RuleCatalog`.
 
-Package version: `2.30.68`
+Package version: `2.30.69`
 
 | Rule ID | Descriptor Title | Severity | Category | Analyzer | Code Fix | Trust | Sample | Docs |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,3 +1,15 @@
+## Release 2.30.69
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
+### Removed Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
 ## Release 2.30.68
 
 ### New Rules

--- a/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
+++ b/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
@@ -17,7 +17,7 @@
         <!-- Fallback for local builds: 2.0.YYYYMMDD-local -->
         <MajorVersion>2</MajorVersion>
         <MinorVersion>30</MinorVersion>
-        <PatchVersion>68</PatchVersion>
+        <PatchVersion>69</PatchVersion>
         <BuildNumber Condition="'$(BuildNumber)' == ''"
         >$([System.DateTime]::Now.ToString('yyyyMMdd'))
         </BuildNumber
@@ -32,9 +32,9 @@
         <RepositoryUrl>https://github.com/georgepwall1991/automapper-analyser</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-                <PackageReleaseNotes>Version 2.30.68 - AM011 single-property fixer trust hardening
-- AM011 no longer manufactures required domain data when no unique fuzzy source match exists
-- Unique fuzzy mappings remain primary; Ignore is the explicit manual-review fallback
+                <PackageReleaseNotes>Version 2.30.69 - AM032 destination-aware null-fix policy
+- Proven nullable destinations offer a primary return-null guard
+- Throw remains available; non-nullable and unproven destinations stay throw-only
 </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>

--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM030_CustomTypeConverterCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM030_CustomTypeConverterCodeFixProvider.cs
@@ -54,14 +54,32 @@ public class AM030_CustomTypeConverterCodeFixProvider : AutoMapperCodeFixProvide
             }
 
             string sourceParameterName = convertMethod.ParameterList.Parameters[0].Identifier.ValueText;
+            IMethodSymbol? convertMethodSymbol = operationContext.SemanticModel.GetDeclaredSymbol(convertMethod);
+            if (convertMethodSymbol != null && CanReturnNull(convertMethodSymbol.ReturnType))
+            {
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        $"Return null when '{sourceParameterName}' is null",
+                        cancellationToken => AddNullGuardAsync(
+                            context.Document,
+                            operationContext.Root,
+                            convertMethod,
+                            sourceParameterName,
+                            NullGuardPolicy.ReturnNull,
+                            cancellationToken),
+                        $"AM032_ReturnNull_{sourceParameterName}"),
+                    diagnostic);
+            }
+
             context.RegisterCodeFix(
                 CodeAction.Create(
-                    $"Add null guard for '{sourceParameterName}'",
+                    $"Throw when '{sourceParameterName}' is null",
                     cancellationToken => AddNullGuardAsync(
                         context.Document,
                         operationContext.Root,
                         convertMethod,
                         sourceParameterName,
+                        NullGuardPolicy.Throw,
                         cancellationToken),
                     $"AM032_AddNullGuard_{sourceParameterName}"),
                 diagnostic);
@@ -73,12 +91,15 @@ public class AM030_CustomTypeConverterCodeFixProvider : AutoMapperCodeFixProvide
         SyntaxNode root,
         MethodDeclarationSyntax convertMethod,
         string sourceParameterName,
+        NullGuardPolicy policy,
         CancellationToken cancellationToken)
     {
-        // Classic if-throw remains the emit form so net48 consumers (documented support matrix)
-        // get compiling code. AM032 analyzer still recognizes ThrowIfNull* when users write it.
-        StatementSyntax guardStatement = SyntaxFactory.ParseStatement(
-            $"if ({sourceParameterName} == null) throw new global::System.ArgumentNullException(nameof({sourceParameterName}));")
+        // Both forms compile for net48 consumers. Null propagation is offered only when the
+        // destination return type is semantically proven nullable; throw remains explicit policy.
+        string guardText = policy == NullGuardPolicy.ReturnNull
+            ? $"if ({sourceParameterName} == null) return null;"
+            : $"if ({sourceParameterName} == null) throw new global::System.ArgumentNullException(nameof({sourceParameterName}));";
+        StatementSyntax guardStatement = SyntaxFactory.ParseStatement(guardText)
             .WithTrailingTrivia(SyntaxFactory.ElasticLineFeed);
 
         MethodDeclarationSyntax updatedMethod;
@@ -112,5 +133,22 @@ public class AM030_CustomTypeConverterCodeFixProvider : AutoMapperCodeFixProvide
 
         SyntaxNode newRoot = root.ReplaceNode(convertMethod, updatedMethod);
         return document.WithSyntaxRoot(newRoot);
+    }
+
+    private static bool CanReturnNull(ITypeSymbol returnType)
+    {
+        if (returnType is INamedTypeSymbol namedType &&
+            namedType.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T)
+        {
+            return true;
+        }
+
+        return returnType.IsReferenceType && returnType.NullableAnnotation == NullableAnnotation.Annotated;
+    }
+
+    private enum NullGuardPolicy
+    {
+        ReturnNull,
+        Throw
     }
 }

--- a/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
@@ -130,7 +130,7 @@ public static class RuleCatalog
     /// <summary>
     ///     Current package version used by docs/package drift tests.
     /// </summary>
-    public const string CurrentPackageVersion = "2.30.68";
+    public const string CurrentPackageVersion = "2.30.69";
 
     /// <summary>
     ///     Implemented rules, grouped by public diagnostic ID.

--- a/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM030_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM030_CodeFixTests.cs
@@ -187,6 +187,163 @@ public class AM030_CodeFixTests
     }
 
     [Fact]
+    public async Task AM032_ShouldOfferReturnNullBeforeThrow_ForNullableReferenceDestination()
+    {
+        const string testCode = """
+                                #nullable enable
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class NullUnsafeConverter : ITypeConverter<string?, string?>
+                                    {
+                                        public string? Convert(string? source, string? destination, ResolutionContext context)
+                                        {
+                                            return source.Trim();
+                                        }
+                                    }
+                                }
+                                """;
+
+        Document document = CreateDocument(testCode);
+        Diagnostic diagnostic = Assert.Single(
+            await GetDiagnosticsAsync(document),
+            item => item.Id == "AM032");
+
+        List<CodeAction> actions = await RegisterActionsAsync(document, diagnostic);
+
+        Assert.Collection(
+            actions,
+            action =>
+            {
+                Assert.Equal("Return null when 'source' is null", action.Title);
+                Assert.Equal("AM032_ReturnNull_source", action.EquivalenceKey);
+            },
+            action =>
+            {
+                Assert.Equal("Throw when 'source' is null", action.Title);
+                Assert.Equal("AM032_AddNullGuard_source", action.EquivalenceKey);
+            });
+
+        string updatedCode = await ApplyActionAsync(actions[0], document);
+        Assert.Contains("if (source == null) return null;", updatedCode, StringComparison.Ordinal);
+        Assert.DoesNotContain("ArgumentNullException", updatedCode, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task AM032_ShouldReturnNull_ForExpressionBodiedNullableValueDestination()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class NullUnsafeConverter : ITypeConverter<string?, int?>
+                                    {
+                                        public int? Convert(string? source, int? destination, ResolutionContext context) => int.Parse(source);
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<string?, int?>().ConvertUsing<NullUnsafeConverter>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string expectedFixedCode = """
+                                         using AutoMapper;
+
+                                         namespace TestNamespace
+                                         {
+                                             public class NullUnsafeConverter : ITypeConverter<string?, int?>
+                                             {
+                                                 public int? Convert(string? source, int? destination, ResolutionContext context)
+                                                 {
+                                                     if (source == null) return null;
+                                                     return int.Parse(source);
+                                                 }
+                                             }
+
+                                             public class TestProfile : Profile
+                                             {
+                                                 public TestProfile()
+                                                 {
+                                                     CreateMap<string?, int?>().ConvertUsing<NullUnsafeConverter>();
+                                                 }
+                                             }
+                                         }
+                                         """;
+
+        await CodeFixVerifier<AM030_CustomTypeConverterAnalyzer, AM030_CustomTypeConverterCodeFixProvider>
+            .VerifyFixAsync(
+                testCode,
+                new DiagnosticResult(AM030_CustomTypeConverterAnalyzer.ConverterNullHandlingIssueRule)
+                    .WithLocation(7, 21)
+                    .WithArguments("NullUnsafeConverter", "String"),
+                expectedFixedCode);
+    }
+
+    [Fact]
+    public async Task AM032_ShouldOfferThrowOnly_ForNonNullableDestination()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class NullUnsafeConverter : ITypeConverter<string?, int>
+                                    {
+                                        public int Convert(string? source, int destination, ResolutionContext context)
+                                        {
+                                            return int.Parse(source);
+                                        }
+                                    }
+                                }
+                                """;
+
+        Document document = CreateDocument(testCode);
+        Diagnostic diagnostic = Assert.Single(
+            await GetDiagnosticsAsync(document),
+            item => item.Id == "AM032");
+
+        CodeAction action = Assert.Single(await RegisterActionsAsync(document, diagnostic));
+        Assert.Equal("Throw when 'source' is null", action.Title);
+        Assert.Equal("AM032_AddNullGuard_source", action.EquivalenceKey);
+    }
+
+    [Fact]
+    public async Task AM032_ShouldOfferThrowOnly_ForObliviousReferenceDestination()
+    {
+        const string testCode = """
+                                #nullable disable
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class NullUnsafeConverter : ITypeConverter<int?, string>
+                                    {
+                                        public string Convert(int? source, string destination, ResolutionContext context)
+                                        {
+                                            return source.Value.ToString();
+                                        }
+                                    }
+                                }
+                                """;
+
+        Document document = CreateDocument(testCode);
+        Diagnostic diagnostic = Assert.Single(
+            await GetDiagnosticsAsync(document),
+            item => item.Id == "AM032");
+
+        CodeAction action = Assert.Single(await RegisterActionsAsync(document, diagnostic));
+        Assert.Equal("Throw when 'source' is null", action.Title);
+        Assert.Equal("AM032_AddNullGuard_source", action.EquivalenceKey);
+    }
+
+    [Fact]
     public async Task AM030_ShouldPreserveExistingSystemUsing_WhenAddingNullGuard()
     {
         const string testCode = """
@@ -888,5 +1045,13 @@ public class AM030_CodeFixTests
 
         await provider.RegisterCodeFixesAsync(context);
         return actions;
+    }
+
+    private static async Task<string> ApplyActionAsync(CodeAction action, Document originalDocument)
+    {
+        ImmutableArray<CodeActionOperation> operations = await action.GetOperationsAsync(CancellationToken.None);
+        ApplyChangesOperation applyChanges = Assert.Single(operations.OfType<ApplyChangesOperation>());
+        Document updatedDocument = applyChanges.ChangedSolution.GetDocument(originalDocument.Id)!;
+        return (await updatedDocument.GetTextAsync()).ToString();
     }
 }


### PR DESCRIPTION
## Verdict

AM032 now makes its generated null policy match the converter destination contract: proven nullable destinations offer `return null` first while retaining the existing exception guard, and non-nullable or unproven destinations stay throw-only.

## Evidence

- TDD red phase reproduced the old unconditional throw behavior for nullable reference and nullable value destinations.
- Added four policy tests covering action order, nullable reference output, expression-bodied `Nullable<T>` output, non-nullable destinations, and oblivious reference destinations.
- AM030 code-fix suite: 18 passed.
- AM030/AM032/AM033 family: 156 passed.
- Clean-branch full suite expected by CI: 1,414 passed, 0 skipped, 0 failed.
- Local superset full suite: 1,435 passed, 0 skipped, 0 failed.
- Release build: 0 warnings, 0 errors.
- Catalog, snapshots, and compatibility documentation checks passed.
- Packed v2.30.69 and verified both healthy and intentionally broken net10/AutoMapper 14 consumers.
- Slopwatch and formatting checks found no issues.

## Release

Prepares v2.30.69. Merge only after required CI and Codecov are green.