### PR TITLE
fix: ignore mutually exclusive AM041 registrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+## [2.30.77] - 2026-07-18
+
+AM041 mutually exclusive branch precision.
+
+### Changed
+
+- **Mutually exclusive registrations**: duplicate `CreateMap<TSource, TDestination>()` calls in opposite arms of the same `if`/`else`, including one `if`/`else if`/`else` chain, no longer emit AM041 when they share one executable body and therefore cannot run together.
+- **Conservative conflict boundary**: independent `if` statements, registrations outside the branch chain, and registrations in different executable bodies still participate in duplicate detection. When an unconditional registration follows mutually exclusive alternatives, AM041 continues to report that real conflict and retains its removal fix.
+
+### Validation
+
+- AM041 analyzer and code-fix suite: **49** passed.
+- Clean-branch full solution suite: **1667** passed, 0 skipped, 0 failed on `net10.0`.
+
 ## [2.30.76] - 2026-07-18
 
 AM022 deferred root cycle-breaker parity.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet Version](https://img.shields.io/nuget/v/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=NuGet)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/AutoMapperAnalyzer.Analyzers.svg?style=flat-square&logo=nuget&label=Downloads)](https://www.nuget.org/packages/AutoMapperAnalyzer.Analyzers/)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/georgepwall1991/automapper-analyser/ci.yml?style=flat-square&logo=github&label=Build)](https://github.com/georgepwall1991/automapper-analyser/actions)
-[![Tests](https://img.shields.io/badge/Tests-1646%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
+[![Tests](https://img.shields.io/badge/Tests-1667%20passing%2C%200%20skipped-success?style=flat-square&logo=checkmarx)](https://github.com/georgepwall1991/automapper-analyser/actions)
 [![.NET](https://img.shields.io/badge/.NET-4.8+%20%7C%206.0+%20%7C%208.0+%20%7C%209.0+%20%7C%2010.0+-512BD4?style=flat-square&logo=dotnet)](https://dotnet.microsoft.com/)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](LICENSE)
 [![Coverage](https://img.shields.io/codecov/c/github/georgepwall1991/automapper-analyser?style=flat-square&logo=codecov&label=Coverage)](https://codecov.io/gh/georgepwall1991/automapper-analyser)
@@ -14,22 +14,22 @@ prevention*
 
 ---
 
-## 🎉 Latest Release: v2.30.76
+## 🎉 Latest Release: v2.30.77
 
-**AM022 deferred root cycle-breaker parity**
+**AM041 mutually exclusive branch precision**
 
 ✅ **Highlights**
 
-- A map stored directly from `CreateMap<TSource, TDestination>()` now honors later same-block semantic `MaxDepth`, `PreserveReferences`, and `ConvertUsing` calls at the root, closing the false AM022 that previously remained after valid deferred configuration.
-- Deferred policies must be the first executable statement after the captured mapping declaration, apart from inert local-function declarations or empty statements, and use a direct fluent receiver chain rooted at that local. Any intervening executable statement—including constructors, arbitrary wrappers, substituting helpers, recursive effects, delegate invocation surfaces, dynamic calls, and conditional control flow—fails closed; policies chained after `ReverseMap()` cannot suppress the forward root diagnostic, and duplicate directions remain conservative unless every registration is constrained.
-- Pull requests now use exact-head GitHub Codex review without the obsolete automatic Claude review workflow; the separate opt-in `@claude` workflow remains available.
+- AM041 no longer reports duplicate `CreateMap<TSource, TDestination>()` registrations that occupy opposite arms of the same `if`/`else` or one `if`/`else if`/`else` chain within a single executable body, because those registrations cannot execute together.
+- Independent `if` statements and registrations outside the mutually exclusive chain remain diagnostic, so the duplicate-removal fixer is withheld only for the proven non-conflicting branch shape.
 
 🧪 **Validation**
 
-- AM022 suite: **131** passed; clean-branch full suite: **1646** passed, 0 skipped, 0 failed on `net10.0`.
+- AM041 analyzer and code-fix suite: **49** passed; clean-branch full suite: **1667** passed, 0 skipped, 0 failed on `net10.0`.
 
 ### Recent Releases
 
+- **v2.30.77**: AM041 excludes proven mutually exclusive `if`/`else` registration alternatives while preserving diagnostics for independent or unconditional duplicates.
 - **v2.30.76**: AM022 honors deferred root `MaxDepth`, `PreserveReferences`, and `ConvertUsing` configuration through direct mapping locals while retaining direction and duplicate ambiguity boundaries.
 - **v2.30.75**: AM022 follows direct constructor-owned recursion edges, distinguishes safe mixed-path `MaxDepth` from unsafe construction-only recursion, and withholds ineffective constructor-owned fixes.
 - **v2.30.74**: AM002 respects exact semantic `ForCtorParam` null-safety ownership, propagates synchronous helper mutations and conditional iterator provenance, requires semantic/unconditional null-safety configuration, tracks nested variance polarity, and repairs unsafe constructor inputs in place.
@@ -242,7 +242,7 @@ Install-Package AutoMapperAnalyzer.Analyzers
 ### Project File (For CI/CD)
 
 ```xml
-<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.76">
+<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.77">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 </PackageReference>

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -1,12 +1,12 @@
 # Analyzer Health
 
-Reviewed: 2026-07-18 (AM022 deferred root cycle-breaker parity prepared as **2.30.76**)
+Reviewed: 2026-07-18 (AM041 mutually exclusive branch precision prepared as **2.30.77**)
 
 This is a deliberately harsh health audit for the **21** implemented AutoMapper analyzer rule IDs in this repository (16 before the 2.30.62 performance split). Several rule IDs still expose multiple diagnostic descriptors, especially `AM002` and `AM022`; the scorecard rates the public rule ID as the user experiences it.
 
 Every implemented rule currently has an analyzer and a code fix provider. Scores are 1-5, where `5` means reference-quality and hard to improve, `3` means usable but meaningfully incomplete, and `1` means unreliable or underbuilt.
 
-**Ship status:** production-acceptable. **2.30.76** AM022 deferred root cycle-breaker parity; **2.30.75** AM022 constructor-parameter cycle ownership; **2.30.74** AM002 constructor-parameter null-safety ownership; **2.30.73** AM041 deferred `ReverseMap()` registration. Every rule now has minimum health 4. Full suite green; catalog/snapshots and package smoke verification are current.
+**Ship status:** production-acceptable. **2.30.77** AM041 mutually exclusive branch precision; **2.30.76** AM022 deferred root cycle-breaker parity; **2.30.75** AM022 constructor-parameter cycle ownership; **2.30.74** AM002 constructor-parameter null-safety ownership; **2.30.73** AM041 deferred `ReverseMap()` registration. Every rule now has minimum health 4. Full suite green; catalog/snapshots and package smoke verification are current.
 
 ## Rubric
 
@@ -52,7 +52,7 @@ Priority is a planning signal: `High` means the analyzer is important and has me
 | AM036 | Sync-over-async in mapping | Performance | Warning | 4 | 4 | 4 | 5 | 4 | 4 | Low | Split from AM031 in 2.30.62. Task.Result/Wait/WaitAll/WaitAny/GetResult including source Task properties; shared ForPath Ignore scaffold. |
 | AM037 | Complex LINQ in mapping | Performance | Warning | 4 | 4 | 4 | 4 | 4 | 3 | Low | Split from AM031 in 2.30.62. Real Enumerable/Queryable SelectMany gate; shared ForPath Ignore scaffold. |
 | AM038 | Non-deterministic operation in mapping | Performance | Info | 4 | 4 | 4 | 5 | 4 | 3 | Low | Split from AM031 in 2.30.62. Info severity; ForMember/ForPath scaffold fixes. |
-| AM041 | Duplicate mapping registration | Configuration | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | Compilation-wide registry peels parentheses in fluent `ReverseMap()` chains. **2.30.73**: a direct local rooted in semantic AutoMapper `CreateMap<S,D>()`, including a fluent configuration initializer, registers later standalone same-block `mapping.ReverseMap()` calls; aliases, conditional/nested calls, assignments, and lookalikes stay excluded. The fixer removes a duplicate deferred statement without leaving invalid expression code. SafeRewrite removal still withholds chained/nested/argument-position configuration. |
+| AM041 | Duplicate mapping registration | Configuration | Warning | 4 | 4 | 4 | 4 | 4 | 4 | Low | Compilation-wide registry peels parentheses in fluent `ReverseMap()` chains. **2.30.73**: a direct local rooted in semantic AutoMapper `CreateMap<S,D>()`, including a fluent configuration initializer, registers later standalone same-block `mapping.ReverseMap()` calls; aliases, conditional/nested calls, assignments, and lookalikes stay excluded. **2.30.77**: registrations in opposite arms of the same `if`/`else` or one `if`/`else if`/`else` chain are not duplicates when they share one executable body; independent branches and registrations outside the chain still report. The fixer removes a duplicate deferred statement without leaving invalid expression code. SafeRewrite removal still withholds chained/nested/argument-position configuration. |
 | AM050 | Redundant MapFrom configuration | Configuration | Info | 4 | 4 | 4 | 4 | 4 | 2 | Low | Safe cleanup rule now requires proven source/destination type compatibility including nullable reference annotations, string literal and `nameof(...)`/constant `ForMember` members resolved through the effective mapping direction including `ReverseMap()` segments with direct reverse-map `nameof(...)`/const analyzer and code-fix coverage, parenthesized/typed lambda parameter shapes — `o.MapFrom((s) => s.Name)` and `o.MapFrom((Source s) => s.Name)` — with `ForMember`/`ForPath` code-fix parity, and parenthesized member bodies such as `s => (s.Name)`/`d => (d.Name)` alongside the simple `s => s.Name` shape. Multi-parameter parenthesized lambdas are intentionally ignored so AutoMapper's `(src, ctx) => ...` overload stays quiet. The automatic `ForMember`/`ForPath` removal code fix now withholds when the options lambda carries sibling configuration (`Condition`, `NullSubstitute`, `PreCondition`, `UseDestinationValue`, `Ignore`, etc.) so policy overrides cannot be silently dropped; simple-MapFrom shapes still receive the automatic action. Product importance remains low. |
 
 ## Planning Shortlist
@@ -75,7 +75,7 @@ Use this table as the hardening queue. Ranking = **Importance × (5 − min(Anal
 | 2 | **AM002** | gap=5, min=4 | Concrete `ForCtorParam` null-safety false positive, read-only alias false negative, and misleading property-fix path closed in 2.30.74. Advanced generic/nullability-flow remains repro-gated. | — until evidence |
 | 3 | **AM022** | gap=4, min=4 | Direct renamed root/downstream edges shipped 2.30.70–2.30.71; constructor-owned `ForCtorParam` edges shipped 2.30.75; deferred root cycle-breaker parity closed in 2.30.76. Advanced configuration inference remains repro-gated. | — until evidence |
 | 4 | **AM020 / AM021 / AM003** | gap=5/4 | Custom-collection / constructor-body insert structural limits. | Opportunistic |
-| 5 | **AM041 / AM050** | gap=4/2 | Concrete AM041 deferred-local `ReverseMap()` false negative closed in 2.30.73; remaining SafeRewrite nuance is repro-gated. AM050 remains low Importance. | Low ROI |
+| 5 | **AM041 / AM050** | gap=4/2 | Concrete AM041 deferred-local `ReverseMap()` false negative closed in 2.30.73 and mutually exclusive branch false positive closed in 2.30.77; remaining SafeRewrite nuance is repro-gated. AM050 remains low Importance. | Low ROI |
 | 6 | **AM033 / AM005 / AM030** | gap=2–3 | Importance-limited. | Product priority only |
 
 **Recommended next hardening batch:**
@@ -147,6 +147,12 @@ Still open (do not start without a repro or explicit product decision):
 - **AM022 / AM031 dataflow-grade heuristics.** High effort, diminishing returns until a concrete false-positive or false-negative pattern is filed. AM022 direct renamed root edges are covered; downstream explicit-member inference remains repro-gated.
 - **AM020 constructor-body CreateMap insert.** Structural host limit; catalog `LikelyRewrite` already honest.
 
+
+## Reanalysis Changelog (2026-07-18 → 2.30.77 AM041 mutually exclusive branch precision)
+
+| Rules | Finding | Change | Score impact |
+| --- | --- | --- | --- |
+| AM041 | Two identical registrations in opposite arms of one `if`/`else` emitted a duplicate warning even though only one arm can execute; accepting the offered removal fix could delete the only registration for one runtime configuration | Build duplicate conflicts in source order and suppress a registration only when every earlier same-direction registration is proven to occupy the opposite arm of the same `if`/`else` within the same executable boundary. This naturally covers `else if` chains while independent `if` statements and unconditional registrations remain conflicts | No numeric move; closes a concrete compiling false positive and prevents a destructive fix without weakening real duplicate detection |
 
 ## Reanalysis Changelog (2026-07-18 → 2.30.76 AM022 deferred root cycle-breaker parity)
 
@@ -377,18 +383,18 @@ Full rule+fixer reanalysis driven by four parallel subagent audits (Type Safety,
 
 Architecture-style coverage currently comes from analyzer/fixer tests, conflict ownership tests, helper tests, sample projects, documentation, the checked-in `RuleCatalog`, generated trust artifacts, package smoke tests, and the deterministic `tools/AnalyzerVerifier` checks.
 
-Current verification (**2026-07-18** against the exact **v2.30.76** release-candidate archive):
+Current verification (**2026-07-18** against the exact **v2.30.77** release-candidate archive):
 
-- Package version in `src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj`: **2.30.76**.
+- Package version in `src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj`: **2.30.77**.
 - `dotnet build automapper-analyser.sln --configuration Release --no-restore -p:RunAnalyzersDuringBuild=false` passed: 0 warnings, 0 errors; the flag excludes the intentionally broken sample diagnostics from the compile gate.
-- Exact-archive AM022 suite: **131** passed, 0 skipped, 0 failed; clean full suite: **1646** passed, 0 skipped, 0 failed.
+- Exact-archive AM041 analyzer and code-fix suite: **49** passed, 0 skipped, 0 failed; clean full suite: **1667** passed, 0 skipped, 0 failed.
 - `dotnet run --project tools/AnalyzerVerifier/AnalyzerVerifier.csproj --configuration Release --no-build -- --check-catalog --check-snapshots --check-compatibility` passed: the rule catalog, sample diagnostics snapshot, and compatibility documentation are up to date.
-- A freshly packed `AutoMapperAnalyzer.Analyzers.2.30.76.nupkg` (SHA-256 `3f4a3cb2f50ef23fbe3c091ef38e7b738bc5a10f52a0f9423960b534622bfa86`) passed isolated AutoMapper 14 / `net10.0` consumer proofs: a healthy mapping built and ran without analyzer/load diagnostics, while a broken string-to-int mapping failed specifically with `AM001`. Deferred root cycle-breaker regressions prove a first-executable-statement direct-local `MaxDepth`, `PreserveReferences`, or `ConvertUsing` suppresses the exact forward map while constructors and every other intervening executable statement, arbitrary wrappers, helper-returned receivers that merely contain the local, substituting extension methods, reassignment, `ref` mutation, invoked or recursive local-function effects, delegate invocation surfaces including `DynamicInvoke`, dynamic calls, conditional exits and expressions, reverse-only calls, and duplicate-ambiguous configurations remain diagnostic. Repository CI independently packages the branch and runs `net8.0`, `net9.0`, and `net10.0` smoke consumers.
-- Remote branch compare is one commit with only the 17 intended workflow/source/test/trust/release files and no trailing-whitespace additions.
+- A freshly packed `AutoMapperAnalyzer.Analyzers.2.30.77.nupkg` (SHA-256 `9725d452f3c600eaba085dc5bb41c06f54a4d0b01918645f499ebd06bb155b7a`) passed isolated AutoMapper 14 / `net10.0` consumer proofs: a healthy mapping built and ran without analyzer/load diagnostics, while a broken string-to-int mapping failed specifically with `AM001`. AM041 regressions prove opposite arms of the same `if`/`else` or one `else if` chain do not conflict within a shared executable body, while independent `if` statements and an unconditional registration outside the chain still report. Local package smoke passed for `net8.0`, `net9.0`, and `net10.0`; repository CI independently repeats that matrix on the PR.
+- Remote publication is constrained to one commit containing only the intended AM041 source/test/trust/release files; the exact compare is rechecked before merge.
 - Full-solution `dotnet format whitespace --verify-no-changes` remains noisy from pre-existing repository-wide whitespace and line-ending debt; the C# blobs touched by this correction preserve the branch's LF convention, add no trailing whitespace, and Slopwatch reports 0 issues.
 - Sample project emits AM0xx when analyzers run (`-p:RunAnalyzersDuringBuild=true`); local untracked `Directory.Build.props` (if present) may skip analyzers during CLI builds — unit tests + AnalyzerVerifier remain the verification source of truth.
-- Approximate list-tests name hits (not exclusive filters; for trend only): AM001 63, AM002 214, AM003 61, AM004 87, AM005 34, AM006 43, AM011 45, AM020 97, AM021 64, AM022 62, AM030/32/33 bucket 156, AM031 292, AM041 45, AM050 48, RuleCatalog 10.
-- Release metadata is synchronized for `v2.30.76`; tag/publication follows the merged PR.
+- Approximate list-tests name hits (not exclusive filters; for trend only): AM001 63, AM002 214, AM003 61, AM004 87, AM005 34, AM006 43, AM011 45, AM020 97, AM021 64, AM022 62, AM030/32/33 bucket 156, AM031 292, AM041 49, AM050 48, RuleCatalog 10.
+- Release metadata is synchronized for `v2.30.77`; tag/publication follows the merged PR.
 - Historical baseline (2026-07-06 @ `b138fa8` / v2.30.55): **1352** tests green — superseded; do not use for planning.
 - The trust-first pass removed active skipped tests, added drift validation, and moved intentional analyzer-test warnings into an explicit test-project warning baseline.
 - `/usr/local/share/dotnet/dotnet --list-runtimes` shows only .NET 10 runtimes in this local environment, so broader multi-TFM runtime verification remains blocked by missing .NET 8 and .NET 9 runtimes.

--- a/docs/ANALYZER_REVIEW_TRACKER.md
+++ b/docs/ANALYZER_REVIEW_TRACKER.md
@@ -65,6 +65,7 @@ Tracks analyzer-by-analyzer improvement passes focused on false positives, contr
 | AM050 preserve sibling configuration | Configuration | _branch_ | v2.30.23 | Withheld the AM050 automatic `ForMember`-removal code action when the options lambda carries sibling configuration (`Condition`, `NullSubstitute`, `PreCondition`, `UseDestinationValue`, `Ignore`, etc.) so the redundant-`MapFrom` cleanup no longer silently drops policy overrides. |
 | AM022 constructor-owned cycle edges | Complex Mappings | main | v2.30.75 | Added unique direct semantic `ForCtorParam` edges for writable, read-only, and exact positional-record constructor-owned destination properties, replayed them downstream, retained `ConvertUsing` ownership, prevented ineffective Ignore/PreserveReferences suppression, and kept mixed-path MaxDepth effective while construction-only cycles still report. |
 | AM022 deferred root cycle breakers | Complex Mappings | main | v2.30.76 | Reused the direction-aware registry at the root so later same-block `MaxDepth`, `PreserveReferences`, and `ConvertUsing` calls through a direct mapping local suppress only the exact constrained direction; reverse-only and duplicate-ambiguous registrations remain diagnostic. |
+| AM041 mutually exclusive registration branches | Configuration | main | v2.30.77 | Opposite arms of the same `if`/`else` or one `else if` chain no longer conflict within a single executable body; independent and unconditional duplicates remain diagnostic. |
 
 ## In Progress
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -725,7 +725,7 @@ dotnet pack --configuration Release
 
 # Test package locally
 cd test-install/NetCoreTest
-dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.76-local
+dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.77-local
 ```
 
 ---
@@ -909,4 +909,4 @@ dotnet build
 
 **Last Updated**: 2026-05-14
 **Maintainer**: George Wall
-**Version**: 2.30.76
+**Version**: 2.30.77

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -113,8 +113,8 @@ The AutoMapper Roslyn Analyzer project uses GitHub Actions for continuous integr
 ### Package Versioning
 
 - **Format**: Major.Minor.Patch (SemVer)
-- **Current**: 2.30.76
-- **Pre-release**: 2.30.76-preview, 2.30.76-beta
+- **Current**: 2.30.77
+- **Pre-release**: 2.30.77-preview, 2.30.77-beta
 
 ## 🔧 Configuration
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -43,7 +43,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.76">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.77">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -67,7 +67,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.76">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.77">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -86,7 +86,7 @@ The AutoMapper Analyzer targets **.NET Standard 2.0**, which provides compatibil
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="14.0.0" />
-    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.76">
+    <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.77">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
@@ -218,7 +218,7 @@ public class Destination
 
 2. **Verify Package Installation**
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.76">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.77">
      <PrivateAssets>all</PrivateAssets>
      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -280,4 +280,4 @@ This guide ensures smooth installation and usage across all supported .NET frame
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.76
+**Version**: 2.30.77

--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -1648,7 +1648,7 @@ using System.Diagnostics.CodeAnalysis;
 
 1. **Check package reference**:
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.76">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.77">
        <PrivateAssets>all</PrivateAssets>
        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -1687,5 +1687,5 @@ If analyzer slows down builds:
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.76
+**Version**: 2.30.77
 **Maintainer**: George Wall

--- a/docs/RULE_CATALOG.md
+++ b/docs/RULE_CATALOG.md
@@ -2,7 +2,7 @@
 
 This file is generated from `RuleCatalog`.
 
-Package version: `2.30.76`
+Package version: `2.30.77`
 
 | Rule ID | Descriptor Title | Severity | Category | Analyzer | Code Fix | Trust | Sample | Docs |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1648,7 +1648,7 @@ using System.Diagnostics.CodeAnalysis;
 
 1. **Check package reference**:
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.76">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.77">
        <PrivateAssets>all</PrivateAssets>
        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -1687,5 +1687,5 @@ If analyzer slows down builds:
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.76
+**Version**: 2.30.77
 **Maintainer**: George Wall

--- a/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,3 +1,15 @@
+## Release 2.30.77
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
+### Removed Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
 ## Release 2.30.76
 
 ### New Rules

--- a/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
+++ b/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
@@ -17,7 +17,7 @@
         <!-- Fallback for local builds: 2.0.YYYYMMDD-local -->
         <MajorVersion>2</MajorVersion>
         <MinorVersion>30</MinorVersion>
-        <PatchVersion>76</PatchVersion>
+        <PatchVersion>77</PatchVersion>
         <BuildNumber Condition="'$(BuildNumber)' == ''"
         >$([System.DateTime]::Now.ToString('yyyyMMdd'))
         </BuildNumber
@@ -32,12 +32,10 @@
         <RepositoryUrl>https://github.com/georgepwall1991/automapper-analyser</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-                <PackageReleaseNotes>Version 2.30.76 - AM022 deferred root cycle-breaker parity
-- Direct local mapping variables configured later with MaxDepth, PreserveReferences, or ConvertUsing now constrain the root map as well as downstream traversal
-- Deferred policies require a straight-line same-block path and direct fluent statement chain so conditional exits or expressions cannot hide an unconstrained map
-- Cycle-breaker ownership remains direction-aware; reverse-only policies do not suppress the forward diagnostic
-- Duplicate mapping directions remain conservative unless every registration carries the same constraint
-- Automatic pull-request review now uses GitHub Codex; the obsolete Claude review workflow is removed
+                <PackageReleaseNotes>Version 2.30.77 - AM041 mutually exclusive branch precision
+- Duplicate CreateMap registrations in opposite arms of one if/else or else-if chain no longer report when they share one executable body
+- Independent if statements and registrations outside the mutually exclusive chain remain diagnostic
+- Prevents the SafeRewrite fixer from deleting a runtime configuration alternative that is not a duplicate
 </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>

--- a/src/AutoMapperAnalyzer.Analyzers/Helpers/CreateMapRegistry.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Helpers/CreateMapRegistry.cs
@@ -319,6 +319,11 @@ internal sealed class CreateMapRegistry
                 for (int i = 1; i < sorted.Count; i++)
                 {
                     MappingInfo duplicate = sorted[i];
+                    if (sorted.Take(i).All(previous => AreMutuallyExclusiveByIfElse(previous, duplicate)))
+                    {
+                        continue;
+                    }
+
                     duplicates[duplicate.Node] = (
                         Source: FormatMappingTypeName(duplicate.Source),
                         Dest: FormatMappingTypeName(duplicate.Destination),
@@ -329,6 +334,46 @@ internal sealed class CreateMapRegistry
         }
 
         return new CreateMapRegistry(mappings.ToImmutableArray(), duplicates);
+    }
+
+    private static bool AreMutuallyExclusiveByIfElse(MappingInfo first, MappingInfo second)
+    {
+        SyntaxNode? firstBoundary = GetContainingExecutableBoundary(first.Node);
+        SyntaxNode? secondBoundary = GetContainingExecutableBoundary(second.Node);
+        if (firstBoundary == null || !ReferenceEquals(firstBoundary, secondBoundary))
+        {
+            return false;
+        }
+
+        foreach (IfStatementSyntax ifStatement in first.Node.Ancestors().OfType<IfStatementSyntax>())
+        {
+            if (ifStatement.Else is not { Statement: StatementSyntax elseStatement } ||
+                !ifStatement.Span.Contains(second.Node.Span))
+            {
+                continue;
+            }
+
+            bool firstInThen = ifStatement.Statement.Span.Contains(first.Node.Span);
+            bool firstInElse = elseStatement.Span.Contains(first.Node.Span);
+            bool secondInThen = ifStatement.Statement.Span.Contains(second.Node.Span);
+            bool secondInElse = elseStatement.Span.Contains(second.Node.Span);
+            if ((firstInThen && secondInElse) || (firstInElse && secondInThen))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static SyntaxNode? GetContainingExecutableBoundary(SyntaxNode node)
+    {
+        return node.Ancestors().FirstOrDefault(ancestor =>
+            ancestor is BaseMethodDeclarationSyntax or
+                AccessorDeclarationSyntax or
+                LocalFunctionStatementSyntax or
+                AnonymousFunctionExpressionSyntax or
+                GlobalStatementSyntax);
     }
 
     public static CreateMapRegistry FromCompilation(Compilation compilation)

--- a/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
@@ -130,7 +130,7 @@ public static class RuleCatalog
     /// <summary>
     ///     Current package version used by docs/package drift tests.
     /// </summary>
-    public const string CurrentPackageVersion = "2.30.76";
+    public const string CurrentPackageVersion = "2.30.77";
 
     /// <summary>
     ///     Implemented rules, grouped by public diagnostic ID.

--- a/tests/AutoMapperAnalyzer.Tests/Configuration/AM041_DuplicateMappingTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Configuration/AM041_DuplicateMappingTests.cs
@@ -329,4 +329,131 @@ public class AM041_DuplicateMappingTests
         await AnalyzerVerifier<AM041_DuplicateMappingAnalyzer>.VerifyAnalyzerAsync(testCode);
     }
 
+    [Fact]
+    public async Task Should_NotReportDiagnostic_WhenRegistrationsAreInOppositeIfElseBranches()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                public class Source {}
+                                public class Destination {}
+
+                                public class MyProfile : Profile
+                                {
+                                    public MyProfile(bool useAlternative)
+                                    {
+                                        if (useAlternative)
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                        else
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await AnalyzerVerifier<AM041_DuplicateMappingAnalyzer>.VerifyAnalyzerAsync(testCode);
+    }
+
+    [Fact]
+    public async Task Should_ReportDiagnostic_WhenRegistrationsAreInIndependentIfStatements()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                public class Source {}
+                                public class Destination {}
+
+                                public class MyProfile : Profile
+                                {
+                                    public MyProfile(bool first, bool second)
+                                    {
+                                        if (first)
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+
+                                        if (second)
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        DiagnosticResult expected = new DiagnosticResult(AM041_DuplicateMappingAnalyzer.DuplicateMappingRule)
+            .WithLocation(17, 13)
+            .WithArguments("Source", "Destination");
+
+        await AnalyzerVerifier<AM041_DuplicateMappingAnalyzer>.VerifyAnalyzerAsync(testCode, expected);
+    }
+
+    [Fact]
+    public async Task Should_NotReportDiagnostic_WhenRegistrationsAreInOneIfElseIfChain()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                public class Source {}
+                                public class Destination {}
+
+                                public class MyProfile : Profile
+                                {
+                                    public MyProfile(bool first, bool second)
+                                    {
+                                        if (first)
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                        else if (second)
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                        else
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                    }
+                                }
+                                """;
+
+        await AnalyzerVerifier<AM041_DuplicateMappingAnalyzer>.VerifyAnalyzerAsync(testCode);
+    }
+
+    [Fact]
+    public async Task Should_ReportDiagnostic_WhenUnconditionalRegistrationFollowsIfElseRegistrations()
+    {
+        const string testCode = """
+                                using AutoMapper;
+
+                                public class Source {}
+                                public class Destination {}
+
+                                public class MyProfile : Profile
+                                {
+                                    public MyProfile(bool useAlternative)
+                                    {
+                                        if (useAlternative)
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+                                        else
+                                        {
+                                            CreateMap<Source, Destination>();
+                                        }
+
+                                        CreateMap<Source, Destination>();
+                                    }
+                                }
+                                """;
+
+        DiagnosticResult expected = new DiagnosticResult(AM041_DuplicateMappingAnalyzer.DuplicateMappingRule)
+            .WithLocation(19, 9)
+            .WithArguments("Source", "Destination");
+
+        await AnalyzerVerifier<AM041_DuplicateMappingAnalyzer>.VerifyAnalyzerAsync(testCode, expected);
+    }
+
 }


### PR DESCRIPTION
## Summary

- stop AM041 from treating registrations in opposite arms of the same `if`/`else` as duplicates when they share one executable body
- cover complete `if`/`else if`/`else` chains while preserving diagnostics for independent `if` statements and unconditional registrations outside the chain
- keep duplicate reporting conservative across methods, accessors, local functions, lambdas, and global-statement boundaries
- prepare package metadata and trust documentation for v2.30.77

## Verification

- red-first regression reproduced the false AM041 at the second mutually exclusive registration
- AM041 analyzer and code-fix suite: 49/49 passed
- full suite: 1,667/1,667 passed, 0 skipped
- Release solution build with sample analyzers disabled: 0 warnings, 0 errors
- catalog, sample snapshot, and compatibility verifier: passed
- Slopwatch 0.4.2 on changed C# files: 0 findings
- package smoke: net8.0, net9.0, and net10.0 passed
- exact nupkg SHA-256: `9725d452f3c600eaba085dc5bb41c06f54a4d0b01918645f499ebd06bb155b7a`
- packaged analyzer DLL is byte-identical to Release output: `aefffa23a108ed19516dadea7adb4892c46d2757d541a99c77860b35e64121d9`
- isolated AutoMapper 14 / net10.0 exact-package consumer ran and printed `42`
- isolated broken exact-package consumer failed specifically with AM001
- independent semantic review: ALLOW, no actionable findings
- remote candidate: one commit, exactly 15 intended files
