### PR TITLE
fix: detect deferred AM041 reverse registrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+## [2.30.73] - 2026-07-16
+
+AM041 deferred `ReverseMap()` registration.
+
+### Changed
+
+- **AM041 local-symbol coverage**: a direct local rooted in semantic AutoMapper `CreateMap<S, D>()`, including a fluent configuration initializer, now registers later standalone `mapping.ReverseMap()` calls in the same block, so the reverse `D → S` direction participates in duplicate detection regardless of statement order.
+- **Conservative boundary**: aliases, fields/properties, conditional or nested calls, assignments, and lookalike APIs remain excluded rather than introducing flow-sensitive guesses.
+- **Executable fix**: when a standalone deferred `ReverseMap()` is the duplicate, the fixer removes that statement instead of rewriting it to the invalid expression statement `mapping;`.
+
+### Validation
+
+- AM041 analyzer and code-fix suite: **45** passed.
+- Clean-branch full solution suite: **1450** passed, 0 skipped, 0 failed on `net10.0`.
+- Public 2.30.72 repro: the deferred-local form emitted no AM041 while the equivalent fluent form did; both AutoMapper 14 configurations passed `AssertConfigurationIsValid()`.
+
 ## [2.30.72] - 2026-07-16
 
 AM001 constructor-parameter ownership precision.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet Version](https://img.shields.io/nuget/v/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=NuGet)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=Downloads)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/georgepwall1991/automapper-analyser/ci.yml?style=flat-square&logo=github&label=Build)](https://github.com/georgepwall1991/automapper-analyser/actions)
-[![Tests](https://img.shields.io/badge/Tests-1440%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
+[![Tests](https://img.shields.io/badge/Tests-1450%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
 [![.NET](https://img.shields.io/badge/.NET-4.8+%20%7C%206.0+%20%7C%208.0+%20%7C%209.0+%20%7C%2010.0+-512BD4?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 [![Coverage](https://img.shields.io/codecov/c/github/georgepwall1991/automapper-analyser?style=flat-square&logo=codecov&label=Coverage)](https://codecov.io/gh/georgepwall1991/automapper-analyser)
@@ -14,22 +14,23 @@ prevention*
 
 ---
 
-## 🎉 Latest Release: v2.30.72
+## 🎉 Latest Release: v2.30.73
 
-**AM001 constructor-parameter ownership precision**
+**AM041 deferred `ReverseMap()` registration**
 
 ✅ **Highlights**
 
-- Semantic AutoMapper `ForCtorParam` mappings now own the exact positional-record property mismatch they explicitly convert.
-- Literal, `nameof(...)`, and const parameter names are recognized without crossing `ReverseMap()` direction boundaries; wrong names still report.
-- Stale AM001 diagnostics withhold code actions once live recomputation proves constructor ownership removed the mismatch.
+- Direct locals rooted in `CreateMap<S, D>()`, including fluent configuration chains, now register later standalone same-block `mapping.ReverseMap()` calls for duplicate detection.
+- Aliases, conditionals, nested calls, and lookalike APIs remain conservatively excluded.
+- Removing a duplicate deferred `ReverseMap()` deletes the statement cleanly instead of leaving invalid `mapping;` code.
 
 🧪 **Validation**
 
-- AM001 suite: **63** passed; clean-branch full suite: **1440** passed, 0 skipped, 0 failed on `net10.0`.
+- AM041 suite: **45** passed; clean-branch full suite: **1450** passed, 0 skipped, 0 failed on `net10.0`.
 
 ### Recent Releases
 
+- **v2.30.73**: AM041 detects direct local deferred `ReverseMap()` registrations, including fluent initializers, and removes duplicate standalone calls safely.
 - **v2.30.72**: AM001 respects exact semantic `ForCtorParam` ownership for positional-record mismatches and withholds stale fixes.
 - **v2.30.71**: AM022 follows unique direct renamed member maps throughout the configured cycle graph while downstream `ForMember`/`ForPath` Ignore overrides remove broken edges.
 - **v2.30.70**: AM022 detects direct renamed `ForMember(...MapFrom...)` cycle edges and emits an effective Ignore alternative.
@@ -238,7 +239,7 @@ Install-Package AutoMapperAnalyzer.Analyzers
 ### Project File (For CI/CD)
 
 ```xml
-<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.72">
+<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.73">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 </PackageReference>

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -1,12 +1,12 @@
 # Analyzer Health
 
-Reviewed: 2026-07-16 (AM001 constructor-parameter ownership precision prepared as **2.30.72**)
+Reviewed: 2026-07-16 (AM041 deferred `ReverseMap()` registration prepared as **2.30.73**)
 
 This is a deliberately harsh health audit for the **21** implemented AutoMapper analyzer rule IDs in this repository (16 before the 2.30.62 performance split). Several rule IDs still expose multiple diagnostic descriptors, especially `AM002` and `AM022`; the scorecard rates the public rule ID as the user experiences it.
 
 Every implemented rule currently has an analyzer and a code fix provider. Scores are 1-5, where `5` means reference-quality and hard to improve, `3` means usable but meaningfully incomplete, and `1` means unreliable or underbuilt.
 
-**Ship status:** production-acceptable. **2.30.72** AM001 constructor-parameter ownership precision; **2.30.71** AM022 downstream direct member-map cycle detection; **2.30.70** AM022 direct root member-map cycle detection; **2.30.69** AM032 destination-aware null fixes. Every rule now has minimum health 4. Full suite green; catalog/snapshots and the executable package compatibility contract are current.
+**Ship status:** production-acceptable. **2.30.73** AM041 deferred `ReverseMap()` registration; **2.30.72** AM001 constructor-parameter ownership precision; **2.30.71** AM022 downstream direct member-map cycle detection; **2.30.70** AM022 direct root member-map cycle detection. Every rule now has minimum health 4. Full suite green; catalog/snapshots and the executable package compatibility contract are current.
 
 ## Rubric
 
@@ -52,7 +52,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | AM036 | Sync-over-async in mapping | Performance | Warning | 4 | 4 | 4 | 5 | 4 | 4 | Low | Split from AM031 in 2.30.62. Task.Result/Wait/WaitAll/WaitAny/GetResult including source Task properties; shared ForPath Ignore scaffold. |
 | AM037 | Complex LINQ in mapping | Performance | Warning | 4 | 4 | 4 | 4 | 4 | 3 | Low | Split from AM031 in 2.30.62. Real Enumerable/Queryable SelectMany gate; shared ForPath Ignore scaffold. |
 | AM038 | Non-deterministic operation in mapping | Performance | Info | 4 | 4 | 4 | 5 | 4 | 3 | Low | Split from AM031 in 2.30.62. Info severity; ForMember/ForPath scaffold fixes. |
-| AM041 | Duplicate mapping registration | Configuration | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | Compilation-wide registry now peels parentheses in `GetReverseMapInvocation`, so `(CreateMap<S,D>()).ReverseMap()` registers reverse duplicates. SafeRewrite removal withholds chained/nested/arg-position config. Remaining risk is nuanced intentional override ordering. |
+| AM041 | Duplicate mapping registration | Configuration | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | Compilation-wide registry peels parentheses in fluent `ReverseMap()` chains. **2.30.73**: a direct local rooted in semantic AutoMapper `CreateMap<S,D>()`, including a fluent configuration initializer, registers later standalone same-block `mapping.ReverseMap()` calls; aliases, conditional/nested calls, assignments, and lookalikes stay excluded. The fixer removes a duplicate deferred statement without leaving invalid expression code. SafeRewrite removal still withholds chained/nested/argument-position configuration. |
 | AM050 | Redundant MapFrom configuration | Configuration | Info | 4 | 4 | 4 | 4 | 4 | 2 | Low | Safe cleanup rule now requires proven source/destination type compatibility including nullable reference annotations, string literal and `nameof(...)`/constant `ForMember` members resolved through the effective mapping direction including `ReverseMap()` segments with direct reverse-map `nameof(...)`/const analyzer and code-fix coverage, parenthesized/typed lambda parameter shapes — `o.MapFrom((s) => s.Name)` and `o.MapFrom((Source s) => s.Name)` — with `ForMember`/`ForPath` code-fix parity, and parenthesized member bodies such as `s => (s.Name)`/`d => (d.Name)` alongside the simple `s => s.Name` shape. Multi-parameter parenthesized lambdas are intentionally ignored so AutoMapper's `(src, ctx) => ...` overload stays quiet. The automatic `ForMember`/`ForPath` removal code fix now withholds when the options lambda carries sibling configuration (`Condition`, `NullSubstitute`, `PreCondition`, `UseDestinationValue`, `Ignore`, etc.) so policy overrides cannot be silently dropped; simple-MapFrom shapes still receive the automatic action. Product importance remains low. |
 
 ## Planning Shortlist
@@ -75,7 +75,7 @@ Use this table as the hardening queue. Ranking = **Importance × (5 − min(Anal
 | 2 | **AM002** | gap=5, min=4 | Advanced generic/nullability-flow only — wait for real user FP/FN. | — until evidence |
 | 3 | **AM022** | gap=4, min=4 | Direct renamed root edges shipped 2.30.70; concrete downstream renamed-edge false negative closed in 2.30.71. Advanced configuration inference remains repro-gated. | — until evidence |
 | 4 | **AM020 / AM021 / AM003** | gap=5/4 | Custom-collection / constructor-body insert structural limits. | Opportunistic |
-| 5 | **AM041 / AM050** | gap=4/2 | SafeRewrite nuance / low Importance. | Low ROI |
+| 5 | **AM041 / AM050** | gap=4/2 | Concrete AM041 deferred-local `ReverseMap()` false negative closed in 2.30.73; remaining SafeRewrite nuance is repro-gated. AM050 remains low Importance. | Low ROI |
 | 6 | **AM033 / AM005 / AM030** | gap=2–3 | Importance-limited. | Product priority only |
 
 **Recommended next hardening batch:**
@@ -147,6 +147,12 @@ Still open (do not start without a repro or explicit product decision):
 - **AM022 / AM031 dataflow-grade heuristics.** High effort, diminishing returns until a concrete false-positive or false-negative pattern is filed. AM022 direct renamed root edges are covered; downstream explicit-member inference remains repro-gated.
 - **AM020 constructor-body CreateMap insert.** Structural host limit; catalog `LikelyRewrite` already honest.
 
+
+## Reanalysis Changelog (2026-07-16 → 2.30.73 AM041 deferred `ReverseMap()` registration)
+
+| Rules | Finding | Change | Score impact |
+| --- | --- | --- | --- |
+| AM041 | A direct local `var mapping = CreateMap<S,D>(); mapping.ReverseMap();` failed to register `D → S`, while the semantically equivalent fluent chain did | Register only later standalone same-block semantic `ReverseMap()` calls whose direct receiver resolves to the exact initializer local; remove a duplicate deferred statement rather than rewriting it to invalid `mapping;` code | No numeric move; closes a concrete compiling false negative and an associated fixer correctness trap |
 
 ## Reanalysis Changelog (2026-07-16 → 2.30.72 AM001 constructor-parameter ownership precision)
 
@@ -325,18 +331,18 @@ Full rule+fixer reanalysis driven by four parallel subagent audits (Type Safety,
 
 Architecture-style coverage currently comes from analyzer/fixer tests, conflict ownership tests, helper tests, sample projects, documentation, the checked-in `RuleCatalog`, generated trust artifacts, package smoke tests, and the deterministic `tools/AnalyzerVerifier` checks.
 
-Current local verification (**2026-07-16** against the **v2.30.72** release candidate):
+Current local verification (**2026-07-16** against the **v2.30.73** release candidate):
 
-- Package version in `src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj`: **2.30.72**.
+- Package version in `src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj`: **2.30.73**.
 - `dotnet build automapper-analyser.sln --configuration Release -warnaserror` passed: 0 warnings, 0 errors.
-- Clean-branch full suite: **1440** passed, 0 skipped, 0 failed.
+- Clean-branch full suite: **1447** passed, 0 skipped, 0 failed.
 - `dotnet run --project tools/AnalyzerVerifier/AnalyzerVerifier.csproj --configuration Release --no-build -- --check-catalog --check-snapshots --check-compatibility` passed: rule catalog, sample diagnostics snapshot, manifest, and compatibility documentation are up to date.
-- The packed `AutoMapperAnalyzer.Analyzers.2.30.72.nupkg` (SHA-256 `c1903e0cf75cb6e7883d6668038c442554e9a819805c481332cebee9a951dc2b`) passed local `net10-am14` verification: the healthy consumer built without analyzer/load diagnostics and the broken string-to-int consumer failed specifically with `AM001`. CI supplies the Windows `net48-am10` and remaining Linux matrix evidence against the same SHA-256-verified artifact.
+- The locally packed `AutoMapperAnalyzer.Analyzers.2.30.73.nupkg` (SHA-256 `9a46390ef571a865e41ea3896b5e4ec9c8856b3a0a677dcf4c7185776c2f97dd`) passed `net10-am14` verification: the healthy consumer built without analyzer/load diagnostics and the broken string-to-int consumer failed specifically with `AM001`. CI independently verifies its clean-branch package across the Windows `net48-am10` and Linux compatibility matrix and records the artifact SHA-256.
 - Remote branch compare is one commit with only the 15 intended source/test/trust/release files and no trailing-whitespace additions.
 - Targeted `dotnet format whitespace` completed on the local candidate; the clean branch preserves the touched files' existing LF convention to avoid whole-file line-ending churn.
 - Sample project emits AM0xx when analyzers run (`-p:RunAnalyzersDuringBuild=true`); local untracked `Directory.Build.props` (if present) may skip analyzers during CLI builds — unit tests + AnalyzerVerifier remain the verification source of truth.
-- Approximate list-tests name hits (not exclusive filters; for trend only): AM001 63, AM002 83, AM003 61, AM004 87, AM005 34, AM006 43, AM011 45, AM020 97, AM021 64, AM022 62, AM030/32/33 bucket 156, AM031 292, AM041 35, AM050 48, RuleCatalog 10.
-- Release metadata is synchronized for `v2.30.72`; tag/publication follows the merged PR.
+- Approximate list-tests name hits (not exclusive filters; for trend only): AM001 63, AM002 83, AM003 61, AM004 87, AM005 34, AM006 43, AM011 45, AM020 97, AM021 64, AM022 62, AM030/32/33 bucket 156, AM031 292, AM041 42, AM050 48, RuleCatalog 10.
+- Release metadata is synchronized for `v2.30.73`; tag/publication follows the merged PR.
 - Historical baseline (2026-07-06 @ `b138fa8` / v2.30.55): **1352** tests green — superseded; do not use for planning.
 - The trust-first pass removed active skipped tests, added drift validation, and moved intentional analyzer-test warnings into an explicit test-project warning baseline.
 - `/usr/local/share/dotnet/dotnet --list-runtimes` shows only .NET 10 runtimes in this local environment, so broader multi-TFM runtime verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -725,7 +725,7 @@ dotnet pack --configuration Release
 
 # Test package locally
 cd test-install/NetCoreTest
-dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.72-local
+dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.73-local
 ```
 
 ---
@@ -909,4 +909,4 @@ dotnet build
 
 **Last Updated**: 2026-05-14
 **Maintainer**: George Wall
-**Version**: 2.30.72
+**Version**: 2.30.73

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -112,8 +112,8 @@ The AutoMapper Roslyn Analyzer project uses GitHub Actions for continuous integr
 ### Package Versioning
 
 - **Format**: Major.Minor.Patch (SemVer)
-- **Current**: 2.30.72
-- **Pre-release**: 2.30.72-preview, 2.30.72-beta
+- **Current**: 2.30.73
+- **Pre-release**: 2.30.73-preview, 2.30.73-beta
 
 ## 🔧 Configuration
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -43,7 +43,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.72">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.73">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -67,7 +67,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.72">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.73">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -86,7 +86,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="14.0.0" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.72">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.73">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -218,7 +218,7 @@ public class Destination
 
 2. **Verify Package Installation**
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.72">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.73">
      <PrivateAssets>all</PrivateAssets>
      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -280,4 +280,4 @@ This guide ensures smooth installation and usage across all supported .NET frame
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.72
+**Version**: 2.30.73

--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -1473,6 +1473,12 @@ The same safety boundary applies to duplicate `CreateMap<TSource, TDestination>(
 
 Duplicate mappings nested inside another expression, such as `Register(CreateMap<S, D>())`, `Register(CreateMap<S, D>().ReverseMap())`, or a variable assignment, still report AM041 but do not receive the automatic removal action. The developer must decide how to preserve the surrounding expression.
 
+AM041 also recognizes a direct local rooted in semantic AutoMapper `CreateMap<S, D>()`, including a fluent
+configuration initializer, followed by a standalone `mapping.ReverseMap()` statement in the same block. The
+deferred reverse direction participates in duplicate detection in either statement order, and a duplicate
+standalone `ReverseMap()` can be removed safely. Aliases, fields/properties, conditional calls, assignments,
+nested argument flow, and lookalike APIs remain outside this deliberately flow-insensitive boundary.
+
 #### Configuration
 
 ```ini
@@ -1623,7 +1629,7 @@ using System.Diagnostics.CodeAnalysis;
 
 1. **Check package reference**:
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.72">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.73">
        <PrivateAssets>all</PrivateAssets>
        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -1662,5 +1668,5 @@ If analyzer slows down builds:
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.72
+**Version**: 2.30.73
 **Maintainer**: George Wall

--- a/docs/RULE_CATALOG.md
+++ b/docs/RULE_CATALOG.md
@@ -2,7 +2,7 @@
 
 This file is generated from `RuleCatalog`.
 
-Package version: `2.30.72`
+Package version: `2.30.73`
 
 | Rule ID | Descriptor Title | Severity | Category | Analyzer | Code Fix | Trust | Sample | Docs |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,3 +1,15 @@
+## Release 2.30.73
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
+### Removed Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
 ## Release 2.30.72
 
 ### New Rules

--- a/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
+++ b/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
@@ -17,7 +17,7 @@
         <!-- Fallback for local builds: 2.0.YYYYMMDD-local -->
         <MajorVersion>2</MajorVersion>
         <MinorVersion>30</MinorVersion>
-        <PatchVersion>72</PatchVersion>
+        <PatchVersion>73</PatchVersion>
         <BuildNumber Condition="'$(BuildNumber)' == ''"
         >$([System.DateTime]::Now.ToString('yyyyMMdd'))
         </BuildNumber
@@ -32,10 +32,10 @@
         <RepositoryUrl>https://github.com/georgepwall1991/automapper-analyser</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-                <PackageReleaseNotes>Version 2.30.72 - AM001 constructor-parameter ownership precision
-- Semantic AutoMapper ForCtorParam configuration suppresses the exact destination mismatch it owns
-- Literal, nameof, and const parameter names respect forward and ReverseMap direction boundaries
-- Stale AM001 diagnostics no longer offer fixes after constructor ownership removes the live mismatch
+                <PackageReleaseNotes>Version 2.30.73 - AM041 deferred ReverseMap registration
+- Direct local CreateMap variables, including fluent initializers, register later standalone same-block ReverseMap calls
+- Alias, conditional, and non-semantic calls remain outside the conservative boundary
+- Duplicate deferred ReverseMap fixes remove the statement without leaving invalid expression code
 </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>

--- a/src/AutoMapperAnalyzer.Analyzers/Configuration/AM041_DuplicateMappingCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Configuration/AM041_DuplicateMappingCodeFixProvider.cs
@@ -187,6 +187,15 @@ public class AM041_DuplicateMappingCodeFixProvider : AutoMapperCodeFixProviderBa
 
             if (invocation.Expression is MemberAccessExpressionSyntax memberAccess)
             {
+                if (memberAccess.Expression is IdentifierNameSyntax &&
+                    invocation.Parent is ExpressionStatementSyntax deferredReverseMapStatement)
+                {
+                    SyntaxNode? newRoot = root.RemoveNode(
+                        deferredReverseMapStatement,
+                        SyntaxRemoveOptions.KeepNoTrivia);
+                    return Task.FromResult(document.WithSyntaxRoot(newRoot!));
+                }
+
                 // Replace the whole ReverseMap() invocation with the expression it was called on
                 // e.g. CreateMap<A,B>().ReverseMap() -> CreateMap<A,B>()
                 return ReplaceNodeAsync(document, root, invocation, memberAccess.Expression);

--- a/src/AutoMapperAnalyzer.Analyzers/Helpers/CreateMapRegistry.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Helpers/CreateMapRegistry.cs
@@ -220,6 +220,26 @@ internal sealed class CreateMapRegistry
                                 reverseDirection: true)
                         });
                     }
+                    else
+                    {
+                        foreach (InvocationExpressionSyntax deferredReverseMap in
+                                 GetDeferredReverseMapInvocations(invocation, semanticModel))
+                        {
+                            var memberAccess = (MemberAccessExpressionSyntax)deferredReverseMap.Expression;
+                            Location location = memberAccess.Name.GetLocation();
+
+                            mappings.Add(new MappingInfo
+                            {
+                                Source = destType,
+                                Destination = sourceType,
+                                Location = location,
+                                Node = deferredReverseMap,
+                                SemanticModel = semanticModel,
+                                IsReverseMap = true,
+                                IsCycleConstrained = false
+                            });
+                        }
+                    }
                 }
             }
         }
@@ -359,6 +379,76 @@ internal sealed class CreateMapRegistry
         }
 
         return false;
+    }
+
+    private static IEnumerable<InvocationExpressionSyntax> GetDeferredReverseMapInvocations(
+        InvocationExpressionSyntax createMapInvocation,
+        SemanticModel semanticModel)
+    {
+        VariableDeclaratorSyntax? declarator = createMapInvocation.Ancestors()
+            .OfType<VariableDeclaratorSyntax>()
+            .FirstOrDefault();
+        if (declarator?.Initializer is not { Value: ExpressionSyntax initializer } ||
+            !IsMappingInitializerRootedAtCreateMap(initializer, createMapInvocation) ||
+            declarator.Parent?.Parent is not LocalDeclarationStatementSyntax declaration ||
+            declaration.Parent is not BlockSyntax block ||
+            semanticModel.GetDeclaredSymbol(declarator) is not ILocalSymbol mappingLocal)
+        {
+            yield break;
+        }
+
+        foreach (ExpressionStatementSyntax statement in block.Statements
+                     .OfType<ExpressionStatementSyntax>()
+                     .Where(candidate => candidate.SpanStart > declaration.SpanStart))
+        {
+            if (statement.Expression is not InvocationExpressionSyntax candidate ||
+                candidate.ArgumentList.Arguments.Count != 0 ||
+                !MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(
+                    candidate,
+                    semanticModel,
+                    "ReverseMap") ||
+                candidate.Expression is not MemberAccessExpressionSyntax
+                {
+                    Expression: IdentifierNameSyntax receiver
+                } ||
+                !SymbolEqualityComparer.Default.Equals(
+                    semanticModel.GetSymbolInfo(receiver).Symbol,
+                    mappingLocal))
+            {
+                continue;
+            }
+
+            yield return candidate;
+        }
+    }
+
+    private static bool IsMappingInitializerRootedAtCreateMap(
+        ExpressionSyntax initializer,
+        InvocationExpressionSyntax createMapInvocation)
+    {
+        ExpressionSyntax current = initializer;
+        while (true)
+        {
+            while (current is ParenthesizedExpressionSyntax parenthesized)
+            {
+                current = parenthesized.Expression;
+            }
+
+            if (current == createMapInvocation)
+            {
+                return true;
+            }
+
+            if (current is not InvocationExpressionSyntax
+                {
+                    Expression: MemberAccessExpressionSyntax memberAccess
+                })
+            {
+                return false;
+            }
+
+            current = memberAccess.Expression;
+        }
     }
 
     private static bool IsCycleBreaker(InvocationExpressionSyntax invocation, SemanticModel semanticModel)

--- a/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
@@ -130,7 +130,7 @@ public static class RuleCatalog
     /// <summary>
     ///     Current package version used by docs/package drift tests.
     /// </summary>
-    public const string CurrentPackageVersion = "2.30.72";
+    public const string CurrentPackageVersion = "2.30.73";
 
     /// <summary>
     ///     Implemented rules, grouped by public diagnostic ID.

--- a/tests/AutoMapperAnalyzer.Tests/Configuration/AM041_CodeFixTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Configuration/AM041_CodeFixTests.cs
@@ -293,6 +293,141 @@ public class AM041_CodeFixTests
     }
 
     [Fact]
+    public async Task Should_Remove_ExplicitMap_WhenDeferredReverseDirectionWasRegisteredFirst()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                public class Source {}
+                                public class Destination {}
+
+                                public class MyProfile : Profile
+                                {
+                                    public MyProfile()
+                                    {
+                                        var mapping = CreateMap<Source, Destination>();
+                                        mapping.ReverseMap();
+                                        CreateMap<Destination, Source>();
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 using AutoMapper;
+
+                                 public class Source {}
+                                 public class Destination {}
+
+                                 public class MyProfile : Profile
+                                 {
+                                     public MyProfile()
+                                     {
+                                         var mapping = CreateMap<Source, Destination>();
+                                         mapping.ReverseMap();
+                                     }
+                                 }
+                                 """;
+
+        DiagnosticResult expected = new DiagnosticResult(AM041_DuplicateMappingAnalyzer.DuplicateMappingRule)
+            .WithLocation(12, 9)
+            .WithArguments("Destination", "Source");
+
+        await CodeFixVerifier<AM041_DuplicateMappingAnalyzer, AM041_DuplicateMappingCodeFixProvider>
+            .VerifyFixAsync(testCode, expected, fixedCode);
+    }
+
+    [Fact]
+    public async Task Should_Remove_StandaloneDeferredReverseMap_WhenItIsTheDuplicate()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                public class Source {}
+                                public class Destination {}
+
+                                public class MyProfile : Profile
+                                {
+                                    public MyProfile()
+                                    {
+                                        CreateMap<Destination, Source>();
+                                        var mapping = CreateMap<Source, Destination>();
+                                        mapping.ReverseMap();
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 using AutoMapper;
+
+                                 public class Source {}
+                                 public class Destination {}
+
+                                 public class MyProfile : Profile
+                                 {
+                                     public MyProfile()
+                                     {
+                                         CreateMap<Destination, Source>();
+                                         var mapping = CreateMap<Source, Destination>();
+                                     }
+                                 }
+                                 """;
+
+        DiagnosticResult expected = new DiagnosticResult(AM041_DuplicateMappingAnalyzer.DuplicateMappingRule)
+            .WithLocation(12, 17)
+            .WithArguments("Destination", "Source");
+
+        await CodeFixVerifier<AM041_DuplicateMappingAnalyzer, AM041_DuplicateMappingCodeFixProvider>
+            .VerifyFixAsync(testCode, expected, fixedCode);
+    }
+
+
+    [Fact]
+    public async Task Should_Remove_StandaloneDeferredReverseMap_AfterConfiguredInitializer()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                public class Source { public string Name { get; set; } = ""; }
+                                public class Destination { public string Name { get; set; } = ""; }
+
+                                public class MyProfile : Profile
+                                {
+                                    public MyProfile()
+                                    {
+                                        CreateMap<Destination, Source>();
+                                        var mapping = CreateMap<Source, Destination>()
+                                            .ForMember(destination => destination.Name, options => options.MapFrom(source => source.Name));
+                                        mapping.ReverseMap();
+                                    }
+                                }
+                                """;
+
+        const string fixedCode = """
+                                 using AutoMapper;
+
+                                 public class Source { public string Name { get; set; } = ""; }
+                                 public class Destination { public string Name { get; set; } = ""; }
+
+                                 public class MyProfile : Profile
+                                 {
+                                     public MyProfile()
+                                     {
+                                         CreateMap<Destination, Source>();
+                                         var mapping = CreateMap<Source, Destination>()
+                                             .ForMember(destination => destination.Name, options => options.MapFrom(source => source.Name));
+                                     }
+                                 }
+                                 """;
+
+        DiagnosticResult expected = new DiagnosticResult(AM041_DuplicateMappingAnalyzer.DuplicateMappingRule)
+            .WithLocation(13, 17)
+            .WithArguments("Destination", "Source");
+
+        await CodeFixVerifier<AM041_DuplicateMappingAnalyzer, AM041_DuplicateMappingCodeFixProvider>
+            .VerifyFixAsync(testCode, expected, fixedCode);
+    }
+
+    [Fact]
     public async Task Should_KeepReverseDirection_WhenDuplicateIsCreateMapInsideReverseMap()
     {
         const string testCode = """

--- a/tests/AutoMapperAnalyzer.Tests/Configuration/AM041_DuplicateMappingTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Configuration/AM041_DuplicateMappingTests.cs
@@ -147,4 +147,186 @@ public class AM041_DuplicateMappingTests
 
         await AnalyzerVerifier<AM041_DuplicateMappingAnalyzer>.VerifyAnalyzerAsync(testCode, expected);
     }
+
+    [Fact]
+    public async Task Should_ReportDiagnostic_When_DeferredReverseMapPrecedesExplicitReverseDirection()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                public class Source {}
+                                public class Destination {}
+
+                                public class MyProfile : Profile
+                                {
+                                    public MyProfile()
+                                    {
+                                        var mapping = CreateMap<Source, Destination>();
+                                        mapping.ReverseMap();
+                                        CreateMap<Destination, Source>();
+                                    }
+                                }
+                                """;
+
+        DiagnosticResult expected = new DiagnosticResult(AM041_DuplicateMappingAnalyzer.DuplicateMappingRule)
+            .WithLocation(12, 9)
+            .WithArguments("Destination", "Source");
+
+        await AnalyzerVerifier<AM041_DuplicateMappingAnalyzer>.VerifyAnalyzerAsync(testCode, expected);
+    }
+
+    [Fact]
+    public async Task Should_ReportDiagnostic_OnDeferredReverseMap_WhenExplicitDirectionPrecedesIt()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                public class Source {}
+                                public class Destination {}
+
+                                public class MyProfile : Profile
+                                {
+                                    public MyProfile()
+                                    {
+                                        CreateMap<Destination, Source>();
+                                        var mapping = CreateMap<Source, Destination>();
+                                        mapping.ReverseMap();
+                                    }
+                                }
+                                """;
+
+        DiagnosticResult expected = new DiagnosticResult(AM041_DuplicateMappingAnalyzer.DuplicateMappingRule)
+            .WithLocation(12, 17)
+            .WithArguments("Destination", "Source");
+
+        await AnalyzerVerifier<AM041_DuplicateMappingAnalyzer>.VerifyAnalyzerAsync(testCode, expected);
+    }
+
+
+    [Fact]
+    public async Task Should_ReportDiagnostic_When_ConfiguredLocalDefersReverseMap()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                public class Source { public string Name { get; set; } = ""; }
+                                public class Destination { public string Name { get; set; } = ""; }
+
+                                public class MyProfile : Profile
+                                {
+                                    public MyProfile()
+                                    {
+                                        var mapping = CreateMap<Source, Destination>()
+                                            .ForMember(destination => destination.Name, options => options.MapFrom(source => source.Name));
+                                        mapping.ReverseMap();
+                                        CreateMap<Destination, Source>();
+                                    }
+                                }
+                                """;
+
+        DiagnosticResult expected = new DiagnosticResult(AM041_DuplicateMappingAnalyzer.DuplicateMappingRule)
+            .WithLocation(13, 9)
+            .WithArguments("Destination", "Source");
+
+        await AnalyzerVerifier<AM041_DuplicateMappingAnalyzer>.VerifyAnalyzerAsync(testCode, expected);
+    }
+
+    [Fact]
+    public async Task Should_NotReportDiagnostic_WhenLocalCreateMapHasNoDeferredReverseMap()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                public class Source {}
+                                public class Destination {}
+
+                                public class MyProfile : Profile
+                                {
+                                    public MyProfile()
+                                    {
+                                        var mapping = CreateMap<Source, Destination>();
+                                        CreateMap<Destination, Source>();
+                                    }
+                                }
+                                """;
+
+        await AnalyzerVerifier<AM041_DuplicateMappingAnalyzer>.VerifyAnalyzerAsync(testCode);
+    }
+
+    [Fact]
+    public async Task Should_NotReportDiagnostic_WhenDeferredReverseMapUsesAlias()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                public class Source {}
+                                public class Destination {}
+
+                                public class MyProfile : Profile
+                                {
+                                    public MyProfile()
+                                    {
+                                        var mapping = CreateMap<Source, Destination>();
+                                        var alias = mapping;
+                                        alias.ReverseMap();
+                                        CreateMap<Destination, Source>();
+                                    }
+                                }
+                                """;
+
+        await AnalyzerVerifier<AM041_DuplicateMappingAnalyzer>.VerifyAnalyzerAsync(testCode);
+    }
+
+    [Fact]
+    public async Task Should_NotReportDiagnostic_WhenDeferredReverseMapIsConditional()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                public class Source {}
+                                public class Destination {}
+
+                                public class MyProfile : Profile
+                                {
+                                    public MyProfile(bool reverse)
+                                    {
+                                        var mapping = CreateMap<Source, Destination>();
+                                        if (reverse)
+                                        {
+                                            mapping.ReverseMap();
+                                        }
+                                        CreateMap<Destination, Source>();
+                                    }
+                                }
+                                """;
+
+        await AnalyzerVerifier<AM041_DuplicateMappingAnalyzer>.VerifyAnalyzerAsync(testCode);
+    }
+
+    [Fact]
+    public async Task Should_NotReportDiagnostic_WhenCreateMapIsNestedInInitializerArgument()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                public class Source {}
+                                public class Destination {}
+
+                                public class MyProfile : Profile
+                                {
+                                    public MyProfile()
+                                    {
+                                        var mapping = Wrap(CreateMap<Source, Destination>());
+                                        mapping.ReverseMap();
+                                        CreateMap<Destination, Source>();
+                                    }
+
+                                    private static IMappingExpression<TSource, TDestination> Wrap<TSource, TDestination>(
+                                        IMappingExpression<TSource, TDestination> mapping) => mapping;
+                                }
+                                """;
+
+        await AnalyzerVerifier<AM041_DuplicateMappingAnalyzer>.VerifyAnalyzerAsync(testCode);
+    }
+
 }


### PR DESCRIPTION
## Summary

- register later standalone same-block semantic `mapping.ReverseMap()` calls when a direct local is rooted in `CreateMap<S, D>()`, including fluent configuration initializers
- report the duplicate reverse direction in either statement order
- keep aliases, conditionals, assignments, nested argument flow, and lookalikes outside the flow-insensitive boundary
- remove a duplicate deferred `ReverseMap()` statement without producing invalid `mapping;` code
- synchronize analyzer health, catalog, package metadata, and release docs for 2.30.73

## Evidence

Public package 2.30.72 emitted AM041 for the fluent form `CreateMap<S,D>().ReverseMap()` plus `CreateMap<D,S>()`, but missed the semantically equivalent direct-local form:

```csharp
var mapping = CreateMap<Source, Destination>();
mapping.ReverseMap();
CreateMap<Destination, Source>();
```

Both forms pass AutoMapper 14 `AssertConfigurationIsValid()`; this change restores consistent preventative duplicate-registration guidance.

Repository review also identified the configured-initializer equivalent:

```csharp
var mapping = CreateMap<Source, Destination>().ForMember(...);
mapping.ReverseMap();
CreateMap<Destination, Source>();
```

That correction is covered end-to-end while `Wrap(CreateMap<S,D>())` remains outside the intentionally flow-insensitive boundary.

## Verification

- AM041 analyzer/code-fix suite: 45 passed
- local full superset: 1,471 passed, 0 skipped, 0 failed
- clean branch expected suite: 1,450 tests
- Release build: 0 warnings, 0 errors
- AnalyzerVerifier catalog, snapshot, and compatibility documentation checks passed
- Slopwatch: 0 findings
- packed 2.30.73 SHA-256: `71c0576d67cb18a5ad2c1029c9ca8bf8cf4971328699e943f6ab35f565ecbe0d`
- `net10-am14` package contract: healthy consumer clean; broken consumer fails specifically with AM001

## Review boundary

No local Claude review was invoked. CI, Codecov, and repository review automation are the merge gates.