### PR TITLE
fix: align version references to 2.30.85

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ prevention*
 
 ---
 
-## 🎉 Latest Release: v2.30.84
+## 🎉 Latest Release: v2.30.85
 
 **Two new rules: AM060 unregistered type maps + AM061 enum member mismatches**
 
@@ -252,7 +252,7 @@ Install-Package AutoMapperAnalyzer.Analyzers
 ### Project File (For CI/CD)
 
 ```xml
-<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.84">
+<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.85">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 </PackageReference>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -725,7 +725,7 @@ dotnet pack --configuration Release
 
 # Test package locally
 cd test-install/NetCoreTest
-dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.84-local
+dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.85-local
 ```
 
 ---
@@ -909,4 +909,4 @@ dotnet build
 
 **Last Updated**: 2026-05-14
 **Maintainer**: George Wall
-**Version**: 2.30.84
+**Version**: 2.30.85

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -118,8 +118,8 @@ The split exists because GitHub cannot resolve local reusable workflows (`uses: 
 ### Package Versioning
 
 - **Format**: Major.Minor.Patch (SemVer)
-- **Current**: 2.30.84
-- **Pre-release**: 2.30.84-preview, 2.30.84-beta
+- **Current**: 2.30.85
+- **Pre-release**: 2.30.85-preview, 2.30.85-beta
 
 ## 🔧 Configuration
 
@@ -202,7 +202,7 @@ dotnet run --project tools/AnalyzerVerifier -- --update-catalog --update-snapsho
 dotnet pack --configuration Release --output ./packages
 
 # Verify the packed analyzer against one compatibility case (matrix in tools/package-compatibility.json)
-dotnet run --project tools/AnalyzerVerifier -- --verify-package-compatibility ./packages/AutoMapperAnalyzer.Analyzers.2.30.84.nupkg --case net10-am14
+dotnet run --project tools/AnalyzerVerifier -- --verify-package-compatibility ./packages/AutoMapperAnalyzer.Analyzers.2.30.85.nupkg --case net10-am14
 
 # Run samples
 dotnet run --project samples/AutoMapperAnalyzer.Samples

--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -1833,7 +1833,7 @@ using System.Diagnostics.CodeAnalysis;
 
 1. **Check package reference**:
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.84">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.85">
        <PrivateAssets>all</PrivateAssets>
        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -1872,5 +1872,5 @@ If analyzer slows down builds:
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.84
+**Version**: 2.30.85
 **Maintainer**: George Wall

--- a/docs/RULE_CATALOG.md
+++ b/docs/RULE_CATALOG.md
@@ -2,7 +2,7 @@
 
 This file is generated from `RuleCatalog`.
 
-Package version: `2.30.84`
+Package version: `2.30.85`
 
 | Rule ID | Descriptor Title | Severity | Category | Analyzer | Code Fix | Trust | Sample | Docs |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1660,7 +1660,7 @@ using System.Diagnostics.CodeAnalysis;
 
 1. **Check package reference**:
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.84">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.85">
        <PrivateAssets>all</PrivateAssets>
        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -1699,5 +1699,5 @@ If analyzer slows down builds:
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.84
+**Version**: 2.30.85
 **Maintainer**: George Wall

--- a/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,3 +1,15 @@
+## Release 2.30.85
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
+### Removed Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+
 ## Release 2.30.84
 
 ### New Rules

--- a/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
@@ -130,7 +130,7 @@ public static class RuleCatalog
     /// <summary>
     ///     Current package version used by docs/package drift tests.
     /// </summary>
-    public const string CurrentPackageVersion = "2.30.84";
+    public const string CurrentPackageVersion = "2.30.85";
 
     /// <summary>
     ///     Implemented rules, grouped by public diagnostic ID.


### PR DESCRIPTION
Updates RuleCatalog.CurrentPackageVersion, AnalyzerReleases.Shipped.md, README, and docs to reference 2.30.85. Fixes the trust test failures that broke the v2.30.85 release workflow.

Generated with Qwen Code