### PR TITLE
fix: honor AM001 constructor parameter ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+## [2.30.72] - 2026-07-16
+
+AM001 constructor-parameter ownership precision.
+
+### Changed
+
+- **AM001 `ForCtorParam` ownership**: semantic AutoMapper constructor-parameter configuration now suppresses the exact positional-record property mismatch it converts, including literal, `nameof(...)`, and const parameter names.
+- **Direction and name boundaries**: wrong parameter names remain diagnostic, and configuration after `ReverseMap()` applies only to the reverse destination.
+- **Stale fixer honesty**: an obsolete AM001 diagnostic no longer offers conversion or Ignore actions after live recomputation proves constructor ownership removed the mismatch.
+
+### Validation
+
+- AM001 analyzer and code-fix suite: **63** passed.
+- Clean-branch full solution suite: **1440** passed, 0 skipped, 0 failed on `net10.0`.
+- AutoMapper 14 runtime repro: configured mapping passes `AssertConfigurationIsValid()` and maps the expected value; the unconfigured control throws `AutoMapperConfigurationException`.
+
 ## [2.30.71] - 2026-07-16
 
 AM022 downstream direct member-map cycle detection.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet Version](https://img.shields.io/nuget/v/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=NuGet)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=Downloads)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/georgepwall1991/automapper-analyser/ci.yml?style=flat-square&logo=github&label=Build)](https://github.com/georgepwall1991/automapper-analyser/actions)
-[![Tests](https://img.shields.io/badge/Tests-1433%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
+[![Tests](https://img.shields.io/badge/Tests-1440%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
 [![.NET](https://img.shields.io/badge/.NET-4.8+%20%7C%206.0+%20%7C%208.0+%20%7C%209.0+%20%7C%2010.0+-512BD4?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 [![Coverage](https://img.shields.io/codecov/c/github/georgepwall1991/automapper-analyser?style=flat-square&logo=codecov&label=Coverage)](https://codecov.io/gh/georgepwall1991/automapper-analyser)
@@ -14,22 +14,23 @@ prevention*
 
 ---
 
-## 🎉 Latest Release: v2.30.71
+## 🎉 Latest Release: v2.30.72
 
-**AM022 downstream direct member-map cycle detection**
+**AM001 constructor-parameter ownership precision**
 
 ✅ **Highlights**
 
-- Unique forward property-to-property `ForMember(...MapFrom...)` mappings now participate throughout configured recursion graphs, including cycles whose multiple legs rename members.
-- Duplicate mapping directions, transformed expressions, reverse-generated mappings, lookalikes, and ambiguous destination configuration remain conservatively excluded.
-- Downstream cycle breakers still stop traversal, and semantic `ForMember`/`ForPath` Ignore overrides remove replayed edges so one effective root Ignore clears the cycle.
+- Semantic AutoMapper `ForCtorParam` mappings now own the exact positional-record property mismatch they explicitly convert.
+- Literal, `nameof(...)`, and const parameter names are recognized without crossing `ReverseMap()` direction boundaries; wrong names still report.
+- Stale AM001 diagnostics withhold code actions once live recomputation proves constructor ownership removed the mismatch.
 
 🧪 **Validation**
 
-- AM022 suite: **85** passed; full solution suite: **1433** passed, 0 skipped, 0 failed on `net10.0`.
+- AM001 suite: **63** passed; clean-branch full suite: **1440** passed, 0 skipped, 0 failed on `net10.0`.
 
 ### Recent Releases
 
+- **v2.30.72**: AM001 respects exact semantic `ForCtorParam` ownership for positional-record mismatches and withholds stale fixes.
 - **v2.30.71**: AM022 follows unique direct renamed member maps throughout the configured cycle graph while downstream `ForMember`/`ForPath` Ignore overrides remove broken edges.
 - **v2.30.70**: AM022 detects direct renamed `ForMember(...MapFrom...)` cycle edges and emits an effective Ignore alternative.
 - **v2.30.69**: AM032 makes nullable-destination null propagation primary while retaining the throw policy.
@@ -237,7 +238,7 @@ Install-Package AutoMapperAnalyzer.Analyzers
 ### Project File (For CI/CD)
 
 ```xml
-<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.71">
+<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.72">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 </PackageReference>

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -1,12 +1,12 @@
 # Analyzer Health
 
-Reviewed: 2026-07-16 (AM022 downstream direct member-map cycle detection prepared as **2.30.71**)
+Reviewed: 2026-07-16 (AM001 constructor-parameter ownership precision prepared as **2.30.72**)
 
 This is a deliberately harsh health audit for the **21** implemented AutoMapper analyzer rule IDs in this repository (16 before the 2.30.62 performance split). Several rule IDs still expose multiple diagnostic descriptors, especially `AM002` and `AM022`; the scorecard rates the public rule ID as the user experiences it.
 
 Every implemented rule currently has an analyzer and a code fix provider. Scores are 1-5, where `5` means reference-quality and hard to improve, `3` means usable but meaningfully incomplete, and `1` means unreliable or underbuilt.
 
-**Ship status:** production-acceptable. **2.30.71** AM022 downstream direct member-map cycle detection; **2.30.70** AM022 direct root member-map cycle detection; **2.30.69** AM032 destination-aware null fixes; **2.30.68** AM011 single-property fixer honesty. Every rule now has minimum health 4. Full suite green; catalog/snapshots current.
+**Ship status:** production-acceptable. **2.30.72** AM001 constructor-parameter ownership precision; **2.30.71** AM022 downstream direct member-map cycle detection; **2.30.70** AM022 direct root member-map cycle detection; **2.30.69** AM032 destination-aware null fixes. Every rule now has minimum health 4. Full suite green; catalog/snapshots and the executable package compatibility contract are current.
 
 ## Rubric
 
@@ -33,7 +33,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 
 | Rule | Title | Domain | Severity | Analyzer | False Positives | Fix Strategy | Tests | Docs/Samples | Importance | Priority | Notes |
 | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |
-| AM001 | Property type mismatch | Type Safety | Error | 4 | 4 | 5 | 5 | 4 | 5 | Low | Direction-preserving ReverseMap keys; collection-only generic deferral; fixer peels nullables, invariant-culture Parse/ToString, keywords, DateTime/Uri/bool/Guid. **Fix Strategy 5**: Convert-all/Ignore-all + nested Fix individual. **2.30.64**: destination property-token placement + MappingInvocation metadata + sibling recompute for aggregates. |
+| AM001 | Property type mismatch | Type Safety | Error | 4 | 4 | 5 | 5 | 4 | 5 | Low | Direction-preserving ReverseMap keys; collection-only generic deferral; fixer peels nullables, invariant-culture Parse/ToString, keywords, DateTime/Uri/bool/Guid. **Fix Strategy 5**: Convert-all/Ignore-all + nested Fix individual. **2.30.64**: destination property-token placement + MappingInvocation metadata + sibling recompute for aggregates. **2.30.72**: exact semantic `ForCtorParam` ownership suppresses positional-record mismatches for literal/`nameof(...)`/const names within the effective mapping direction, while wrong names and the opposite `ReverseMap()` direction still report; stale diagnostics withhold fixes after live recomputation. |
 | AM002 | Nullable compatibility issue | Type Safety | Error/Info | 4 | 4 | 4 | 5 | 4 | 5 | Low | Descriptor-accurate docs now call out the Error/Info split, reverse-map nullable-to-non-nullable losses report and fix even when forward-side nullability policy is configured before `ReverseMap()`, pass-through and different-member nullable `MapFrom` bodies no longer hide nullable-to-non-nullable errors even when the same-name source member is non-nullable, diagnostics name the actual nullable source member for explicit different-source mappings, constructed generic source/destination labels such as `Source<T>` and `Destination<T>` are preserved, null-forgiving-only generic `MapFrom` bodies now report instead of treating compiler suppression as runtime null handling, semantic string literal/`nameof(...)`/const destination-member selectors and typed-lambda safe mappings are recognized as explicit nullability configuration, helper methods inside member options no longer masquerade as AutoMapper null handlers or mapping configuration, unsafe `NullSubstitute` values still report while assignable fallback values and typed value-type defaults are respected, unguarded nullable receiver dereferences inside `MapFrom` still report even when the final mapped value has a different type, while guarded dereferences and nullable value `GetValueOrDefault()` stay quiet, member-level converter/resolver ownership is respected including generic member-resolver `MapFrom<TResolver, TSourceMember>(...)` forms while generic expression `MapFrom<TSourceMember>(...)` overloads remain analyzable, top-level `ForPath` including typed-lambda paths respects null handling while child-only `ForPath` does not suppress parent nullability, repeated destination-member configuration uses the later effective mapping, the fixer preserves existing member options/source expressions and emits fully qualified framework defaults or `default!` for generic/reference fallback defaults when adding defaults without appending behind `Condition`/`PreCondition`, and catalog trust now marks the Info descriptor as analyzer-only. Remaining opportunities are advanced generic/nullability-flow semantics. |
 | AM003 | Collection type incompatibility | Type Safety | Error | 4 | 4 | 4 | 5 | 4 | 4 | Low | Shared container-incompatibility predicate with AM021 (HashSet/Queue/Stack/SortedSet/LinkedList/Immutable*/FrozenSet). Combined container+element mismatches report AM003 only; CreateRange fixes still convert elements when a named conversion exists. Sample isolates same-element List→HashSet. Custom-collection edge cases remain. |
 | AM004 | Source property has no corresponding destination property | Data Integrity | Warning | 4 | 4 | 5 | 5 | 5 | 5 | Low | Unique-best fuzzy, reverse-map, property-token placement. **Fix Strategy 5 (2.30.65)**: same-document sibling recompute offers Map-all/DoNotValidate-all from one property-token caret. Catalog Scaffold remains accurate. |
@@ -71,7 +71,7 @@ Use this table as the hardening queue. Ranking = **Importance × (5 − min(Anal
 
 | Rank | Rule | Signal | Residual (evidence-backed) | Likely score move if closed |
 | --- | --- | --- | --- | --- |
-| 1 | **AM001** | gap=4, min=4 | Property-token placement shipped 2.30.64. Residual: advanced conversion modelling only with user repros. | — |
+| 1 | **AM001** | gap=4, min=4 | Property-token placement shipped 2.30.64; concrete positional-record `ForCtorParam` false positive closed in 2.30.72. Residual advanced conversion modelling remains repro-gated. | — until evidence |
 | 2 | **AM002** | gap=5, min=4 | Advanced generic/nullability-flow only — wait for real user FP/FN. | — until evidence |
 | 3 | **AM022** | gap=4, min=4 | Direct renamed root edges shipped 2.30.70; concrete downstream renamed-edge false negative closed in 2.30.71. Advanced configuration inference remains repro-gated. | — until evidence |
 | 4 | **AM020 / AM021 / AM003** | gap=5/4 | Custom-collection / constructor-body insert structural limits. | Opportunistic |
@@ -147,6 +147,12 @@ Still open (do not start without a repro or explicit product decision):
 - **AM022 / AM031 dataflow-grade heuristics.** High effort, diminishing returns until a concrete false-positive or false-negative pattern is filed. AM022 direct renamed root edges are covered; downstream explicit-member inference remains repro-gated.
 - **AM020 constructor-body CreateMap insert.** Structural host limit; catalog `LikelyRewrite` already honest.
 
+
+## Reanalysis Changelog (2026-07-16 → 2.30.72 AM001 constructor-parameter ownership precision)
+
+| Rules | Finding | Change | Score impact |
+| --- | --- | --- | --- |
+| AM001 | A runtime-valid positional-record mapping explicitly converted with semantic AutoMapper `ForCtorParam` still emitted build-blocking AM001 claiming there was no explicit conversion | Treat exact constant constructor-parameter names as destination ownership within the effective fluent direction; keep wrong names and opposite `ReverseMap()` directions diagnostic; suppress stale fixes after live recomputation finds no mismatch | No numeric move; closes a concrete Error false positive and restores the diagnostic contract |
 
 ## Reanalysis Changelog (2026-07-16 → 2.30.70 AM022 direct member-map cycle detection)
 
@@ -319,17 +325,18 @@ Full rule+fixer reanalysis driven by four parallel subagent audits (Type Safety,
 
 Architecture-style coverage currently comes from analyzer/fixer tests, conflict ownership tests, helper tests, sample projects, documentation, the checked-in `RuleCatalog`, generated trust artifacts, package smoke tests, and the deterministic `tools/AnalyzerVerifier` checks.
 
-Current local verification (**2026-07-16** against the **v2.30.71** release candidate):
+Current local verification (**2026-07-16** against the **v2.30.72** release candidate):
 
-- Package version in `src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj`: **2.30.71**.
+- Package version in `src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj`: **2.30.72**.
 - `dotnet build automapper-analyser.sln --configuration Release -warnaserror` passed: 0 warnings, 0 errors.
-- Clean-branch full suite: **1433** passed, 0 skipped, 0 failed.
-- `dotnet run --project tools/AnalyzerVerifier/AnalyzerVerifier.csproj --configuration Release --no-build -- --check-catalog --check-snapshots` passed: rule catalog and sample diagnostics snapshot are up to date.
+- Clean-branch full suite: **1440** passed, 0 skipped, 0 failed.
+- `dotnet run --project tools/AnalyzerVerifier/AnalyzerVerifier.csproj --configuration Release --no-build -- --check-catalog --check-snapshots --check-compatibility` passed: rule catalog, sample diagnostics snapshot, manifest, and compatibility documentation are up to date.
+- The packed `AutoMapperAnalyzer.Analyzers.2.30.72.nupkg` (SHA-256 `c1903e0cf75cb6e7883d6668038c442554e9a819805c481332cebee9a951dc2b`) passed local `net10-am14` verification: the healthy consumer built without analyzer/load diagnostics and the broken string-to-int consumer failed specifically with `AM001`. CI supplies the Windows `net48-am10` and remaining Linux matrix evidence against the same SHA-256-verified artifact.
 - Remote branch compare is one commit with only the 15 intended source/test/trust/release files and no trailing-whitespace additions.
 - Targeted `dotnet format whitespace` completed on the local candidate; the clean branch preserves the touched files' existing LF convention to avoid whole-file line-ending churn.
 - Sample project emits AM0xx when analyzers run (`-p:RunAnalyzersDuringBuild=true`); local untracked `Directory.Build.props` (if present) may skip analyzers during CLI builds — unit tests + AnalyzerVerifier remain the verification source of truth.
-- Approximate list-tests name hits (not exclusive filters; for trend only): AM001 57, AM002 83, AM003 61, AM004 87, AM005 34, AM006 43, AM011 45, AM020 97, AM021 64, AM022 62, AM030/32/33 bucket 156, AM031 292, AM041 35, AM050 48, RuleCatalog 10.
-- Release metadata is synchronized for `v2.30.71`; tag/publication follows the merged PR.
+- Approximate list-tests name hits (not exclusive filters; for trend only): AM001 63, AM002 83, AM003 61, AM004 87, AM005 34, AM006 43, AM011 45, AM020 97, AM021 64, AM022 62, AM030/32/33 bucket 156, AM031 292, AM041 35, AM050 48, RuleCatalog 10.
+- Release metadata is synchronized for `v2.30.72`; tag/publication follows the merged PR.
 - Historical baseline (2026-07-06 @ `b138fa8` / v2.30.55): **1352** tests green — superseded; do not use for planning.
 - The trust-first pass removed active skipped tests, added drift validation, and moved intentional analyzer-test warnings into an explicit test-project warning baseline.
 - `/usr/local/share/dotnet/dotnet --list-runtimes` shows only .NET 10 runtimes in this local environment, so broader multi-TFM runtime verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -725,7 +725,7 @@ dotnet pack --configuration Release
 
 # Test package locally
 cd test-install/NetCoreTest
-dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.71-local
+dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.72-local
 ```
 
 ---
@@ -909,4 +909,4 @@ dotnet build
 
 **Last Updated**: 2026-05-14
 **Maintainer**: George Wall
-**Version**: 2.30.71
+**Version**: 2.30.72

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -112,8 +112,8 @@ The AutoMapper Roslyn Analyzer project uses GitHub Actions for continuous integr
 ### Package Versioning
 
 - **Format**: Major.Minor.Patch (SemVer)
-- **Current**: 2.30.71
-- **Pre-release**: 2.30.71-preview, 2.30.71-beta
+- **Current**: 2.30.72
+- **Pre-release**: 2.30.72-preview, 2.30.72-beta
 
 ## 🔧 Configuration
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -43,7 +43,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.71">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.72">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -67,7 +67,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.71">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.72">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -86,7 +86,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="14.0.0" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.71">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.72">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -218,7 +218,7 @@ public class Destination
 
 2. **Verify Package Installation**
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.71">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.72">
      <PrivateAssets>all</PrivateAssets>
      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -280,4 +280,4 @@ This guide ensures smooth installation and usage across all supported .NET frame
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.71
+**Version**: 2.30.72

--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -131,6 +131,11 @@ to domain types remain AM001 conversion problems. AM020 excludes actual `System`
 classification, but user-defined types that merely share framework short names are still analyzed as domain
 types.
 
+An exact semantic AutoMapper `ForCtorParam` owns the named destination constructor parameter just like an
+explicit member conversion. Literal, `nameof(...)`, and `const string` parameter names are recognized within
+the effective fluent mapping direction. A wrong parameter name or configuration placed after `ReverseMap()`
+does not suppress the forward diagnostic.
+
 #### When to Use
 
 - ✅ String → numeric conversions
@@ -1618,7 +1623,7 @@ using System.Diagnostics.CodeAnalysis;
 
 1. **Check package reference**:
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.71">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.72">
        <PrivateAssets>all</PrivateAssets>
        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -1657,5 +1662,5 @@ If analyzer slows down builds:
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.71
+**Version**: 2.30.72
 **Maintainer**: George Wall

--- a/docs/RULE_CATALOG.md
+++ b/docs/RULE_CATALOG.md
@@ -2,7 +2,7 @@
 
 This file is generated from `RuleCatalog`.
 
-Package version: `2.30.71`
+Package version: `2.30.72`
 
 | Rule ID | Descriptor Title | Severity | Category | Analyzer | Code Fix | Trust | Sample | Docs |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,3 +1,15 @@
+## Release 2.30.72
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
+### Removed Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
 ## Release 2.30.71
 
 ### New Rules

--- a/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
+++ b/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
@@ -17,7 +17,7 @@
         <!-- Fallback for local builds: 2.0.YYYYMMDD-local -->
         <MajorVersion>2</MajorVersion>
         <MinorVersion>30</MinorVersion>
-        <PatchVersion>71</PatchVersion>
+        <PatchVersion>72</PatchVersion>
         <BuildNumber Condition="'$(BuildNumber)' == ''"
         >$([System.DateTime]::Now.ToString('yyyyMMdd'))
         </BuildNumber
@@ -32,10 +32,10 @@
         <RepositoryUrl>https://github.com/georgepwall1991/automapper-analyser</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-                <PackageReleaseNotes>Version 2.30.71 - AM022 downstream direct member-map cycle detection
-- Unique forward direct property MapFrom edges participate throughout configured cycle graphs
-- Duplicate directions, reverse-generated mappings, transformed expressions, and ambiguous members remain excluded
-- Downstream cycle breakers and semantic ForMember/ForPath Ignore overrides terminate traversal; one effective root Ignore clears the cycle
+                <PackageReleaseNotes>Version 2.30.72 - AM001 constructor-parameter ownership precision
+- Semantic AutoMapper ForCtorParam configuration suppresses the exact destination mismatch it owns
+- Literal, nameof, and const parameter names respect forward and ReverseMap direction boundaries
+- Stale AM001 diagnostics no longer offer fixes after constructor ownership removes the live mismatch
 </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>

--- a/src/AutoMapperAnalyzer.Analyzers/Helpers/AM020MappingConfigurationHelpers.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Helpers/AM020MappingConfigurationHelpers.cs
@@ -56,7 +56,8 @@ internal static class AM020MappingConfigurationHelpers
                      ShouldStopAtReverseMapBoundary(createMapInvocation, semanticModel)))
         {
             if (MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(invocation, semanticModel, "ForMember") ||
-                MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(invocation, semanticModel, "ForPath"))
+                MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(invocation, semanticModel, "ForPath") ||
+                MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(invocation, semanticModel, "ForCtorParam"))
             {
                 mappingCalls.Add(invocation);
             }

--- a/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
@@ -130,7 +130,7 @@ public static class RuleCatalog
     /// <summary>
     ///     Current package version used by docs/package drift tests.
     /// </summary>
-    public const string CurrentPackageVersion = "2.30.71";
+    public const string CurrentPackageVersion = "2.30.72";
 
     /// <summary>
     ///     Implemented rules, grouped by public diagnostic ID.

--- a/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM001_PropertyTypeMismatchCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM001_PropertyTypeMismatchCodeFixProvider.cs
@@ -42,10 +42,16 @@ public class AM001_PropertyTypeMismatchCodeFixProvider : AutoMapperCodeFixProvid
                      AM001_PropertyTypeMismatchAnalyzer.PropertyNamePropertyName))
         {
             // Expand to every convention type-mismatch on this map (not only diags in the caret context).
-            List<string> allMismatched = GetMismatchedPropertyNames(operationContext, group.Invocation);
-            if (allMismatched.Count == 0)
+            List<string>? allMismatched = GetMismatchedPropertyNames(operationContext, group.Invocation);
+            if (allMismatched == null)
             {
                 allMismatched = group.PropertyNames.ToList();
+            }
+            else if (allMismatched.Count == 0)
+            {
+                // The map no longer has a live AM001 mismatch (for example, a stale IDE
+                // diagnostic after explicit ForCtorParam ownership was added).
+                continue;
             }
 
             var expandedGroup = new DiagnosticInvocationGroup(
@@ -102,7 +108,7 @@ public class AM001_PropertyTypeMismatchCodeFixProvider : AutoMapperCodeFixProvid
         }
     }
 
-    private static List<string> GetMismatchedPropertyNames(
+    private static List<string>? GetMismatchedPropertyNames(
         CodeFixOperationContext operationContext,
         InvocationExpressionSyntax invocation)
     {
@@ -110,7 +116,7 @@ public class AM001_PropertyTypeMismatchCodeFixProvider : AutoMapperCodeFixProvid
             ResolveCreateMapTypesWithReverse(invocation, operationContext.SemanticModel);
         if (sourceType == null || destinationType == null)
         {
-            return [];
+            return null;
         }
 
         var names = new List<string>();

--- a/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM001_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM001_CodeFixTests.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
@@ -1536,6 +1537,68 @@ public class AM001_CodeFixTests
                 Diagnostic(AM001_PropertyTypeMismatchAnalyzer.PropertyTypeMismatchRule, 13, 25,
                     "CreatedDate", "Source", "string", "Destination", "System.DateTime"),
                 expectedFixedCode);
+    }
+
+    [Fact]
+    public async Task AM001_ShouldNotOfferFix_WhenStaleDiagnosticIsOwnedByForCtorParam()
+    {
+        const string testCode = """
+                                using System;
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public record Source(Guid Value);
+
+                                    public record Destination(int Value);
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>()
+                                                .ForCtorParam(nameof(Destination.Value),
+                                                    options => options.MapFrom(source => source.Value.GetHashCode()));
+                                        }
+                                    }
+                                }
+                                """;
+
+        Document document = CreateDocument(testCode);
+        SyntaxNode root = (await document.GetSyntaxRootAsync())!;
+        InvocationExpressionSyntax createMapInvocation = root.DescendantNodes()
+            .OfType<InvocationExpressionSyntax>()
+            .Single(invocation => invocation.Expression is GenericNameSyntax
+            {
+                Identifier.ValueText: "CreateMap"
+            });
+        ParameterSyntax destinationParameter = root.DescendantNodes()
+            .OfType<RecordDeclarationSyntax>()
+            .Single(record => record.Identifier.ValueText == "Destination")
+            .ParameterList!
+            .Parameters
+            .Single();
+
+        var properties = ImmutableDictionary.CreateBuilder<string, string?>();
+        properties.Add("PropertyName", "Value");
+        properties.Add("SourcePropertyType", "System.Guid");
+        properties.Add("DestinationPropertyType", "int");
+        properties.Add("MappingInvocationStart", createMapInvocation.SpanStart.ToString(CultureInfo.InvariantCulture));
+        properties.Add("MappingInvocationLength", createMapInvocation.Span.Length.ToString(CultureInfo.InvariantCulture));
+
+        Diagnostic staleDiagnostic = Microsoft.CodeAnalysis.Diagnostic.Create(
+            AM001_PropertyTypeMismatchAnalyzer.PropertyTypeMismatchRule,
+            destinationParameter.Identifier.GetLocation(),
+            properties.ToImmutable(),
+            "Value",
+            "Source",
+            "System.Guid",
+            "Destination",
+            "int");
+
+        List<CodeAction> actions = await RegisterActionsAsync(document, [staleDiagnostic]);
+
+        Assert.Empty(actions);
     }
 
     private static Document CreateDocument(string source)

--- a/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM001_PropertyTypeMismatchTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/TypeSafety/AM001_PropertyTypeMismatchTests.cs
@@ -967,6 +967,153 @@ public class AM001_PropertyTypeMismatchTests
         await AnalyzerVerifier<AM001_PropertyTypeMismatchAnalyzer>.VerifyAnalyzerAsync(testCode);
     }
 
+    [Theory]
+    [InlineData("\"Value\"")]
+    [InlineData("nameof(Destination.Value)")]
+    [InlineData("ValueParameter")]
+    public async Task AM001_ShouldNotReportDiagnostic_WhenRecordConstructorParameterHandlesMismatch(
+        string parameterNameExpression)
+    {
+        string testCode = $$"""
+                            using System;
+                            using AutoMapper;
+
+                            namespace TestNamespace
+                            {
+                                public record Source(Guid Value);
+
+                                public record Destination(int Value);
+
+                                public class TestProfile : Profile
+                                {
+                                    private const string ValueParameter = nameof(Destination.Value);
+
+                                    public TestProfile()
+                                    {
+                                        CreateMap<Source, Destination>()
+                                            .ForCtorParam({{parameterNameExpression}},
+                                                options => options.MapFrom(source => source.Value.GetHashCode()));
+                                    }
+                                }
+                            }
+                            """;
+
+        await AnalyzerVerifier<AM001_PropertyTypeMismatchAnalyzer>.VerifyAnalyzerAsync(testCode);
+    }
+
+    [Fact]
+    public async Task AM001_ShouldReportDiagnostic_WhenRecordConstructorParameterIsNotConfigured()
+    {
+        const string testCode = """
+                                using System;
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public record Source(Guid Value);
+
+                                    public record Destination(int Value);
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await AnalyzerVerifier<AM001_PropertyTypeMismatchAnalyzer>.VerifyAnalyzerAsync(
+            testCode,
+            CreateDiagnostic(
+                AM001_PropertyTypeMismatchAnalyzer.PropertyTypeMismatchRule,
+                8,
+                35,
+                "Value",
+                "Source",
+                "System.Guid",
+                "Destination",
+                "int"));
+    }
+
+    [Fact]
+    public async Task AM001_ShouldReportDiagnostic_WhenForCtorParamNamesDifferentParameter()
+    {
+        const string testCode = """
+                                using System;
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public record Source(Guid Value);
+
+                                    public record Destination(int Value);
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>()
+                                                .ForCtorParam("Other",
+                                                    options => options.MapFrom(source => source.Value.GetHashCode()));
+                                        }
+                                    }
+                                }
+                                """;
+
+        await AnalyzerVerifier<AM001_PropertyTypeMismatchAnalyzer>.VerifyAnalyzerAsync(
+            testCode,
+            CreateDiagnostic(
+                AM001_PropertyTypeMismatchAnalyzer.PropertyTypeMismatchRule,
+                8,
+                35,
+                "Value",
+                "Source",
+                "System.Guid",
+                "Destination",
+                "int"));
+    }
+
+    [Fact]
+    public async Task AM001_ShouldReportForwardDiagnostic_WhenForCtorParamAppearsAfterReverseMap()
+    {
+        const string testCode = """
+                                using System;
+                                using AutoMapper;
+
+                                namespace TestNamespace
+                                {
+                                    public record Source(Guid Value);
+
+                                    public record Destination(int Value);
+
+                                    public class TestProfile : Profile
+                                    {
+                                        public TestProfile()
+                                        {
+                                            CreateMap<Source, Destination>()
+                                                .ReverseMap()
+                                                .ForCtorParam(nameof(Source.Value),
+                                                    options => options.MapFrom(destination => Guid.Empty));
+                                        }
+                                    }
+                                }
+                                """;
+
+        await AnalyzerVerifier<AM001_PropertyTypeMismatchAnalyzer>.VerifyAnalyzerAsync(
+            testCode,
+            CreateDiagnostic(
+                AM001_PropertyTypeMismatchAnalyzer.PropertyTypeMismatchRule,
+                8,
+                35,
+                "Value",
+                "Source",
+                "System.Guid",
+                "Destination",
+                "int"));
+    }
+
     [Fact]
     public async Task AM001_ShouldReportDiagnostic_WhenNullableSourceTypeIsAlsoTypeIncompatible()
     {


### PR DESCRIPTION
## Summary

- recognize exact semantic AutoMapper `ForCtorParam` configuration as ownership of the named destination constructor parameter
- keep wrong names and configuration across a `ReverseMap()` direction boundary diagnostic
- withhold AM001 code actions when a stale diagnostic no longer corresponds to a live mismatch
- synchronize the analyzer health tracker, generated catalog, package metadata, and release documentation for 2.30.72

## Evidence

A compiling AutoMapper 14 / .NET 10 positional-record mapping from `Guid` to `int` remained runtime-valid when explicitly converted with `ForCtorParam`, but package 2.30.71 emitted build-blocking AM001. The unconfigured control both emits AM001 and fails AutoMapper configuration validation.

## Verification

- AM001 analyzer and code-fix suite: 63 passed
- local full superset: 1,461 passed, 0 skipped, 0 failed
- clean branch expected suite: 1,440 tests
- Release build: 0 warnings, 0 errors
- AnalyzerVerifier catalog, snapshot, and compatibility documentation checks passed
- Slopwatch: 0 findings
- packed 2.30.72 SHA-256: `c1903e0cf75cb6e7883d6668038c442554e9a819805c481332cebee9a951dc2b`
- `net10-am14` package contract: healthy consumer clean; broken consumer fails specifically with AM001

## Review boundary

No local Claude review was invoked. CI, Codecov, and repository review automation are the merge gates.