### PR TITLE
release: v2.30.85 — AM021 nested collection safety + dependency updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+## [2.30.85] - 2026-07-21
+
+AM021 nested collection element fix safety + dependency updates.
+
+### Fixed
+
+- **AM021 nested collection safety**: AM021 now withholds its ordinary complex element `CreateMap` action when either element is a nested generic collection or array, keeping those shapes on the explicit manual-review Ignore path. Plain domain-object element maps, executable primitive conversions, dictionary behavior, and Stack LIFO order safety are preserved.
+
+### Changed
+
+- Bump Microsoft.NET.Test.Sdk from 18.0.1 to 18.8.1.
+- Bump coverlet.collector from 6.0.4 to 10.0.1.
+- Bump codecov/codecov-action from v6 to v7.
+
 ## [2.30.84] - 2026-07-21
 
 Two new rules: AM060 unregistered type maps and AM061 enum member mismatches.

--- a/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
+++ b/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
@@ -17,7 +17,7 @@
         <!-- Fallback for local builds: 2.0.YYYYMMDD-local -->
         <MajorVersion>2</MajorVersion>
         <MinorVersion>30</MinorVersion>
-        <PatchVersion>84</PatchVersion>
+        <PatchVersion>85</PatchVersion>
         <BuildNumber Condition="'$(BuildNumber)' == ''"
         >$([System.DateTime]::Now.ToString('yyyyMMdd'))
         </BuildNumber
@@ -32,12 +32,10 @@
         <RepositoryUrl>https://github.com/georgepwall1991/automapper-analyser</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-                <PackageReleaseNotes>Version 2.30.84 - AM060 unregistered type maps + AM061 enum member mismatches
-- New AM060 (Warning): Map/ProjectTo call sites with no reachable CreateMap registration are surfaced at compile time instead of throwing AutoMapperMappingException at runtime
-- Registry-aware reachability: ReverseMap directions, base-type/interface registrations, assignable pairs, and collection element maps all count; open-generic, generic-helper, and cross-assembly configurations stay conservatively silent
-- AM060 code fix scaffolds the missing CreateMap into a Profile constructor in the same document
-- New AM061 (Warning): enum-to-enum property pairs whose members misalign by name/value are flagged before they silently corrupt data
-- AM061 honors Ignore, ConvertUsing, non-trivial MapFrom, and [Flags] enums; fixes offer name-based Enum.Parse conversion or explicit Ignore
+                <PackageReleaseNotes>Version 2.30.85 - AM021 nested collection safety + dependency updates
+- AM021 now withholds ineffective element CreateMap actions for nested generic collections and arrays, keeping those shapes on the explicit manual-review Ignore path
+- Plain domain-object element maps, executable primitive conversions, dictionary handling, and Stack LIFO order safety are preserved
+- Bump Microsoft.NET.Test.Sdk 18.0.1 to 18.8.1, coverlet.collector 6.0.4 to 10.0.1, codecov-action v6 to v7
 </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Release v2.30.85

### Fixed
- AM021 withholds ineffective element CreateMap actions for nested generic collections and arrays

### Changed
- Bump Microsoft.NET.Test.Sdk 18.0.1 → 18.8.1
- Bump coverlet.collector 6.0.4 → 10.0.1
- Bump codecov/codecov-action v6 → v7

Patch bump: all changes are bug fixes and dependency updates.

Generated with Qwen Code