### PR TITLE
fix: detect AM022 cycles across direct renamed member maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+## [2.30.70] - 2026-07-16
+
+AM022 direct member-map cycle detection.
+
+### Changed
+
+- **AM022 direct `ForMember(...MapFrom...)` edges**: a uniquely configured, semantically AutoMapper-owned direct property mapping can now close the root recursion graph even when source and destination member names differ.
+- **Conservative boundary**: only direct property-to-property expression lambdas on the current forward map participate. Duplicate destination configuration, transformed expressions, lookalike APIs, reverse segments, and downstream explicit-member inference remain excluded.
+- **Effective Ignore fix**: the graph-aware Ignore action is appended after the existing `MapFrom` so the cycle breaker is the effective destination-member policy; MaxDepth remains first.
+
+### Validation
+
+- AM022 analyzer and code-fix suite: **75** passed.
+- Clean-branch full suite: **1423** passed, 0 skipped, 0 failed.
+
 ## [2.30.69] - 2026-07-16
 
 AM032 destination-aware null-fix policy.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet Version](https://img.shields.io/nuget/v/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=NuGet)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=Downloads)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/georgepwall1991/automapper-analyser/ci.yml?style=flat-square&logo=github&label=Build)](https://github.com/georgepwall1991/automapper-analyser/actions)
-[![Tests](https://img.shields.io/badge/Tests-1414%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
+[![Tests](https://img.shields.io/badge/Tests-1423%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
 [![.NET](https://img.shields.io/badge/.NET-4.8+%20%7C%206.0+%20%7C%208.0+%20%7C%209.0+%20%7C%2010.0+-512BD4?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 [![Coverage](https://img.shields.io/codecov/c/github/georgepwall1991/automapper-analyser?style=flat-square&logo=codecov&label=Coverage)](https://codecov.io/gh/georgepwall1991/automapper-analyser)
@@ -14,21 +14,23 @@ prevention*
 
 ---
 
-## 🎉 Latest Release: v2.30.69
+## 🎉 Latest Release: v2.30.70
 
-**AM032 destination-aware null-fix policy**
+**AM022 direct member-map cycle detection**
 
 ✅ **Highlights**
 
-- Proven nullable destinations offer null propagation first and retain the exception guard as an explicit alternative.
-- Non-nullable, oblivious, and unproven destinations remain conservatively throw-only.
+- Direct property-to-property `ForMember(...MapFrom...)` mappings now participate in root cycle detection even when member names differ.
+- Duplicate, transformed, reverse, lookalike, and downstream explicit-member shapes remain conservatively excluded.
+- Ignore is appended after the existing MapFrom so the generated cycle breaker is effective; MaxDepth remains first.
 
 🧪 **Validation**
 
-- Clean-branch full suite: **1414** passed, 0 skipped, 0 failed on `net10.0`.
+- AM022 suite: **75** passed; clean-branch full suite: **1423** passed, 0 skipped, 0 failed on `net10.0`.
 
 ### Recent Releases
 
+- **v2.30.70**: AM022 detects direct renamed `ForMember(...MapFrom...)` cycle edges and emits an effective Ignore alternative.
 - **v2.30.69**: AM032 makes nullable-destination null propagation primary while retaining the throw policy.
 - **v2.30.68**: AM011 single-property fixes stop manufacturing required domain data when no unique fuzzy source match exists.
 - **v2.30.67**: AM031 and AM034–AM038 add executable `ForPath` Ignore scaffolds while preserving conservative cache/removal boundaries.
@@ -234,7 +236,7 @@ Install-Package AutoMapperAnalyzer.Analyzers
 ### Project File (For CI/CD)
 
 ```xml
-<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.69">
+<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.70">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 </PackageReference>

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -1,12 +1,12 @@
 # Analyzer Health
 
-Reviewed: 2026-07-16 (AM032 destination-aware null-fix policy prepared as **2.30.69**)
+Reviewed: 2026-07-16 (AM022 direct member-map cycle detection prepared as **2.30.70**)
 
 This is a deliberately harsh health audit for the **21** implemented AutoMapper analyzer rule IDs in this repository (16 before the 2.30.62 performance split). Several rule IDs still expose multiple diagnostic descriptors, especially `AM002` and `AM022`; the scorecard rates the public rule ID as the user experiences it.
 
 Every implemented rule currently has an analyzer and a code fix provider. Scores are 1-5, where `5` means reference-quality and hard to improve, `3` means usable but meaningfully incomplete, and `1` means unreliable or underbuilt.
 
-**Ship status:** production-acceptable. **2.30.69** AM032 destination-aware null fixes; **2.30.68** AM011 single-property fixer honesty; **2.30.67** performance `ForPath` Ignore scaffolds; **2.30.66** AM022 downstream cycle breakers. Every rule now has minimum health 4. Full suite green; catalog/snapshots current.
+**Ship status:** production-acceptable. **2.30.70** AM022 direct member-map cycle detection; **2.30.69** AM032 destination-aware null fixes; **2.30.68** AM011 single-property fixer honesty; **2.30.67** performance `ForPath` Ignore scaffolds. Every rule now has minimum health 4. Full suite green; catalog/snapshots current.
 
 ## Rubric
 
@@ -42,7 +42,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | AM011 | Required destination property is not mapped | Data Integrity | Error | 4 | 5 | 4 | 5 | 5 | 5 | Low | Important runtime-failure guardrail; per-property fuzzy resolves ReverseMap types. **2.30.68**: single-property fixes map only a unique compatible fuzzy source; otherwise the sole fallback is explicit Ignore, never fabricated required data. Aggregate Map-all stays unique-fuzzy-only; mixed/default bulk remains honest Scaffold-all + manual review; stale diagnostics withhold. |
 | AM020 | Nested object mapping configuration missing | Complex Mappings | Warning | 4 | 4 | 4 | 5 | 5 | 5 | Low | Reference analyzer; fixer now shares public+internal property discovery with the analyzer (internal nested CreateMap fix covered). Catalog trust is `LikelyRewrite` (constructor-body insertion remains a structural limit). |
 | AM021 | Collection element type incompatibility | Complex Mappings | Warning | 4 | 4 | 4 | 5 | 4 | 4 | Low | Defers fully when AM003 owns container incompatibility (shared helper). Same-container element mismatches, dictionary axes, reverse gaps, and implicit element conversions remain AM021. List simple Select rewrites now refuse non-compiling Parse destinations (string-source gate matches dictionaries). |
-| AM022 | Infinite recursion risk | Complex Mappings | Warning | 4 | 4 | 4 | 5 | 4 | 4 | Low | Requires configured nested CreateMap chains for indirect cycles; strong semantic suppressions. **2.30.66**: direction-aware graph traversal stops at downstream `MaxDepth`, `PreserveReferences`, and `ConvertUsing` maps, with all-registrations protection for ambiguous duplicates. Catalog `Scaffold` matches hard-coded `MaxDepth(2)` policy; graph-edge Ignore remains manual review. |
+| AM022 | Infinite recursion risk | Complex Mappings | Warning | 4 | 4 | 4 | 5 | 4 | 4 | Low | Requires configured nested CreateMap chains for indirect cycles; strong semantic suppressions. **2.30.70**: uniquely configured direct root `ForMember(...MapFrom(source => source.Property))` edges close renamed cycles; duplicate, transformed, reverse, lookalike, and downstream explicit-member shapes remain excluded. Ignore is appended after MapFrom so it wins; downstream `MaxDepth`, `PreserveReferences`, and `ConvertUsing` still terminate traversal. Catalog `Scaffold` remains honest. |
 | AM030 | Invalid type converter implementation | Custom Conversions | Error | 4 | 4 | 4 | 4 | 4 | 3 | Low | Analyzer-only by design; AM001/AM020/AM021 own missing-converter mapping. Split from AM032/AM033 is clean in catalog and trust tests. Direct AM030 coverage includes empty implementation, wrong return type, missing `ResolutionContext`, and non-public `Convert` (each paired with the matching compiler error). |
 | AM032 | Type converter null handling | Custom Conversions | Warning | 4 | 4 | 5 | 5 | 4 | 4 | Low | Best-in-class null-guard detection with catalog `LikelyRewrite` trust. Recognizes `ThrowIfNull*`, switch/pattern/coalesce/conditional-access guards, and nullable pass-through. **Fix Strategy 5 (2.30.69)**: proven nullable destinations offer return-null first plus the retained throw policy; non-nullable, oblivious, and unproven destinations remain throw-only. Residual analyzer work is heuristic null-flow only and requires a concrete repro. |
 | AM033 | Unused type converter | Custom Conversions | Info | 4 | 4 | 4 | 4 | 4 | 2 | Low | Unused-converter diagnostics now have their own Info rule ID and remain analyzer-only, and the shared converter code-fix provider no longer advertises AM033 as fixable. Usage analysis recognizes generic, instance, type-based including parenthesized/casted `typeof(...)` and simple explicit or implicit `Type` locals/fields/properties initialized from, expression-bodied to, or getter-bodied to `typeof(...)`, parameterless `Type` factory methods and local functions that expression-body or return `typeof(...)`, simple interface-typed locals/fields/properties, and DI/service-provider interface handles passed to `ConvertUsing(...)`. Product importance is intentionally lower because this is cleanup guidance. |
@@ -71,17 +71,17 @@ Use this table as the hardening queue. Ranking = **Importance × (5 − min(Anal
 
 | Rank | Rule | Signal | Residual (evidence-backed) | Likely score move if closed |
 | --- | --- | --- | --- | --- |
-| 1 | **AM022** | gap=4, min=4 | Downstream global cycle breakers shipped 2.30.66. Member-level graph/dataflow refinements remain opportunistic. | FP 4→5 needs evidence-backed dataflow precision |
-| 2 | **AM001** | gap=4, min=4 | Property-token placement shipped 2.30.64. Residual: advanced conversion modelling only with user repros. | — |
-| 3 | **AM002** | gap=5, min=4 | Advanced generic/nullability-flow only — wait for real user FP/FN. | — until evidence |
+| 1 | **AM001** | gap=4, min=4 | Property-token placement shipped 2.30.64. Residual: advanced conversion modelling only with user repros. | — |
+| 2 | **AM002** | gap=5, min=4 | Advanced generic/nullability-flow only — wait for real user FP/FN. | — until evidence |
+| 3 | **AM022** | gap=4, min=4 | Direct renamed root edges shipped 2.30.70. Downstream explicit-member inference remains opportunistic and repro-gated. | — until evidence |
 | 4 | **AM020 / AM021 / AM003** | gap=5/4 | Custom-collection / constructor-body insert structural limits. | Opportunistic |
 | 5 | **AM041 / AM050** | gap=4/2 | SafeRewrite nuance / low Importance. | Low ROI |
 | 6 | **AM033 / AM005 / AM030** | gap=2–3 | Importance-limited. | Product priority only |
 
 **Recommended next hardening batch:**
 
-1. **AM022 member-level graph/dataflow precision only with a concrete repro**
-2. **Monitor sweep** for a new evidence-backed residual
+1. **Monitor sweep** for a new evidence-backed residual
+2. **AM022 downstream explicit-member precision only with a concrete compiling repro**
 
 Do **not** open advanced AM001/AM002 conversion/nullability modelling without a filed false-positive/false-negative repro.
 
@@ -108,6 +108,7 @@ Active queue (also summarized in Working Base). Prefer one focus per hardening b
 - _AM031 / AM034–AM038 `ForPath` fixer parity — resolved in 2.30.67._ Nested paths receive an executable Ignore scaffold; caching and convention removal remain safely withheld.
 - _AM011 single-property fixer honesty — resolved in 2.30.68._ Unique compatible fuzzy mappings remain primary; otherwise the fixer offers explicit Ignore instead of manufacturing required domain data.
 - _AM032 destination-aware null fixes — resolved in 2.30.69._ Proven nullable destinations offer return-null first and retain throw; non-nullable and unproven destinations remain throw-only.
+- _AM022 direct member-map cycle detection — resolved in 2.30.70._ A unique direct root MapFrom edge can close a renamed cycle; effective Ignore is appended after MapFrom. Ambiguous and complex shapes remain conservative.
 
 Resolved historical P2 (keep for audit trail):
 
@@ -143,9 +144,15 @@ Still open (do not start without a repro or explicit product decision):
 
 - **AM002 generic / nullability flow semantics.** Advanced generic/nullability-flow only after a real user FP/FN class.
 - **AM001 explicit/domain conversion guidance.** Predefined + compiler-known implicits are done; domain/explicit guidance needs concrete cases.
-- **AM022 / AM031 dataflow-grade heuristics.** High effort, diminishing returns until a concrete false-positive pattern is filed (prefer P2 ID-split / graph-Ignore first).
+- **AM022 / AM031 dataflow-grade heuristics.** High effort, diminishing returns until a concrete false-positive or false-negative pattern is filed. AM022 direct renamed root edges are covered; downstream explicit-member inference remains repro-gated.
 - **AM020 constructor-body CreateMap insert.** Structural host limit; catalog `LikelyRewrite` already honest.
 
+
+## Reanalysis Changelog (2026-07-16 → 2.30.70 AM022 direct member-map cycle detection)
+
+| Rules | Finding | Change | Score impact |
+| --- | --- | --- | --- |
+| AM022 | A compiling direct `ForMember(d => d.RenamedChild, o => o.MapFrom(s => s.Child))` root edge disappeared from the convention graph, hiding a configured two-map cycle | Add only one unique semantic direct property edge on the current forward root map; retain downstream convention traversal and all breaker/ambiguity/lookalike exclusions. Append Ignore after MapFrom so the alternative is effective | No numeric move; closes a concrete false negative while retaining the deliberate heuristic ceiling |
 
 ## Reanalysis Changelog (2026-07-16 → 2.30.69 AM032 destination-aware null-fix policy)
 
@@ -235,7 +242,7 @@ Full rule+fixer reanalysis driven by four parallel subagent audits (Type Safety,
 | AM030 | ~5 direct tests in shared 146-test bucket. | Tests 4→3; tightened Notes. | AM030 Tests −1 |
 | AM032 | Null-flow heuristic + throw-only fix policy risk. | False Positives 4→3; tightened Notes. | AM032 False Positives −1 |
 
-## Fixer Trust Summary (v2.30.69)
+## Fixer Trust Summary (v2.30.70)
 
 | Rule | Fixable? | Catalog trust | Notes |
 | --- | --- | --- | --- |
@@ -246,7 +253,7 @@ Full rule+fixer reanalysis driven by four parallel subagent audits (Type Safety,
 | AM005 | Yes | LikelyRewrite | Single explicit `ForMember` rewrite; keyword-escaped source |
 | AM020 | Yes | LikelyRewrite | Adds missing `CreateMap<,>()` pairs; public+internal property parity |
 | AM021 | Yes | LikelyRewrite | Executable `ToDictionary`/Select rewrites; Parse gated to string sources |
-| AM022 | Yes | Scaffold | `MaxDepth(2)` + graph-aware Ignore on cycle edges (manual review) |
+| AM022 | Yes | Scaffold | `MaxDepth(2)` + graph-aware Ignore on convention/direct root cycle edges; Ignore follows existing MapFrom so it is effective (manual review) |
 | AM030, AM033 | No | NoFix | Analyzer-only by design |
 | AM032 | Yes | LikelyRewrite | Proven nullable destinations: return-null primary + throw alternative; all other destinations: throw-only |
 | AM031 | Yes | Scaffold | Multiple enumeration; cache rewrite + Ignore/Remove on ForMember; Ignore scaffold on ForPath |
@@ -312,17 +319,17 @@ Full rule+fixer reanalysis driven by four parallel subagent audits (Type Safety,
 
 Architecture-style coverage currently comes from analyzer/fixer tests, conflict ownership tests, helper tests, sample projects, documentation, the checked-in `RuleCatalog`, generated trust artifacts, package smoke tests, and the deterministic `tools/AnalyzerVerifier` checks.
 
-Current local verification (**2026-07-16** against the **v2.30.69** release candidate):
+Current local verification (**2026-07-16** against the **v2.30.70** release candidate):
 
-- Package version in `src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj`: **2.30.69**.
+- Package version in `src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj`: **2.30.70**.
 - `dotnet build automapper-analyser.sln --configuration Release -warnaserror` passed: 0 warnings, 0 errors.
-- Clean-branch full suite: **1414** passed, 0 skipped, 0 failed.
+- Clean-branch full suite: **1423** passed, 0 skipped, 0 failed.
 - `dotnet run --project tools/AnalyzerVerifier/AnalyzerVerifier.csproj --configuration Release --no-build -- --check-catalog --check-snapshots` passed: rule catalog and sample diagnostics snapshot are up to date.
-- `git diff --check` passed.
-- Targeted `dotnet format whitespace` completed without diffs in the changed C# files; the repository-wide check still exposes pre-existing line-ending drift outside this slice.
+- Remote branch compare is one commit with only the 15 intended source/test/trust/release files and no trailing-whitespace additions.
+- Targeted `dotnet format whitespace` completed on the local candidate; the clean branch preserves the touched files' existing LF convention to avoid whole-file line-ending churn.
 - Sample project emits AM0xx when analyzers run (`-p:RunAnalyzersDuringBuild=true`); local untracked `Directory.Build.props` (if present) may skip analyzers during CLI builds — unit tests + AnalyzerVerifier remain the verification source of truth.
-- Approximate list-tests name hits (not exclusive filters; for trend only): AM001 57, AM002 83, AM003 61, AM004 87, AM005 34, AM006 43, AM011 45, AM020 97, AM021 64, AM022 53, AM030/32/33 bucket 156, AM031 292, AM041 35, AM050 48, RuleCatalog 10.
-- Release metadata is synchronized for `v2.30.69`; tag/publication follows the merged PR.
+- Approximate list-tests name hits (not exclusive filters; for trend only): AM001 57, AM002 83, AM003 61, AM004 87, AM005 34, AM006 43, AM011 45, AM020 97, AM021 64, AM022 62, AM030/32/33 bucket 156, AM031 292, AM041 35, AM050 48, RuleCatalog 10.
+- Release metadata is synchronized for `v2.30.70`; tag/publication follows the merged PR.
 - Historical baseline (2026-07-06 @ `b138fa8` / v2.30.55): **1352** tests green — superseded; do not use for planning.
 - The trust-first pass removed active skipped tests, added drift validation, and moved intentional analyzer-test warnings into an explicit test-project warning baseline.
 - `/usr/local/share/dotnet/dotnet --list-runtimes` shows only .NET 10 runtimes in this local environment, so broader multi-TFM runtime verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -725,7 +725,7 @@ dotnet pack --configuration Release
 
 # Test package locally
 cd test-install/NetCoreTest
-dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.69-local
+dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.70-local
 ```
 
 ---
@@ -909,4 +909,4 @@ dotnet build
 
 **Last Updated**: 2026-05-14
 **Maintainer**: George Wall
-**Version**: 2.30.69
+**Version**: 2.30.70

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -112,8 +112,8 @@ The AutoMapper Roslyn Analyzer project uses GitHub Actions for continuous integr
 ### Package Versioning
 
 - **Format**: Major.Minor.Patch (SemVer)
-- **Current**: 2.30.69
-- **Pre-release**: 2.30.69-preview, 2.30.69-beta
+- **Current**: 2.30.70
+- **Pre-release**: 2.30.70-preview, 2.30.70-beta
 
 ## 🔧 Configuration
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -43,7 +43,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.69">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.70">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -67,7 +67,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.69">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.70">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -86,7 +86,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="14.0.0" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.69">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.70">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -218,7 +218,7 @@ public class Destination
 
 2. **Verify Package Installation**
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.69">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.70">
      <PrivateAssets>all</PrivateAssets>
      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -280,4 +280,4 @@ This guide ensures smooth installation and usage across all supported .NET frame
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.69
+**Version**: 2.30.70

--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -869,8 +869,8 @@ dotnet_diagnostic.AM021.severity = warning
 
 #### Description
 
-Detects circular reference patterns in convention-mapped object graphs that can cause stack overflow without `MaxDepth`
-configuration.
+Detects circular reference patterns in convention-mapped object graphs and in proven direct
+`ForMember(...MapFrom(source => source.Property))` root edges that can cause stack overflow without a cycle breaker.
 
 #### Problem
 
@@ -975,6 +975,12 @@ that AutoMapper can use for recursion. Ignoring the top-level recursive destinat
 own recursion behavior explicitly. For indirect cycles, the traversal honours these cycle breakers on downstream
 `CreateMap` registrations as well as the root map, including direct same-block calls through a local mapping variable,
 while preserving configuration direction around `ReverseMap()`.
+When the current forward map renames a root edge, AM022 also follows a uniquely configured direct property mapping such
+as `.ForMember(d => d.RenamedChild, o => o.MapFrom(s => s.Child))`. This inference is deliberately root-only and
+requires semantic AutoMapper ownership plus direct expression-bodied property selectors. Duplicate destination
+configuration, `ForPath`, reverse-map segments, blocks, method calls, transforms, resolvers, converters, and downstream
+explicit-member inference remain outside the automatic graph. For these renamed root edges, the Ignore lightbulb is
+appended after the existing MapFrom so Ignore is the effective member policy; MaxDepth remains the first action.
 Helper methods named `Ignore` or cycle-breaker names are not treated as suppression unless they resolve to
 AutoMapper's member-configuration `Ignore()` method. Built-in framework types such as `System.Guid` stay out of
 graph recursion analysis, but user-defined types with the same short names are still analyzed.
@@ -1608,7 +1614,7 @@ using System.Diagnostics.CodeAnalysis;
 
 1. **Check package reference**:
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.69">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.70">
        <PrivateAssets>all</PrivateAssets>
        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -1647,5 +1653,5 @@ If analyzer slows down builds:
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.69
+**Version**: 2.30.70
 **Maintainer**: George Wall

--- a/docs/RULE_CATALOG.md
+++ b/docs/RULE_CATALOG.md
@@ -2,7 +2,7 @@
 
 This file is generated from `RuleCatalog`.
 
-Package version: `2.30.69`
+Package version: `2.30.70`
 
 | Rule ID | Descriptor Title | Severity | Category | Analyzer | Code Fix | Trust | Sample | Docs |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,3 +1,15 @@
+## Release 2.30.70
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
+### Removed Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
 ## Release 2.30.69
 
 ### New Rules

--- a/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
+++ b/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
@@ -17,7 +17,7 @@
         <!-- Fallback for local builds: 2.0.YYYYMMDD-local -->
         <MajorVersion>2</MajorVersion>
         <MinorVersion>30</MinorVersion>
-        <PatchVersion>69</PatchVersion>
+        <PatchVersion>70</PatchVersion>
         <BuildNumber Condition="'$(BuildNumber)' == ''"
         >$([System.DateTime]::Now.ToString('yyyyMMdd'))
         </BuildNumber
@@ -32,9 +32,10 @@
         <RepositoryUrl>https://github.com/georgepwall1991/automapper-analyser</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-                <PackageReleaseNotes>Version 2.30.69 - AM032 destination-aware null-fix policy
-- Proven nullable destinations offer a primary return-null guard
-- Throw remains available; non-nullable and unproven destinations stay throw-only
+                <PackageReleaseNotes>Version 2.30.70 - AM022 direct member-map cycle detection
+- Direct property MapFrom edges close renamed root cycles
+- Duplicate, transformed, reverse, lookalike, and downstream explicit shapes remain excluded
+- Ignore is appended after MapFrom so the generated cycle breaker is effective
 </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>

--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM022_InfiniteRecursionAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM022_InfiniteRecursionAnalyzer.cs
@@ -74,6 +74,12 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
         InvocationExpressionSyntax? reverseMapInvocation =
             AutoMapperAnalysisHelpers.GetReverseMapInvocation(invocationExpr);
         CreateMapRegistry createMapRegistry = CreateMapRegistry.FromCompilation(context.Compilation);
+        ImmutableArray<(IPropertySymbol SourceProperty, IPropertySymbol DestinationProperty)> rootMappedPairs =
+            GetRootMappedPropertyPairs(
+                invocationExpr,
+                typeArguments.sourceType,
+                typeArguments.destinationType,
+                context.SemanticModel);
 
         // Check if recursion is constrained or the mapping body is custom-owned.
         if (
@@ -94,7 +100,8 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
                 typeArguments.destinationType as INamedTypeSymbol,
                 reverseMapInvocation,
                 context.SemanticModel,
-                createMapRegistry
+                createMapRegistry,
+                rootMappedPairs
             )
         )
         {
@@ -107,7 +114,8 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
             invocationExpr,
             typeArguments.sourceType,
             typeArguments.destinationType,
-            createMapRegistry
+            createMapRegistry,
+            rootMappedPairs
         );
     }
 
@@ -143,7 +151,8 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
         INamedTypeSymbol? destinationType,
         InvocationExpressionSyntax? reverseMapInvocation,
         SemanticModel semanticModel,
-        CreateMapRegistry createMapRegistry
+        CreateMapRegistry createMapRegistry,
+        ImmutableArray<(IPropertySymbol SourceProperty, IPropertySymbol DestinationProperty)> rootMappedPairs
     )
     {
         if (sourceType == null || destinationType == null)
@@ -155,7 +164,8 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
         HashSet<string> selfReferencingDestProperties = FindRecursiveDestinationProperties(
             sourceType,
             destinationType,
-            createMapRegistry);
+            createMapRegistry,
+            rootMappedPairs);
         if (
             selfReferencingDestProperties.Count > 0
             && selfReferencingDestProperties.All(prop => ignoredProperties.Contains(prop))
@@ -260,7 +270,8 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
         InvocationExpressionSyntax invocation,
         ITypeSymbol? sourceType,
         ITypeSymbol? destinationType,
-        CreateMapRegistry createMapRegistry
+        CreateMapRegistry createMapRegistry,
+        ImmutableArray<(IPropertySymbol SourceProperty, IPropertySymbol DestinationProperty)> rootMappedPairs
     )
     {
         if (sourceType == null || destinationType == null)
@@ -269,7 +280,7 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
         }
 
         // Check for self-referencing mapped properties on both sides to reduce false positives.
-        if (HasMappedSelfReference(sourceType, destinationType))
+        if (HasMappedSelfReference(sourceType, destinationType, rootMappedPairs))
         {
             var diagnostic = Diagnostic.Create(
                 SelfReferencingTypeRule,
@@ -282,8 +293,8 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // Check for circular references reachable through convention-mapped member paths.
-        if (HasMappedCircularReference(sourceType, destinationType, createMapRegistry))
+        // Check for circular references reachable through proven root member paths.
+        if (HasMappedCircularReference(sourceType, destinationType, createMapRegistry, rootMappedPairs))
         {
             var diagnostic = Diagnostic.Create(
                 InfiniteRecursionRiskRule,
@@ -296,15 +307,17 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    private static bool HasMappedSelfReference(ITypeSymbol? sourceType, ITypeSymbol? destinationType)
+    private static bool HasMappedSelfReference(
+        ITypeSymbol? sourceType,
+        ITypeSymbol? destinationType,
+        ImmutableArray<(IPropertySymbol SourceProperty, IPropertySymbol DestinationProperty)> rootMappedPairs)
     {
         if (sourceType == null || destinationType == null)
         {
             return false;
         }
 
-        foreach ((IPropertySymbol sourceProperty, IPropertySymbol destinationProperty) in
-                 GetConventionMappedPropertyPairs(sourceType, destinationType))
+        foreach ((IPropertySymbol sourceProperty, IPropertySymbol destinationProperty) in rootMappedPairs)
         {
             if (
                 IsSelfReference(sourceProperty.Type, sourceType)
@@ -319,7 +332,7 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
     }
 
     /// <summary>
-    ///     Destination properties on a CreateMap pair whose convention-mapped path participates
+    ///     Destination properties on a CreateMap pair whose mapped path participates
     ///     in a configured circular graph (self-ref or multi-type). Used by the analyzer for
     ///     Ignore suppression and by the code fix for graph-aware Ignore actions.
     /// </summary>
@@ -329,12 +342,44 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
         CreateMapRegistry createMapRegistry
     )
     {
+        return FindRecursiveDestinationProperties(
+            sourceType,
+            destinationType,
+            createMapRegistry,
+            GetConventionMappedPropertyPairs(sourceType, destinationType).ToImmutableArray());
+    }
+
+    /// <summary>
+    ///     Finds recursive destination members using the current CreateMap's proven root edges,
+    ///     including direct property-to-property ForMember MapFrom configuration.
+    /// </summary>
+    internal static HashSet<string> FindRecursiveDestinationProperties(
+        INamedTypeSymbol sourceType,
+        INamedTypeSymbol destinationType,
+        CreateMapRegistry createMapRegistry,
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel
+    )
+    {
+        return FindRecursiveDestinationProperties(
+            sourceType,
+            destinationType,
+            createMapRegistry,
+            GetRootMappedPropertyPairs(invocation, sourceType, destinationType, semanticModel));
+    }
+
+    private static HashSet<string> FindRecursiveDestinationProperties(
+        INamedTypeSymbol sourceType,
+        INamedTypeSymbol destinationType,
+        CreateMapRegistry createMapRegistry,
+        ImmutableArray<(IPropertySymbol SourceProperty, IPropertySymbol DestinationProperty)> rootMappedPairs
+    )
+    {
         var recursiveProperties = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var visited = new HashSet<string>(StringComparer.Ordinal);
         visited.Add(GetTypePairKey(sourceType, destinationType));
 
-        foreach ((IPropertySymbol sourceProperty, IPropertySymbol destinationProperty) in
-                 GetConventionMappedPropertyPairs(sourceType, destinationType))
+        foreach ((IPropertySymbol sourceProperty, IPropertySymbol destinationProperty) in rootMappedPairs)
         {
             ITypeSymbol sourcePropertyType = UnwrapCollectionElementType(sourceProperty.Type);
             ITypeSymbol destinationPropertyType = UnwrapCollectionElementType(destinationProperty.Type);
@@ -365,7 +410,8 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
     private static bool HasMappedCircularReference(
         ITypeSymbol? sourceType,
         ITypeSymbol? destinationType,
-        CreateMapRegistry createMapRegistry
+        CreateMapRegistry createMapRegistry,
+        ImmutableArray<(IPropertySymbol SourceProperty, IPropertySymbol DestinationProperty)> rootMappedPairs
     )
     {
         if (sourceType == null || destinationType == null)
@@ -374,7 +420,14 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
         }
 
         var visited = new HashSet<string>(StringComparer.Ordinal);
-        return HasMappedCircularReferenceRecursive(sourceType, destinationType, visited, createMapRegistry, 0, 10);
+        return HasMappedCircularReferenceRecursive(
+            sourceType,
+            destinationType,
+            visited,
+            createMapRegistry,
+            0,
+            10,
+            rootMappedPairs);
     }
 
     private static bool HasMappedCircularReferenceRecursive(
@@ -383,7 +436,8 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
         HashSet<string> visited,
         CreateMapRegistry createMapRegistry,
         int depth,
-        int maxDepth
+        int maxDepth,
+        ImmutableArray<(IPropertySymbol SourceProperty, IPropertySymbol DestinationProperty)> rootMappedPairs = default
     )
     {
         // Prevent stack overflow by limiting recursion depth
@@ -406,8 +460,12 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
 
         visited.Add(typePairKey);
 
-        foreach ((IPropertySymbol sourceProperty, IPropertySymbol destinationProperty) in
-                 GetConventionMappedPropertyPairs(currentSourceType, currentDestinationType))
+        IEnumerable<(IPropertySymbol SourceProperty, IPropertySymbol DestinationProperty)> mappedPairs =
+            depth == 0 && !rootMappedPairs.IsDefault
+                ? rootMappedPairs
+                : GetConventionMappedPropertyPairs(currentSourceType, currentDestinationType);
+
+        foreach ((IPropertySymbol sourceProperty, IPropertySymbol destinationProperty) in mappedPairs)
         {
             ITypeSymbol sourcePropertyType = UnwrapCollectionElementType(sourceProperty.Type);
             ITypeSymbol destinationPropertyType = UnwrapCollectionElementType(destinationProperty.Type);
@@ -442,6 +500,137 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
+    }
+
+    private static ImmutableArray<(IPropertySymbol SourceProperty, IPropertySymbol DestinationProperty)>
+        GetRootMappedPropertyPairs(
+            InvocationExpressionSyntax invocation,
+            ITypeSymbol sourceType,
+            ITypeSymbol destinationType,
+            SemanticModel semanticModel
+        )
+    {
+        var mappedPairs = GetConventionMappedPropertyPairs(sourceType, destinationType).ToList();
+        var configuredMembers = new List<(
+            IPropertySymbol DestinationProperty,
+            InvocationExpressionSyntax ForMemberInvocation)>();
+
+        foreach (InvocationExpressionSyntax chainedInvocation in
+                 MappingChainAnalysisHelper.GetScopedChainInvocations(
+                     invocation,
+                     semanticModel,
+                     stopAtReverseMapBoundary: true))
+        {
+            if (!MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(
+                    chainedInvocation,
+                    semanticModel,
+                    "ForMember")
+                || chainedInvocation.ArgumentList.Arguments.Count < 2
+                || !TryGetDirectSelectedProperty(
+                    chainedInvocation.ArgumentList.Arguments[0].Expression,
+                    semanticModel,
+                    out IPropertySymbol destinationProperty))
+            {
+                continue;
+            }
+
+            configuredMembers.Add((destinationProperty, chainedInvocation));
+        }
+
+        foreach ((IPropertySymbol destinationProperty, InvocationExpressionSyntax forMemberInvocation) in
+                 configuredMembers)
+        {
+            int configurationCount = configuredMembers.Count(candidate =>
+                SymbolEqualityComparer.Default.Equals(candidate.DestinationProperty, destinationProperty));
+            if (configurationCount != 1
+                || !TryGetDirectMapFromSourceProperty(
+                    forMemberInvocation,
+                    semanticModel,
+                    out IPropertySymbol sourceProperty)
+                || mappedPairs.Any(pair =>
+                    SymbolEqualityComparer.Default.Equals(pair.DestinationProperty, destinationProperty)))
+            {
+                continue;
+            }
+
+            mappedPairs.Add((sourceProperty, destinationProperty));
+        }
+
+        return mappedPairs.ToImmutableArray();
+    }
+
+    private static bool TryGetDirectMapFromSourceProperty(
+        InvocationExpressionSyntax forMemberInvocation,
+        SemanticModel semanticModel,
+        out IPropertySymbol sourceProperty)
+    {
+        sourceProperty = null!;
+        if (forMemberInvocation.ArgumentList.Arguments.Count < 2)
+        {
+            return false;
+        }
+
+        ImmutableArray<InvocationExpressionSyntax> mapFromInvocations = forMemberInvocation.ArgumentList.Arguments[1]
+            .Expression
+            .DescendantNodesAndSelf()
+            .OfType<InvocationExpressionSyntax>()
+            .Where(candidate => MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(
+                candidate,
+                semanticModel,
+                "MapFrom"))
+            .ToImmutableArray();
+
+        return mapFromInvocations.Length == 1
+               && mapFromInvocations[0].ArgumentList.Arguments.Count == 1
+               && TryGetDirectSelectedProperty(
+                   mapFromInvocations[0].ArgumentList.Arguments[0].Expression,
+                   semanticModel,
+                   out sourceProperty);
+    }
+
+    private static bool TryGetDirectSelectedProperty(
+        ExpressionSyntax selector,
+        SemanticModel semanticModel,
+        out IPropertySymbol property)
+    {
+        property = null!;
+
+        string? parameterName;
+        MemberAccessExpressionSyntax? memberAccess;
+        switch (selector)
+        {
+            case SimpleLambdaExpressionSyntax
+            {
+                Body: MemberAccessExpressionSyntax simpleMemberAccess
+            } simpleLambda:
+                parameterName = simpleLambda.Parameter.Identifier.ValueText;
+                memberAccess = simpleMemberAccess;
+                break;
+            case ParenthesizedLambdaExpressionSyntax
+            {
+                ParameterList.Parameters.Count: 1,
+                Body: MemberAccessExpressionSyntax parenthesizedMemberAccess
+            } parenthesizedLambda:
+                parameterName = parenthesizedLambda.ParameterList.Parameters[0].Identifier.ValueText;
+                memberAccess = parenthesizedMemberAccess;
+                break;
+            default:
+                return false;
+        }
+
+        if (memberAccess.Expression is not IdentifierNameSyntax identifier
+            || !string.Equals(identifier.Identifier.ValueText, parameterName, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (semanticModel.GetSymbolInfo(memberAccess).Symbol is not IPropertySymbol resolvedProperty)
+        {
+            return false;
+        }
+
+        property = resolvedProperty;
+        return true;
     }
 
     private static IEnumerable<(IPropertySymbol SourceProperty, IPropertySymbol DestinationProperty)>

--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM022_InfiniteRecursionCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM022_InfiniteRecursionCodeFixProvider.cs
@@ -54,6 +54,10 @@ public class AM022_InfiniteRecursionCodeFixProvider : AutoMapperCodeFixProviderB
             ImmutableList<string> cycleProperties = FindCycleBreakingProperties(
                 createMapTypes.Item1,
                 createMapTypes.Item2,
+                invocation,
+                operationContext.SemanticModel);
+            InvocationExpressionSyntax ignoreInsertionPoint = FindIgnoreInsertionPoint(
+                invocation,
                 operationContext.SemanticModel);
 
             // Best-first: MaxDepth scaffold first (consistent single- and multi-property), then Ignore.
@@ -72,7 +76,11 @@ public class AM022_InfiniteRecursionCodeFixProvider : AutoMapperCodeFixProviderB
                     CodeAction.Create(
                         $"Ignore circular property '{propertyName}' (manual review)",
                         cancellationToken =>
-                            AddIgnoreAsync(context.Document, operationContext.Root, invocation, propertyName),
+                            AddIgnoreAsync(
+                                context.Document,
+                                operationContext.Root,
+                                ignoreInsertionPoint,
+                                propertyName),
                         $"AM022_Ignore_{propertyName}"),
                     diagnostic);
             }
@@ -82,7 +90,7 @@ public class AM022_InfiniteRecursionCodeFixProvider : AutoMapperCodeFixProviderB
                     CodeAction.Create(
                         $"Ignore all {cycleProperties.Count} circular properties (manual review)",
                         cancellationToken =>
-                            AddIgnoreMultipleAsync(context.Document, operationContext.Root, invocation,
+                            AddIgnoreMultipleAsync(context.Document, operationContext.Root, ignoreInsertionPoint,
                                 cycleProperties),
                         "AM022_IgnoreAll"),
                     diagnostic);
@@ -93,6 +101,7 @@ public class AM022_InfiniteRecursionCodeFixProvider : AutoMapperCodeFixProviderB
     private static ImmutableList<string> FindCycleBreakingProperties(
         ITypeSymbol sourceType,
         ITypeSymbol destType,
+        InvocationExpressionSyntax invocation,
         SemanticModel semanticModel)
     {
         // Prefer the same graph edges the analyzer uses for Ignore suppression so the lightbulb
@@ -101,7 +110,12 @@ public class AM022_InfiniteRecursionCodeFixProvider : AutoMapperCodeFixProviderB
         {
             CreateMapRegistry registry = CreateMapRegistry.FromCompilation(semanticModel.Compilation);
             HashSet<string> recursive = AM022_InfiniteRecursionAnalyzer
-                .FindRecursiveDestinationProperties(namedSource, namedDest, registry);
+                .FindRecursiveDestinationProperties(
+                    namedSource,
+                    namedDest,
+                    registry,
+                    invocation,
+                    semanticModel);
             if (recursive.Count > 0)
             {
                 return recursive.OrderBy(name => name, StringComparer.Ordinal).ToImmutableList();
@@ -110,6 +124,32 @@ public class AM022_InfiniteRecursionCodeFixProvider : AutoMapperCodeFixProviderB
 
         // Fallback: destination same-type self-references when the graph walk is empty.
         return FindSelfReferencingProperties(destType);
+    }
+
+    private static InvocationExpressionSyntax FindIgnoreInsertionPoint(
+        InvocationExpressionSyntax createMapInvocation,
+        SemanticModel semanticModel)
+    {
+        foreach (InvocationExpressionSyntax chainedInvocation in MappingChainAnalysisHelper
+                     .GetScopedChainInvocations(
+                         createMapInvocation,
+                         semanticModel,
+                         stopAtReverseMapBoundary: true)
+                     .Reverse())
+        {
+            SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(chainedInvocation);
+            IEnumerable<IMethodSymbol> methodSymbols = symbolInfo.Symbol is IMethodSymbol method
+                ? new[] { method }
+                : symbolInfo.CandidateSymbols.OfType<IMethodSymbol>();
+
+            if (methodSymbols.Any(candidate =>
+                    MappingChainAnalysisHelper.IsAutoMapperMethod(candidate, candidate.Name)))
+            {
+                return chainedInvocation;
+            }
+        }
+
+        return createMapInvocation;
     }
 
     private static ImmutableList<string> FindSelfReferencingProperties(ITypeSymbol destType)

--- a/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
@@ -130,7 +130,7 @@ public static class RuleCatalog
     /// <summary>
     ///     Current package version used by docs/package drift tests.
     /// </summary>
-    public const string CurrentPackageVersion = "2.30.69";
+    public const string CurrentPackageVersion = "2.30.70";
 
     /// <summary>
     ///     Implemented rules, grouped by public diagnostic ID.

--- a/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM022_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM022_CodeFixTests.cs
@@ -841,6 +841,94 @@ public class AM022_CodeFixTests
     }
 
     [Fact]
+    public async Task AM022_ShouldOfferEffectiveIgnoreForDirectForMemberCycleEdge()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class SourceParent
+                                    {
+                                        public SourceChild Child { get; set; }
+                                    }
+
+                                    public class SourceChild
+                                    {
+                                        public SourceParent Parent { get; set; }
+                                    }
+
+                                    public class DestinationParent
+                                    {
+                                        public DestinationChild RenamedChild { get; set; }
+                                    }
+
+                                    public class DestinationChild
+                                    {
+                                        public DestinationParent Parent { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<SourceParent, DestinationParent>()
+                                                .ForMember(destination => destination.RenamedChild, options => options.MapFrom(source => source.Child));
+                                            CreateMap<SourceChild, DestinationChild>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string expectedFixedCode = """
+                                         using AutoMapper;
+
+                                         namespace TestNamespace
+                                         {
+                                             public class SourceParent
+                                             {
+                                                 public SourceChild Child { get; set; }
+                                             }
+
+                                             public class SourceChild
+                                             {
+                                                 public SourceParent Parent { get; set; }
+                                             }
+
+                                             public class DestinationParent
+                                             {
+                                                 public DestinationChild RenamedChild { get; set; }
+                                             }
+
+                                             public class DestinationChild
+                                             {
+                                                 public DestinationParent Parent { get; set; }
+                                             }
+
+                                             public class TestProfile : Profile
+                                             {
+                                                 public TestProfile()
+                                                 {
+                                                     CreateMap<SourceParent, DestinationParent>()
+                                                         .ForMember(destination => destination.RenamedChild, options => options.MapFrom(source => source.Child)).ForMember(dest => dest.RenamedChild, opt => opt.Ignore());
+                                                     CreateMap<SourceChild, DestinationChild>();
+                                                 }
+                                             }
+                                         }
+                                         """;
+
+        // Index 0 remains MaxDepth; index 1 appends Ignore after the existing MapFrom so Ignore wins.
+        await CodeFixVerifier<AM022_InfiniteRecursionAnalyzer, AM022_InfiniteRecursionCodeFixProvider>
+            .VerifyFixAsync(
+                testCode,
+                new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule)
+                    .WithLocation(29, 13)
+                    .WithArguments("SourceParent", "DestinationParent"),
+                expectedFixedCode,
+                codeActionIndex: 1);
+    }
+
+    [Fact]
     public async Task AM022_ShouldIgnoreAllGraphEdges_WhenSelfRefAndMultiTypeCycleBothPresent()
     {
         // DestA has Parent: DestA (self-ref) and BReference: DestB (multi-type edge).

--- a/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM022_InfiniteRecursionTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM022_InfiniteRecursionTests.cs
@@ -1960,4 +1960,314 @@ public class AM022_InfiniteRecursionTests
             .ExpectDiagnostic(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule, 30, 13, "SourceB", "DestB")
             .RunAsync();
     }
+
+    [Fact]
+    public async Task AM022_ShouldReportRootDiagnostic_WhenDirectForMemberMapFromClosesConfiguredCycle()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class SourceParent
+                                    {
+                                        public SourceChild Child { get; set; }
+                                    }
+
+                                    public class SourceChild
+                                    {
+                                        public SourceParent Parent { get; set; }
+                                    }
+
+                                    public class DestinationParent
+                                    {
+                                        public DestinationChild RenamedChild { get; set; }
+                                    }
+
+                                    public class DestinationChild
+                                    {
+                                        public DestinationParent Parent { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<SourceParent, DestinationParent>()
+                                                .ForMember(destination => destination.RenamedChild, options => options.MapFrom(source => source.Child));
+                                            CreateMap<SourceChild, DestinationChild>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM022_InfiniteRecursionAnalyzer>()
+            .WithSource(testCode)
+            .ExpectDiagnostic(
+                AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule,
+                29,
+                13,
+                "SourceParent",
+                "DestinationParent")
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM022_ShouldNotReportDiagnostic_WhenDirectForMemberCycleNestedMapIsMissing()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class SourceParent
+                                    {
+                                        public SourceChild Child { get; set; }
+                                    }
+
+                                    public class SourceChild
+                                    {
+                                        public SourceParent Parent { get; set; }
+                                    }
+
+                                    public class DestinationParent
+                                    {
+                                        public DestinationChild RenamedChild { get; set; }
+                                    }
+
+                                    public class DestinationChild
+                                    {
+                                        public DestinationParent Parent { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<SourceParent, DestinationParent>()
+                                                .ForMember(destination => destination.RenamedChild, options => options.MapFrom(source => source.Child));
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM022_InfiniteRecursionAnalyzer>()
+            .WithSource(testCode)
+            .ExpectNoDiagnostics()
+            .RunAsync();
+    }
+
+    [Theory]
+    [InlineData(".MaxDepth(2)")]
+    [InlineData(".PreserveReferences()")]
+    [InlineData(".ConvertUsing((SourceChild source) => new DestinationChild())")]
+    public async Task AM022_ShouldNotReportDiagnostic_WhenDirectForMemberCycleNestedMapIsConstrained(
+        string cycleBreaker)
+    {
+        string testCode = $$"""
+                            using AutoMapper;
+
+                            namespace TestNamespace
+                            {
+                                public class SourceParent
+                                {
+                                    public SourceChild Child { get; set; }
+                                }
+
+                                public class SourceChild
+                                {
+                                    public SourceParent Parent { get; set; }
+                                }
+
+                                public class DestinationParent
+                                {
+                                    public DestinationChild RenamedChild { get; set; }
+                                }
+
+                                public class DestinationChild
+                                {
+                                    public DestinationParent Parent { get; set; }
+                                }
+
+                                public class TestProfile : Profile
+                                {
+                                    public TestProfile()
+                                    {
+                                        CreateMap<SourceParent, DestinationParent>()
+                                            .ForMember(destination => destination.RenamedChild, options => options.MapFrom(source => source.Child));
+                                        CreateMap<SourceChild, DestinationChild>(){{cycleBreaker}};
+                                    }
+                                }
+                            }
+                            """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM022_InfiniteRecursionAnalyzer>()
+            .WithSource(testCode)
+            .ExpectNoDiagnostics()
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM022_ShouldNotReportDiagnostic_WhenMapFromExpressionIsTransformed()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class SourceParent
+                                    {
+                                        public SourceChild Child { get; set; }
+                                    }
+
+                                    public class SourceChild
+                                    {
+                                        public SourceParent Parent { get; set; }
+                                    }
+
+                                    public class DestinationParent
+                                    {
+                                        public DestinationChild RenamedChild { get; set; }
+                                    }
+
+                                    public class DestinationChild
+                                    {
+                                        public DestinationParent Parent { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<SourceParent, DestinationParent>()
+                                                .ForMember(destination => destination.RenamedChild, options =>
+                                                    options.MapFrom(source => SelectChild(source.Child)));
+                                            CreateMap<SourceChild, DestinationChild>();
+                                        }
+
+                                        private static SourceChild SelectChild(SourceChild child) => child;
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM022_InfiniteRecursionAnalyzer>()
+            .WithSource(testCode)
+            .ExpectNoDiagnostics()
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM022_ShouldNotReportDiagnostic_WhenDestinationMemberHasDuplicateConfiguration()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class SourceParent
+                                    {
+                                        public SourceChild Child { get; set; }
+                                    }
+
+                                    public class SourceChild
+                                    {
+                                        public SourceParent Parent { get; set; }
+                                    }
+
+                                    public class DestinationParent
+                                    {
+                                        public DestinationChild RenamedChild { get; set; }
+                                    }
+
+                                    public class DestinationChild
+                                    {
+                                        public DestinationParent Parent { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<SourceParent, DestinationParent>()
+                                                .ForMember(destination => destination.RenamedChild, options => options.MapFrom(source => source.Child))
+                                                .ForMember(destination => destination.RenamedChild, options => options.MapFrom(source => source.Child));
+                                            CreateMap<SourceChild, DestinationChild>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM022_InfiniteRecursionAnalyzer>()
+            .WithSource(testCode)
+            .ExpectNoDiagnostics()
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM022_ShouldNotReportDiagnostic_WhenMapFromIsNotAutoMapperOwned()
+    {
+        const string testCode = """
+                                using AutoMapper;
+                                using System;
+
+                                namespace TestNamespace
+                                {
+                                    public class SourceParent
+                                    {
+                                        public SourceChild Child { get; set; }
+                                    }
+
+                                    public class SourceChild
+                                    {
+                                        public SourceParent Parent { get; set; }
+                                    }
+
+                                    public class DestinationParent
+                                    {
+                                        public DestinationChild RenamedChild { get; set; }
+                                    }
+
+                                    public class DestinationChild
+                                    {
+                                        public DestinationParent Parent { get; set; }
+                                    }
+
+                                    public sealed class CustomMemberConfiguration
+                                    {
+                                        public void MapFrom<TSource>(Func<TSource, SourceChild> selector)
+                                        {
+                                        }
+                                    }
+
+                                    public static class CustomMemberExtensions
+                                    {
+                                        public static CustomMemberConfiguration Custom<TSource, TDestination, TMember>(
+                                            this IMemberConfigurationExpression<TSource, TDestination, TMember> options) => new();
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<SourceParent, DestinationParent>()
+                                                .ForMember(
+                                                    destination => destination.RenamedChild,
+                                                    options => options.Custom().MapFrom((SourceParent source) => source.Child));
+                                            CreateMap<SourceChild, DestinationChild>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM022_InfiniteRecursionAnalyzer>()
+            .WithSource(testCode)
+            .ExpectNoDiagnostics()
+            .RunAsync();
+    }
 }


### PR DESCRIPTION
## Verdict

AM022 now detects a concrete hidden recursion risk when the current map renames a root edge through a direct `ForMember(...MapFrom...)`. The inference is deliberately narrow, and the Ignore alternative is appended after MapFrom so it is effective.

## Evidence

- External AutoMapper 14 repro: the renamed-edge cycle emitted no AM022, while the convention-named control emitted AM022.
- TDD red phase: the new analyzer and fixer regressions both failed with zero diagnostics before implementation.
- AM022 suite: 75 passed.
- Clean-branch full suite expected by CI: 1,423 passed, 0 skipped, 0 failed.
- Local superset full suite: 1,444 passed, 0 skipped, 0 failed.
- Release build: 0 warnings, 0 errors.
- Catalog, snapshots, and compatibility documentation checks passed.
- v2.30.70 package SHA-256: `837154b25d457fdd465cc680d938cb8f56a0e207a0e2a79b444889aed91a8335`.
- Healthy net10/AutoMapper 14 consumer built cleanly; broken consumer failed specifically with AM001.
- Slopwatch found no issues in the changed source/test slice.
- Remote compare: one commit, 15 intended files, no trailing-whitespace or conflict-marker additions.

## Safety boundary

- Include only one unique, semantic AutoMapper `ForMember` on the current forward root map.
- Require direct property selectors and direct expression-bodied `MapFrom(source => source.Property)`.
- Exclude duplicate destination configuration, `ForPath`, reverse segments, blocks, calls/transforms, resolvers, converters, lookalikes, and downstream explicit-member inference.
- Preserve downstream `MaxDepth`, `PreserveReferences`, and `ConvertUsing` cycle breakers.
- Keep MaxDepth first; append Ignore after the existing MapFrom.

## Release

Prepares v2.30.70. Merge only after required CI, package-smoke, Codecov upload, and review surfaces are clean.