### PR TITLE
docs(ci): explain why the top-level permissions block is required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches: [ main, develop ]
 
+# Required, not cosmetic: without an explicit top-level permissions block the
+# reusable compatibility call below dies with startup_failure on branch pushes
+# (release.yml declares permissions for the same reason).
 permissions:
   actions: read
   contents: read


### PR DESCRIPTION
Comment-only: the `permissions:` block in ci.yml is load-bearing for the reusable compatibility call (branch pushes die with startup_failure without it). Document it so it is not removed as apparently unused.

Generated with Qwen Code