### PR TITLE
fix(ci): declare explicit permissions for reusable compatibility call

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
   push:
     branches: [ main, develop ]
 
+permissions:
+  actions: read
+  contents: read
+
 env:
   DOTNET_VERSION: '10.0.x'
   SOLUTION_FILE: 'automapper-analyser.sln'


### PR DESCRIPTION
Probe: branch-push CI runs die with startup_failure while the identical reusable call from release.yml (tag push) succeeds. The only structural difference is release.yml's top-level `permissions:` block. Testing whether declaring it fixes branch-push startup.

Generated with Qwen Code