### PR TITLE
fix: detect AM022 cycles across downstream renamed member maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+## [2.30.71] - 2026-07-16
+
+AM022 downstream direct member-map cycle detection.
+
+### Changed
+
+- **AM022 downstream direct `ForMember(...MapFrom...)` edges**: uniquely registered forward maps now contribute strict direct property-to-property edges throughout the configured recursion graph, so cycles with renamed members on multiple legs report every owning `CreateMap`.
+- **Conservative boundary**: duplicate mapping directions, reverse-generated mappings, duplicate destination configuration, transformed expressions, `ForPath` member inference, lookalike APIs, resolvers, and converters remain excluded; downstream `MaxDepth`, `PreserveReferences`, and `ConvertUsing` still terminate traversal.
+- **Graph-breaking fix**: semantic `ForMember` and `ForPath` Ignore overrides remove the destination edge when downstream maps are replayed. One root Ignore action therefore clears all diagnostics for the broken cycle and is appended after an existing `MapFrom` so it is effective.
+
+### Validation
+
+- AM022 analyzer and code-fix suite: **85** passed.
+- Full solution suite: **1433** passed, 0 skipped, 0 failed on `net10.0`.
+
 ## [2.30.70] - 2026-07-16
 
 AM022 direct member-map cycle detection.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet Version](https://img.shields.io/nuget/v/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=NuGet)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=Downloads)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/georgepwall1991/automapper-analyser/ci.yml?style=flat-square&logo=github&label=Build)](https://github.com/georgepwall1991/automapper-analyser/actions)
-[![Tests](https://img.shields.io/badge/Tests-1423%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
+[![Tests](https://img.shields.io/badge/Tests-1433%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
 [![.NET](https://img.shields.io/badge/.NET-4.8+%20%7C%206.0+%20%7C%208.0+%20%7C%209.0+%20%7C%2010.0+-512BD4?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 [![Coverage](https://img.shields.io/codecov/c/github/georgepwall1991/automapper-analyser?style=flat-square&logo=codecov&label=Coverage)](https://codecov.io/gh/georgepwall1991/automapper-analyser)
@@ -14,22 +14,23 @@ prevention*
 
 ---
 
-## 🎉 Latest Release: v2.30.70
+## 🎉 Latest Release: v2.30.71
 
-**AM022 direct member-map cycle detection**
+**AM022 downstream direct member-map cycle detection**
 
 ✅ **Highlights**
 
-- Direct property-to-property `ForMember(...MapFrom...)` mappings now participate in root cycle detection even when member names differ.
-- Duplicate, transformed, reverse, lookalike, and downstream explicit-member shapes remain conservatively excluded.
-- Ignore is appended after the existing MapFrom so the generated cycle breaker is effective; MaxDepth remains first.
+- Unique forward property-to-property `ForMember(...MapFrom...)` mappings now participate throughout configured recursion graphs, including cycles whose multiple legs rename members.
+- Duplicate mapping directions, transformed expressions, reverse-generated mappings, lookalikes, and ambiguous destination configuration remain conservatively excluded.
+- Downstream cycle breakers still stop traversal, and semantic `ForMember`/`ForPath` Ignore overrides remove replayed edges so one effective root Ignore clears the cycle.
 
 🧪 **Validation**
 
-- AM022 suite: **75** passed; clean-branch full suite: **1423** passed, 0 skipped, 0 failed on `net10.0`.
+- AM022 suite: **85** passed; full solution suite: **1433** passed, 0 skipped, 0 failed on `net10.0`.
 
 ### Recent Releases
 
+- **v2.30.71**: AM022 follows unique direct renamed member maps throughout the configured cycle graph while downstream `ForMember`/`ForPath` Ignore overrides remove broken edges.
 - **v2.30.70**: AM022 detects direct renamed `ForMember(...MapFrom...)` cycle edges and emits an effective Ignore alternative.
 - **v2.30.69**: AM032 makes nullable-destination null propagation primary while retaining the throw policy.
 - **v2.30.68**: AM011 single-property fixes stop manufacturing required domain data when no unique fuzzy source match exists.
@@ -236,7 +237,7 @@ Install-Package AutoMapperAnalyzer.Analyzers
 ### Project File (For CI/CD)
 
 ```xml
-<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.70">
+<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.71">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 </PackageReference>

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -1,12 +1,12 @@
 # Analyzer Health
 
-Reviewed: 2026-07-16 (AM022 direct member-map cycle detection prepared as **2.30.70**)
+Reviewed: 2026-07-16 (AM022 downstream direct member-map cycle detection prepared as **2.30.71**)
 
 This is a deliberately harsh health audit for the **21** implemented AutoMapper analyzer rule IDs in this repository (16 before the 2.30.62 performance split). Several rule IDs still expose multiple diagnostic descriptors, especially `AM002` and `AM022`; the scorecard rates the public rule ID as the user experiences it.
 
 Every implemented rule currently has an analyzer and a code fix provider. Scores are 1-5, where `5` means reference-quality and hard to improve, `3` means usable but meaningfully incomplete, and `1` means unreliable or underbuilt.
 
-**Ship status:** production-acceptable. **2.30.70** AM022 direct member-map cycle detection; **2.30.69** AM032 destination-aware null fixes; **2.30.68** AM011 single-property fixer honesty; **2.30.67** performance `ForPath` Ignore scaffolds. Every rule now has minimum health 4. Full suite green; catalog/snapshots current.
+**Ship status:** production-acceptable. **2.30.71** AM022 downstream direct member-map cycle detection; **2.30.70** AM022 direct root member-map cycle detection; **2.30.69** AM032 destination-aware null fixes; **2.30.68** AM011 single-property fixer honesty. Every rule now has minimum health 4. Full suite green; catalog/snapshots current.
 
 ## Rubric
 
@@ -42,7 +42,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | AM011 | Required destination property is not mapped | Data Integrity | Error | 4 | 5 | 4 | 5 | 5 | 5 | Low | Important runtime-failure guardrail; per-property fuzzy resolves ReverseMap types. **2.30.68**: single-property fixes map only a unique compatible fuzzy source; otherwise the sole fallback is explicit Ignore, never fabricated required data. Aggregate Map-all stays unique-fuzzy-only; mixed/default bulk remains honest Scaffold-all + manual review; stale diagnostics withhold. |
 | AM020 | Nested object mapping configuration missing | Complex Mappings | Warning | 4 | 4 | 4 | 5 | 5 | 5 | Low | Reference analyzer; fixer now shares public+internal property discovery with the analyzer (internal nested CreateMap fix covered). Catalog trust is `LikelyRewrite` (constructor-body insertion remains a structural limit). |
 | AM021 | Collection element type incompatibility | Complex Mappings | Warning | 4 | 4 | 4 | 5 | 4 | 4 | Low | Defers fully when AM003 owns container incompatibility (shared helper). Same-container element mismatches, dictionary axes, reverse gaps, and implicit element conversions remain AM021. List simple Select rewrites now refuse non-compiling Parse destinations (string-source gate matches dictionaries). |
-| AM022 | Infinite recursion risk | Complex Mappings | Warning | 4 | 4 | 4 | 5 | 4 | 4 | Low | Requires configured nested CreateMap chains for indirect cycles; strong semantic suppressions. **2.30.70**: uniquely configured direct root `ForMember(...MapFrom(source => source.Property))` edges close renamed cycles; duplicate, transformed, reverse, lookalike, and downstream explicit-member shapes remain excluded. Ignore is appended after MapFrom so it wins; downstream `MaxDepth`, `PreserveReferences`, and `ConvertUsing` still terminate traversal. Catalog `Scaffold` remains honest. |
+| AM022 | Infinite recursion risk | Complex Mappings | Warning | 4 | 4 | 4 | 5 | 4 | 4 | Low | Requires configured nested CreateMap chains for indirect cycles; strong semantic suppressions. **2.30.71**: uniquely registered forward `ForMember(...MapFrom(source => source.Property))` edges close renamed cycles at the root and downstream, so every owning map reports. Duplicate directions, duplicate destination configuration, transformed expressions, reverse-generated mappings, lookalikes, `ForPath` member inference, resolvers, and converters remain excluded. Semantic `ForMember`/`ForPath` Ignore overrides remove replayed downstream edges, so one effective root Ignore clears the cycle; downstream `MaxDepth`, `PreserveReferences`, and `ConvertUsing` also terminate traversal. Catalog `Scaffold` remains honest. |
 | AM030 | Invalid type converter implementation | Custom Conversions | Error | 4 | 4 | 4 | 4 | 4 | 3 | Low | Analyzer-only by design; AM001/AM020/AM021 own missing-converter mapping. Split from AM032/AM033 is clean in catalog and trust tests. Direct AM030 coverage includes empty implementation, wrong return type, missing `ResolutionContext`, and non-public `Convert` (each paired with the matching compiler error). |
 | AM032 | Type converter null handling | Custom Conversions | Warning | 4 | 4 | 5 | 5 | 4 | 4 | Low | Best-in-class null-guard detection with catalog `LikelyRewrite` trust. Recognizes `ThrowIfNull*`, switch/pattern/coalesce/conditional-access guards, and nullable pass-through. **Fix Strategy 5 (2.30.69)**: proven nullable destinations offer return-null first plus the retained throw policy; non-nullable, oblivious, and unproven destinations remain throw-only. Residual analyzer work is heuristic null-flow only and requires a concrete repro. |
 | AM033 | Unused type converter | Custom Conversions | Info | 4 | 4 | 4 | 4 | 4 | 2 | Low | Unused-converter diagnostics now have their own Info rule ID and remain analyzer-only, and the shared converter code-fix provider no longer advertises AM033 as fixable. Usage analysis recognizes generic, instance, type-based including parenthesized/casted `typeof(...)` and simple explicit or implicit `Type` locals/fields/properties initialized from, expression-bodied to, or getter-bodied to `typeof(...)`, parameterless `Type` factory methods and local functions that expression-body or return `typeof(...)`, simple interface-typed locals/fields/properties, and DI/service-provider interface handles passed to `ConvertUsing(...)`. Product importance is intentionally lower because this is cleanup guidance. |
@@ -73,7 +73,7 @@ Use this table as the hardening queue. Ranking = **Importance × (5 − min(Anal
 | --- | --- | --- | --- | --- |
 | 1 | **AM001** | gap=4, min=4 | Property-token placement shipped 2.30.64. Residual: advanced conversion modelling only with user repros. | — |
 | 2 | **AM002** | gap=5, min=4 | Advanced generic/nullability-flow only — wait for real user FP/FN. | — until evidence |
-| 3 | **AM022** | gap=4, min=4 | Direct renamed root edges shipped 2.30.70. Downstream explicit-member inference remains opportunistic and repro-gated. | — until evidence |
+| 3 | **AM022** | gap=4, min=4 | Direct renamed root edges shipped 2.30.70; concrete downstream renamed-edge false negative closed in 2.30.71. Advanced configuration inference remains repro-gated. | — until evidence |
 | 4 | **AM020 / AM021 / AM003** | gap=5/4 | Custom-collection / constructor-body insert structural limits. | Opportunistic |
 | 5 | **AM041 / AM050** | gap=4/2 | SafeRewrite nuance / low Importance. | Low ROI |
 | 6 | **AM033 / AM005 / AM030** | gap=2–3 | Importance-limited. | Product priority only |
@@ -81,7 +81,7 @@ Use this table as the hardening queue. Ranking = **Importance × (5 − min(Anal
 **Recommended next hardening batch:**
 
 1. **Monitor sweep** for a new evidence-backed residual
-2. **AM022 downstream explicit-member precision only with a concrete compiling repro**
+2. Advance AM001, AM002, or AM022 only when a concrete compiling false positive/negative proves the gap
 
 Do **not** open advanced AM001/AM002 conversion/nullability modelling without a filed false-positive/false-negative repro.
 
@@ -304,7 +304,7 @@ Full rule+fixer reanalysis driven by four parallel subagent audits (Type Safety,
 - AM021 now respects compiler-known implicit element conversions from Roslyn conversion classification, including user-defined value-object conversions such as `Money` to `decimal`, while explicit-only element conversions and reverse-map directions where a forward implicit conversion is not reversible still report.
 - AM021 simple-conversion fixes now emit fully qualified `global::System.Convert`, `global::System.DateTime`, and `global::System.Guid` calls instead of relying on `using System`, avoiding user-type shadowing in generated mappings. Immutable/frozen destination collections use fully qualified `ImmutableList.CreateRange(...)`, `ImmutableHashSet.CreateRange(...)`, and `FrozenSet.ToFrozenSet(...)` factory calls, while custom collection lookalikes stay on the manual-review ignore path.
 - AM021's Tests score is now calibrated to 5, matching AM022 after the current coverage review found comparable analyzer breadth and stronger code-fix method count for AM021.
-- AM022 ignore suppression now uses semantic AutoMapper method ownership, so helper calls such as `MappingHelpers.Ignore()` inside a `ForMember` options lambda no longer hide a real recursion diagnostic. AM022 also reuses the shared namespace-aware built-in classifier for simple-type pruning, keeping actual `System.Guid`/`DateTime`-style framework types out of recursion graphs without suppressing user-defined domain types that share those short names.
+- AM022 ignore suppression uses semantic AutoMapper method ownership, so helper calls such as `MappingHelpers.Ignore()` inside a `ForMember` options lambda do not hide a real recursion diagnostic. In 2.30.71, strict direct property-to-property member maps from a unique forward registration also participate downstream; duplicate directions, reverse-generated mappings, transforms, and ambiguous member configuration remain outside inference. AM022 also reuses the shared namespace-aware built-in classifier for simple-type pruning, keeping actual `System.Guid`/`DateTime`-style framework types out of recursion graphs without suppressing user-defined domain types that share those short names.
 - AM041 duplicate-map diagnostics now include constructed generic type arguments and array element types/ranks, so collection duplicates name the actionable source/destination shapes instead of collapsing both sides to the metadata type name.
 - AM041 now avoids offering the duplicate-map removal fix for `ReverseMap().ForMember(...)` style chains, including parenthesized chains, where the reverse direction carries additional configuration that cannot be safely rewritten.
 - AM041 now also withholds the duplicate-map removal fix when the duplicate is a `CreateMap<TSource, TDestination>()` registration carrying chained mapping configuration — including `CreateMap<>().ForMember(...)`, parenthesized `(CreateMap<>()).ForMember(...)`, and `CreateMap<>().ReverseMap().ForMember(...)` shapes — so policy overrides such as `.ForMember(d => d.X, opt => opt.Ignore())` are no longer silently dropped by an automatic statement removal. Bare `CreateMap<TSource, TDestination>().ReverseMap()` reversals, including `(CreateMap<TSource, TDestination>()).ReverseMap()`, preserve the reverse direction through the safe swapped `CreateMap` rewrite.
@@ -319,17 +319,17 @@ Full rule+fixer reanalysis driven by four parallel subagent audits (Type Safety,
 
 Architecture-style coverage currently comes from analyzer/fixer tests, conflict ownership tests, helper tests, sample projects, documentation, the checked-in `RuleCatalog`, generated trust artifacts, package smoke tests, and the deterministic `tools/AnalyzerVerifier` checks.
 
-Current local verification (**2026-07-16** against the **v2.30.70** release candidate):
+Current local verification (**2026-07-16** against the **v2.30.71** release candidate):
 
-- Package version in `src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj`: **2.30.70**.
+- Package version in `src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj`: **2.30.71**.
 - `dotnet build automapper-analyser.sln --configuration Release -warnaserror` passed: 0 warnings, 0 errors.
-- Clean-branch full suite: **1423** passed, 0 skipped, 0 failed.
+- Clean-branch full suite: **1433** passed, 0 skipped, 0 failed.
 - `dotnet run --project tools/AnalyzerVerifier/AnalyzerVerifier.csproj --configuration Release --no-build -- --check-catalog --check-snapshots` passed: rule catalog and sample diagnostics snapshot are up to date.
 - Remote branch compare is one commit with only the 15 intended source/test/trust/release files and no trailing-whitespace additions.
 - Targeted `dotnet format whitespace` completed on the local candidate; the clean branch preserves the touched files' existing LF convention to avoid whole-file line-ending churn.
 - Sample project emits AM0xx when analyzers run (`-p:RunAnalyzersDuringBuild=true`); local untracked `Directory.Build.props` (if present) may skip analyzers during CLI builds — unit tests + AnalyzerVerifier remain the verification source of truth.
 - Approximate list-tests name hits (not exclusive filters; for trend only): AM001 57, AM002 83, AM003 61, AM004 87, AM005 34, AM006 43, AM011 45, AM020 97, AM021 64, AM022 62, AM030/32/33 bucket 156, AM031 292, AM041 35, AM050 48, RuleCatalog 10.
-- Release metadata is synchronized for `v2.30.70`; tag/publication follows the merged PR.
+- Release metadata is synchronized for `v2.30.71`; tag/publication follows the merged PR.
 - Historical baseline (2026-07-06 @ `b138fa8` / v2.30.55): **1352** tests green — superseded; do not use for planning.
 - The trust-first pass removed active skipped tests, added drift validation, and moved intentional analyzer-test warnings into an explicit test-project warning baseline.
 - `/usr/local/share/dotnet/dotnet --list-runtimes` shows only .NET 10 runtimes in this local environment, so broader multi-TFM runtime verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -725,7 +725,7 @@ dotnet pack --configuration Release
 
 # Test package locally
 cd test-install/NetCoreTest
-dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.70-local
+dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.71-local
 ```
 
 ---
@@ -909,4 +909,4 @@ dotnet build
 
 **Last Updated**: 2026-05-14
 **Maintainer**: George Wall
-**Version**: 2.30.70
+**Version**: 2.30.71

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -112,8 +112,8 @@ The AutoMapper Roslyn Analyzer project uses GitHub Actions for continuous integr
 ### Package Versioning
 
 - **Format**: Major.Minor.Patch (SemVer)
-- **Current**: 2.30.70
-- **Pre-release**: 2.30.70-preview, 2.30.70-beta
+- **Current**: 2.30.71
+- **Pre-release**: 2.30.71-preview, 2.30.71-beta
 
 ## 🔧 Configuration
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -43,7 +43,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.70">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.71">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -67,7 +67,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.70">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.71">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -86,7 +86,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="14.0.0" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.70">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.71">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -218,7 +218,7 @@ public class Destination
 
 2. **Verify Package Installation**
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.70">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.71">
      <PrivateAssets>all</PrivateAssets>
      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -280,4 +280,4 @@ This guide ensures smooth installation and usage across all supported .NET frame
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.70
+**Version**: 2.30.71

--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -975,12 +975,16 @@ that AutoMapper can use for recursion. Ignoring the top-level recursive destinat
 own recursion behavior explicitly. For indirect cycles, the traversal honours these cycle breakers on downstream
 `CreateMap` registrations as well as the root map, including direct same-block calls through a local mapping variable,
 while preserving configuration direction around `ReverseMap()`.
-When the current forward map renames a root edge, AM022 also follows a uniquely configured direct property mapping such
-as `.ForMember(d => d.RenamedChild, o => o.MapFrom(s => s.Child))`. This inference is deliberately root-only and
-requires semantic AutoMapper ownership plus direct expression-bodied property selectors. Duplicate destination
-configuration, `ForPath`, reverse-map segments, blocks, method calls, transforms, resolvers, converters, and downstream
-explicit-member inference remain outside the automatic graph. For these renamed root edges, the Ignore lightbulb is
-appended after the existing MapFrom so Ignore is the effective member policy; MaxDepth remains the first action.
+When a forward map renames an edge, AM022 also follows a uniquely configured direct property mapping such as
+`.ForMember(d => d.RenamedChild, o => o.MapFrom(s => s.Child))` at the root and throughout the configured recursion
+graph. The inference requires exactly one forward registration for the type direction, semantic AutoMapper ownership,
+and direct expression-bodied property selectors. Duplicate mapping directions, duplicate destination configuration,
+`ForPath`, reverse-generated mappings, blocks, method calls, transforms, resolvers, and converters remain outside the
+automatic graph. Downstream `MaxDepth`, `PreserveReferences`, and `ConvertUsing` still terminate the path. For renamed
+root edges, the Ignore lightbulb is appended after the existing MapFrom so Ignore is the effective member policy;
+MaxDepth remains the first action, and breaking one root edge clears every diagnostic for that cycle. Semantic
+`ForMember(...Ignore())` and `ForPath(...Ignore())` overrides also remove that destination edge when a downstream map
+is replayed, including when `ForPath` overrides an earlier direct `MapFrom` for the same member.
 Helper methods named `Ignore` or cycle-breaker names are not treated as suppression unless they resolve to
 AutoMapper's member-configuration `Ignore()` method. Built-in framework types such as `System.Guid` stay out of
 graph recursion analysis, but user-defined types with the same short names are still analyzed.
@@ -1614,7 +1618,7 @@ using System.Diagnostics.CodeAnalysis;
 
 1. **Check package reference**:
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.70">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.71">
        <PrivateAssets>all</PrivateAssets>
        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -1653,5 +1657,5 @@ If analyzer slows down builds:
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.70
+**Version**: 2.30.71
 **Maintainer**: George Wall

--- a/docs/RULE_CATALOG.md
+++ b/docs/RULE_CATALOG.md
@@ -2,7 +2,7 @@
 
 This file is generated from `RuleCatalog`.
 
-Package version: `2.30.70`
+Package version: `2.30.71`
 
 | Rule ID | Descriptor Title | Severity | Category | Analyzer | Code Fix | Trust | Sample | Docs |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,3 +1,15 @@
+## Release 2.30.71
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
+### Removed Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
 ## Release 2.30.70
 
 ### New Rules

--- a/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
+++ b/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
@@ -17,7 +17,7 @@
         <!-- Fallback for local builds: 2.0.YYYYMMDD-local -->
         <MajorVersion>2</MajorVersion>
         <MinorVersion>30</MinorVersion>
-        <PatchVersion>70</PatchVersion>
+        <PatchVersion>71</PatchVersion>
         <BuildNumber Condition="'$(BuildNumber)' == ''"
         >$([System.DateTime]::Now.ToString('yyyyMMdd'))
         </BuildNumber
@@ -32,10 +32,10 @@
         <RepositoryUrl>https://github.com/georgepwall1991/automapper-analyser</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-                <PackageReleaseNotes>Version 2.30.70 - AM022 direct member-map cycle detection
-- Direct property MapFrom edges close renamed root cycles
-- Duplicate, transformed, reverse, lookalike, and downstream explicit shapes remain excluded
-- Ignore is appended after MapFrom so the generated cycle breaker is effective
+                <PackageReleaseNotes>Version 2.30.71 - AM022 downstream direct member-map cycle detection
+- Unique forward direct property MapFrom edges participate throughout configured cycle graphs
+- Duplicate directions, reverse-generated mappings, transformed expressions, and ambiguous members remain excluded
+- Downstream cycle breakers and semantic ForMember/ForPath Ignore overrides terminate traversal; one effective root Ignore clears the cycle
 </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>

--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM022_InfiniteRecursionAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM022_InfiniteRecursionAnalyzer.cs
@@ -79,7 +79,8 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
                 invocationExpr,
                 typeArguments.sourceType,
                 typeArguments.destinationType,
-                context.SemanticModel);
+                context.SemanticModel,
+                createMapRegistry);
 
         // Check if recursion is constrained or the mapping body is custom-owned.
         if (
@@ -260,8 +261,16 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
             return null;
         }
 
+        ExpressionSyntax destinationSelector = forMemberCall.ArgumentList.Arguments[0].Expression;
+        if (MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(forMemberCall, semanticModel, "ForPath"))
+        {
+            return TryGetDirectSelectedProperty(destinationSelector, semanticModel, out IPropertySymbol property)
+                ? property.Name
+                : null;
+        }
+
         return AM020MappingConfigurationHelpers.GetSelectedTopLevelMemberNameWithSemanticModel(
-            forMemberCall.ArgumentList.Arguments[0].Expression,
+            destinationSelector,
             semanticModel);
     }
 
@@ -294,7 +303,11 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
         }
 
         // Check for circular references reachable through proven root member paths.
-        if (HasMappedCircularReference(sourceType, destinationType, createMapRegistry, rootMappedPairs))
+        if (HasMappedCircularReference(
+                sourceType,
+                destinationType,
+                createMapRegistry,
+                rootMappedPairs))
         {
             var diagnostic = Diagnostic.Create(
                 InfiniteRecursionRiskRule,
@@ -365,7 +378,12 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
             sourceType,
             destinationType,
             createMapRegistry,
-            GetRootMappedPropertyPairs(invocation, sourceType, destinationType, semanticModel));
+            GetRootMappedPropertyPairs(
+                invocation,
+                sourceType,
+                destinationType,
+                semanticModel,
+                createMapRegistry));
     }
 
     private static HashSet<string> FindRecursiveDestinationProperties(
@@ -463,7 +481,10 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
         IEnumerable<(IPropertySymbol SourceProperty, IPropertySymbol DestinationProperty)> mappedPairs =
             depth == 0 && !rootMappedPairs.IsDefault
                 ? rootMappedPairs
-                : GetConventionMappedPropertyPairs(currentSourceType, currentDestinationType);
+                : GetDownstreamMappedPropertyPairs(
+                    currentSourceType,
+                    currentDestinationType,
+                    createMapRegistry);
 
         foreach ((IPropertySymbol sourceProperty, IPropertySymbol destinationProperty) in mappedPairs)
         {
@@ -503,14 +524,55 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
     }
 
     private static ImmutableArray<(IPropertySymbol SourceProperty, IPropertySymbol DestinationProperty)>
+        GetDownstreamMappedPropertyPairs(
+            ITypeSymbol sourceType,
+            ITypeSymbol destinationType,
+            CreateMapRegistry createMapRegistry)
+    {
+        if (createMapRegistry.TryGetUniqueForwardMapping(
+                sourceType,
+                destinationType,
+                out var invocation,
+                out SemanticModel semanticModel))
+        {
+            return GetRootMappedPropertyPairs(
+                invocation,
+                sourceType,
+                destinationType,
+                semanticModel,
+                createMapRegistry);
+        }
+
+        return GetConventionMappedPropertyPairs(sourceType, destinationType).ToImmutableArray();
+    }
+
+    private static ImmutableArray<(IPropertySymbol SourceProperty, IPropertySymbol DestinationProperty)>
         GetRootMappedPropertyPairs(
             InvocationExpressionSyntax invocation,
             ITypeSymbol sourceType,
             ITypeSymbol destinationType,
-            SemanticModel semanticModel
+            SemanticModel semanticModel,
+            CreateMapRegistry createMapRegistry
         )
     {
         var mappedPairs = GetConventionMappedPropertyPairs(sourceType, destinationType).ToList();
+        if (!createMapRegistry.TryGetUniqueForwardMapping(
+                sourceType,
+                destinationType,
+                out var registeredInvocation,
+                out _)
+            || registeredInvocation.SyntaxTree != invocation.SyntaxTree
+            || registeredInvocation.Span != invocation.Span)
+        {
+            return mappedPairs.ToImmutableArray();
+        }
+
+        HashSet<string> ignoredProperties = GetIgnoredProperties(
+            invocation,
+            AutoMapperAnalysisHelpers.GetReverseMapInvocation(invocation),
+            semanticModel);
+        mappedPairs.RemoveAll(pair => ignoredProperties.Contains(pair.DestinationProperty.Name));
+
         var configuredMembers = new List<(
             IPropertySymbol DestinationProperty,
             InvocationExpressionSyntax ForMemberInvocation)>();
@@ -542,7 +604,8 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
         {
             int configurationCount = configuredMembers.Count(candidate =>
                 SymbolEqualityComparer.Default.Equals(candidate.DestinationProperty, destinationProperty));
-            if (configurationCount != 1
+            if (ignoredProperties.Contains(destinationProperty.Name)
+                || configurationCount != 1
                 || !TryGetDirectMapFromSourceProperty(
                     forMemberInvocation,
                     semanticModel,

--- a/src/AutoMapperAnalyzer.Analyzers/Helpers/CreateMapRegistry.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Helpers/CreateMapRegistry.cs
@@ -48,6 +48,46 @@ internal sealed class CreateMapRegistry
     }
 
     /// <summary>
+    ///     Gets the sole explicit forward registration for a mapping direction.
+    ///     Reverse-generated and duplicate registrations are deliberately treated as ambiguous.
+    /// </summary>
+    public bool TryGetUniqueForwardMapping(
+        ITypeSymbol? source,
+        ITypeSymbol? destination,
+        out InvocationExpressionSyntax invocation,
+        out SemanticModel semanticModel)
+    {
+        invocation = null!;
+        semanticModel = null!;
+        MappingInfo? match = null;
+
+        foreach (MappingInfo mapping in _mappings)
+        {
+            if (!SymbolEqualityComparer.Default.Equals(mapping.Source, source) ||
+                !SymbolEqualityComparer.Default.Equals(mapping.Destination, destination))
+            {
+                continue;
+            }
+
+            if (match != null)
+            {
+                return false;
+            }
+
+            match = mapping;
+        }
+
+        if (match is not { IsReverseMap: false } uniqueForwardMapping)
+        {
+            return false;
+        }
+
+        invocation = uniqueForwardMapping.Node;
+        semanticModel = uniqueForwardMapping.SemanticModel;
+        return true;
+    }
+
+    /// <summary>
     ///     Checks whether every registration for a mapping direction explicitly constrains recursive traversal.
     /// </summary>
     public bool IsCycleConstrained(ITypeSymbol? source, ITypeSymbol? destination)
@@ -143,6 +183,7 @@ internal sealed class CreateMapRegistry
                         Destination = destType,
                         Location = invocation.GetLocation(),
                         Node = invocation,
+                        SemanticModel = semanticModel,
                         IsReverseMap = false,
                         IsCycleConstrained = HasCycleBreaker(
                             invocation,
@@ -170,6 +211,7 @@ internal sealed class CreateMapRegistry
                             Destination = sourceType,
                             Location = loc,
                             Node = reverseMapInvocation,
+                            SemanticModel = semanticModel,
                             IsReverseMap = true,
                             IsCycleConstrained = HasCycleBreaker(
                                 invocation,
@@ -350,6 +392,7 @@ internal sealed class CreateMapRegistry
         public ITypeSymbol Destination;
         public Location Location;
         public InvocationExpressionSyntax Node;
+        public SemanticModel SemanticModel;
         public bool IsReverseMap;
         public bool IsCycleConstrained;
     }

--- a/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
@@ -130,7 +130,7 @@ public static class RuleCatalog
     /// <summary>
     ///     Current package version used by docs/package drift tests.
     /// </summary>
-    public const string CurrentPackageVersion = "2.30.70";
+    public const string CurrentPackageVersion = "2.30.71";
 
     /// <summary>
     ///     Implemented rules, grouped by public diagnostic ID.

--- a/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM022_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM022_CodeFixTests.cs
@@ -810,8 +810,8 @@ public class AM022_CodeFixTests
                                                  public TestProfile()
                                                  {
                                                      CreateMap<SourceA, DestA>().ForMember(dest => dest.BReference, opt => opt.Ignore());
-                                                     CreateMap<SourceB, DestB>().ForMember(dest => dest.CReference, opt => opt.Ignore());
-                                                     CreateMap<SourceC, DestC>().ForMember(dest => dest.AReference, opt => opt.Ignore());
+                                                     CreateMap<SourceB, DestB>();
+                                                     CreateMap<SourceC, DestC>();
                                                  }
                                              }
                                          }
@@ -835,8 +835,8 @@ public class AM022_CodeFixTests
                 },
                 expectedFixedCode,
                 codeActionIndex: 1,
-                incrementalIterations: 3,
-                fixAllIterations: 3,
+                incrementalIterations: 1,
+                fixAllIterations: 1,
                 remainingDiagnostics: null);
     }
 
@@ -917,15 +917,25 @@ public class AM022_CodeFixTests
                                          }
                                          """;
 
+        var expectedDiagnostics = new[]
+        {
+            new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule)
+                .WithLocation(29, 13)
+                .WithArguments("SourceParent", "DestinationParent"),
+            new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule)
+                .WithLocation(31, 13)
+                .WithArguments("SourceChild", "DestinationChild")
+        };
+
         // Index 0 remains MaxDepth; index 1 appends Ignore after the existing MapFrom so Ignore wins.
+        // Breaking the root edge clears both diagnostics in one application.
         await CodeFixVerifier<AM022_InfiniteRecursionAnalyzer, AM022_InfiniteRecursionCodeFixProvider>
             .VerifyFixAsync(
                 testCode,
-                new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule)
-                    .WithLocation(29, 13)
-                    .WithArguments("SourceParent", "DestinationParent"),
+                expectedDiagnostics,
                 expectedFixedCode,
-                codeActionIndex: 1);
+                1,
+                1);
     }
 
     [Fact]
@@ -1012,13 +1022,13 @@ public class AM022_CodeFixTests
                                                  public TestProfile()
                                                  {
                                                      CreateMap<SourceA, DestA>().ForMember(dest => dest.BReference, opt => opt.Ignore()).ForMember(dest => dest.Parent, opt => opt.Ignore());
-                                                     CreateMap<SourceB, DestB>().ForMember(dest => dest.AReference, opt => opt.Ignore());
+                                                     CreateMap<SourceB, DestB>();
                                                  }
                                              }
                                          }
                                          """;
 
-        // Index 0 MaxDepth; index 1 Ignore-all graph edges (BReference, Parent — ordinal order).
+        // Index 0 MaxDepth; index 1 ignores SourceA's graph edges, which breaks both cycles.
         await CodeFixVerifier<AM022_InfiniteRecursionAnalyzer, AM022_InfiniteRecursionCodeFixProvider>
             .VerifyFixAsync(
                 testCode,
@@ -1033,8 +1043,8 @@ public class AM022_CodeFixTests
                 },
                 expectedFixedCode,
                 codeActionIndex: 1,
-                incrementalIterations: 2,
-                fixAllIterations: 2,
+                incrementalIterations: 1,
+                fixAllIterations: 1,
                 remainingDiagnostics: null);
     }
 
@@ -1518,5 +1528,103 @@ public class AM022_CodeFixTests
                     .WithArguments("SourceNode", "DestNode"),
                 expectedFixedCode,
                 0);
+    }
+
+    [Fact]
+    public async Task AM022_ShouldIgnoreRootMember_WhenCycleUsesTwoDirectRenamedMemberMaps()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class SourceA
+                                    {
+                                        public SourceB Child { get; set; }
+                                    }
+
+                                    public class SourceB
+                                    {
+                                        public SourceA Parent { get; set; }
+                                    }
+
+                                    public class DestinationA
+                                    {
+                                        public DestinationB RenamedChild { get; set; }
+                                    }
+
+                                    public class DestinationB
+                                    {
+                                        public DestinationA RenamedParent { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<SourceA, DestinationA>()
+                                                .ForMember(destination => destination.RenamedChild, options => options.MapFrom(source => source.Child));
+                                            CreateMap<SourceB, DestinationB>()
+                                                .ForMember(destination => destination.RenamedParent, options => options.MapFrom(source => source.Parent));
+                                        }
+                                    }
+                                }
+                                """;
+
+        const string expectedFixedCode = """
+                                         using AutoMapper;
+
+                                         namespace TestNamespace
+                                         {
+                                             public class SourceA
+                                             {
+                                                 public SourceB Child { get; set; }
+                                             }
+
+                                             public class SourceB
+                                             {
+                                                 public SourceA Parent { get; set; }
+                                             }
+
+                                             public class DestinationA
+                                             {
+                                                 public DestinationB RenamedChild { get; set; }
+                                             }
+
+                                             public class DestinationB
+                                             {
+                                                 public DestinationA RenamedParent { get; set; }
+                                             }
+
+                                             public class TestProfile : Profile
+                                             {
+                                                 public TestProfile()
+                                                 {
+                                                     CreateMap<SourceA, DestinationA>()
+                                                         .ForMember(destination => destination.RenamedChild, options => options.MapFrom(source => source.Child)).ForMember(dest => dest.RenamedChild, opt => opt.Ignore());
+                                                     CreateMap<SourceB, DestinationB>()
+                                                         .ForMember(destination => destination.RenamedParent, options => options.MapFrom(source => source.Parent));
+                                                 }
+                                             }
+                                         }
+                                         """;
+
+        var expectedDiagnostics = new[]
+        {
+            new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule)
+                .WithLocation(29, 13)
+                .WithArguments("SourceA", "DestinationA"),
+            new DiagnosticResult(AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule)
+                .WithLocation(31, 13)
+                .WithArguments("SourceB", "DestinationB")
+        };
+
+        await CodeFixVerifier<AM022_InfiniteRecursionAnalyzer, AM022_InfiniteRecursionCodeFixProvider>
+            .VerifyFixAsync(
+                testCode,
+                expectedDiagnostics,
+                expectedFixedCode,
+                1,
+                1);
     }
 }

--- a/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM022_InfiniteRecursionTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/ComplexMappings/AM022_InfiniteRecursionTests.cs
@@ -2010,6 +2010,12 @@ public class AM022_InfiniteRecursionTests
                 13,
                 "SourceParent",
                 "DestinationParent")
+            .ExpectDiagnostic(
+                AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule,
+                31,
+                13,
+                "SourceChild",
+                "DestinationChild")
             .RunAsync();
     }
 
@@ -2259,6 +2265,378 @@ public class AM022_InfiniteRecursionTests
                                                     destination => destination.RenamedChild,
                                                     options => options.Custom().MapFrom((SourceParent source) => source.Child));
                                             CreateMap<SourceChild, DestinationChild>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM022_InfiniteRecursionAnalyzer>()
+            .WithSource(testCode)
+            .ExpectNoDiagnostics()
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM022_ShouldReportBothDiagnostics_WhenCycleUsesTwoDirectRenamedMemberMaps()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class SourceA
+                                    {
+                                        public SourceB Child { get; set; }
+                                    }
+
+                                    public class SourceB
+                                    {
+                                        public SourceA Parent { get; set; }
+                                    }
+
+                                    public class DestinationA
+                                    {
+                                        public DestinationB RenamedChild { get; set; }
+                                    }
+
+                                    public class DestinationB
+                                    {
+                                        public DestinationA RenamedParent { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<SourceA, DestinationA>()
+                                                .ForMember(destination => destination.RenamedChild, options => options.MapFrom(source => source.Child));
+                                            CreateMap<SourceB, DestinationB>()
+                                                .ForMember(destination => destination.RenamedParent, options => options.MapFrom(source => source.Parent));
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM022_InfiniteRecursionAnalyzer>()
+            .WithSource(testCode)
+            .ExpectDiagnostic(
+                AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule,
+                29,
+                13,
+                "SourceA",
+                "DestinationA")
+            .ExpectDiagnostic(
+                AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule,
+                31,
+                13,
+                "SourceB",
+                "DestinationB")
+            .RunAsync();
+    }
+
+
+    [Fact]
+    public async Task AM022_ShouldNotReportDiagnostic_WhenDownstreamDirectRenamedMemberIsIgnoredWithForPath()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class SourceA
+                                    {
+                                        public SourceB Child { get; set; }
+                                    }
+
+                                    public class SourceB
+                                    {
+                                        public SourceA Parent { get; set; }
+                                    }
+
+                                    public class DestinationA
+                                    {
+                                        public DestinationB RenamedChild { get; set; }
+                                    }
+
+                                    public class DestinationB
+                                    {
+                                        public DestinationA RenamedParent { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<SourceA, DestinationA>()
+                                                .ForMember(destination => destination.RenamedChild, options => options.MapFrom(source => source.Child))
+                                                .ForPath(destination => destination.RenamedChild, options => options.Ignore());
+                                            CreateMap<SourceB, DestinationB>()
+                                                .ForMember(destination => destination.RenamedParent, options => options.MapFrom(source => source.Parent));
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM022_InfiniteRecursionAnalyzer>()
+            .WithSource(testCode)
+            .ExpectNoDiagnostics()
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM022_ShouldReportBothDiagnostics_WhenNestedForPathIgnoreDoesNotOwnDirectRenamedMember()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class SourceA
+                                    {
+                                        public SourceB Child { get; set; }
+                                    }
+
+                                    public class SourceB
+                                    {
+                                        public SourceA Parent { get; set; }
+                                    }
+
+                                    public class DestinationA
+                                    {
+                                        public DestinationB RenamedChild { get; set; }
+                                    }
+
+                                    public class DestinationB
+                                    {
+                                        public DestinationA RenamedParent { get; set; }
+                                        public string Label { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<SourceA, DestinationA>()
+                                                .ForMember(destination => destination.RenamedChild, options => options.MapFrom(source => source.Child))
+                                                .ForPath(destination => destination.RenamedChild.Label, options => options.Ignore());
+                                            CreateMap<SourceB, DestinationB>()
+                                                .ForMember(destination => destination.RenamedParent, options => options.MapFrom(source => source.Parent));
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM022_InfiniteRecursionAnalyzer>()
+            .WithSource(testCode)
+            .ExpectDiagnostic(
+                AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule,
+                30,
+                13,
+                "SourceA",
+                "DestinationA")
+            .ExpectDiagnostic(
+                AM022_InfiniteRecursionAnalyzer.InfiniteRecursionRiskRule,
+                33,
+                13,
+                "SourceB",
+                "DestinationB")
+            .RunAsync();
+    }
+
+    [Theory]
+    [InlineData(".MaxDepth(2)")]
+    [InlineData(".PreserveReferences()")]
+    [InlineData(".ConvertUsing((SourceB source) => new DestinationB())")]
+    public async Task AM022_ShouldNotReportDiagnostic_WhenDownstreamDirectRenamedMapIsConstrained(
+        string cycleBreaker)
+    {
+        string testCode = $$"""
+                            using AutoMapper;
+
+                            namespace TestNamespace
+                            {
+                                public class SourceA
+                                {
+                                    public SourceB Child { get; set; }
+                                }
+
+                                public class SourceB
+                                {
+                                    public SourceA Parent { get; set; }
+                                }
+
+                                public class DestinationA
+                                {
+                                    public DestinationB RenamedChild { get; set; }
+                                }
+
+                                public class DestinationB
+                                {
+                                    public DestinationA RenamedParent { get; set; }
+                                }
+
+                                public class TestProfile : Profile
+                                {
+                                    public TestProfile()
+                                    {
+                                        CreateMap<SourceA, DestinationA>()
+                                            .ForMember(destination => destination.RenamedChild, options => options.MapFrom(source => source.Child));
+                                        CreateMap<SourceB, DestinationB>()
+                                            .ForMember(destination => destination.RenamedParent, options => options.MapFrom(source => source.Parent)){{cycleBreaker}};
+                                    }
+                                }
+                            }
+                            """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM022_InfiniteRecursionAnalyzer>()
+            .WithSource(testCode)
+            .ExpectNoDiagnostics()
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM022_ShouldNotReportDiagnostic_WhenDownstreamDirectRenamedMapIsDuplicated()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class SourceA
+                                    {
+                                        public SourceB Child { get; set; }
+                                    }
+
+                                    public class SourceB
+                                    {
+                                        public SourceA Parent { get; set; }
+                                    }
+
+                                    public class DestinationA
+                                    {
+                                        public DestinationB RenamedChild { get; set; }
+                                    }
+
+                                    public class DestinationB
+                                    {
+                                        public DestinationA RenamedParent { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<SourceA, DestinationA>()
+                                                .ForMember(destination => destination.RenamedChild, options => options.MapFrom(source => source.Child));
+                                            CreateMap<SourceB, DestinationB>()
+                                                .ForMember(destination => destination.RenamedParent, options => options.MapFrom(source => source.Parent));
+                                            CreateMap<SourceB, DestinationB>()
+                                                .ForMember(destination => destination.RenamedParent, options => options.MapFrom(source => source.Parent));
+                                        }
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM022_InfiniteRecursionAnalyzer>()
+            .WithSource(testCode)
+            .ExpectNoDiagnostics()
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM022_ShouldNotReportDiagnostic_WhenDownstreamMapFromExpressionIsTransformed()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class SourceA
+                                    {
+                                        public SourceB Child { get; set; }
+                                    }
+
+                                    public class SourceB
+                                    {
+                                        public SourceA Parent { get; set; }
+                                    }
+
+                                    public class DestinationA
+                                    {
+                                        public DestinationB RenamedChild { get; set; }
+                                    }
+
+                                    public class DestinationB
+                                    {
+                                        public DestinationA RenamedParent { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<SourceA, DestinationA>()
+                                                .ForMember(destination => destination.RenamedChild, options => options.MapFrom(source => source.Child));
+                                            CreateMap<SourceB, DestinationB>()
+                                                .ForMember(destination => destination.RenamedParent, options =>
+                                                    options.MapFrom(source => SelectParent(source.Parent)));
+                                        }
+
+                                        private static SourceA SelectParent(SourceA parent) => parent;
+                                    }
+                                }
+                                """;
+
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM022_InfiniteRecursionAnalyzer>()
+            .WithSource(testCode)
+            .ExpectNoDiagnostics()
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM022_ShouldNotInferDownstreamMembersFromReverseMapConfiguration()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public class SourceA
+                                    {
+                                        public SourceB Child { get; set; }
+                                    }
+
+                                    public class SourceB
+                                    {
+                                        public SourceA Parent { get; set; }
+                                    }
+
+                                    public class DestinationA
+                                    {
+                                        public DestinationB RenamedChild { get; set; }
+                                    }
+
+                                    public class DestinationB
+                                    {
+                                        public DestinationA RenamedParent { get; set; }
+                                    }
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<SourceA, DestinationA>()
+                                                .ForMember(destination => destination.RenamedChild, options => options.MapFrom(source => source.Child));
+                                            CreateMap<DestinationB, SourceB>()
+                                                .ReverseMap()
+                                                .ForMember(destination => destination.RenamedParent, options => options.MapFrom(source => source.Parent));
                                         }
                                     }
                                 }


### PR DESCRIPTION
## Summary

- follow uniquely registered forward `ForMember(...MapFrom(source => source.Property))` edges throughout AM022's configured recursion graph
- report every owning `CreateMap` when multiple renamed direct edges close a cycle
- remove exact top-level `ForMember`/`ForPath` Ignore overrides from replayed downstream edges, while nested paths remain edge-specific
- preserve conservative exclusions for duplicate directions, reverse-generated mappings, ambiguous members, transforms, `ForPath` member inference, resolvers, converters, and lookalike APIs

## Proven gaps

A compiling AutoMapper 14 configuration with renamed direct edges on both cycle legs passed `AssertConfigurationIsValid()`, but v2.30.70 emitted zero AM022 diagnostics. A convention-named control in the same consumer emitted AM022 on both registrations, proving the analyzer was loaded.

The initial tests failed exactly as expected: 2 diagnostics expected, 0 actual.

Review then exposed a downstream false positive: a direct `MapFrom` edge followed by exact `ForPath(...Ignore())` was still replayed from another map. Its regression failed with one unexpected AM022. A counter-regression also proved nested `ForPath` ignores must not erase their parent edge.

## Verification

- AM022 analyzer/code-fix suite: 85/85 passed
- full local superset: 1454/1454 passed, 0 skipped
- Release build with `-warnaserror`: 0 warnings, 0 errors
- rule catalog, sample snapshot, and compatibility documentation checks: current
- Slopwatch: 0 issues across 3 changed C# files
- packaged v2.30.71 SHA-256: `000e49bd3d6f3b5862361b521d6806762f244ab6c7a47dd0e4d966576620d85d`

The clean PR branch is one commit ahead of verified main, changes 15 intended files, and adds 10 tests to main's 1423-test baseline. CI should therefore report 1433 tests.

## Fix behavior

MaxDepth remains action 0. Ignore remains action 1, follows an existing MapFrom so it is effective, and breaking one root edge clears all diagnostics for the cycle. Exact top-level Ignore overrides suppress only their destination edge; nested `ForPath` ignores do not suppress the parent mapping.