### PR TITLE
test: execute code-fix output against real AutoMapper instead of comparing it to text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Added
+
+- **Runtime verification for code-fix output** (`tests/.../Infrastructure/CodeFixRuntimeVerifier.cs`).
+  Fixer tests verify fixes by string equality against expected text, which cannot distinguish a fix
+  AutoMapper accepts from one that merely looks right. The harness compiles fix output against the real
+  AutoMapper assembly, registers every declared `Profile`, and calls `AssertConfigurationIsValid()`;
+  `MapThroughFixedCode` executes a mapping so ordering and conversion can be asserted on real values.
+  Self-tests prove it fails for non-compiling output, semantically rejected configurations, and
+  incorrect `Stack<T>` ordering — the 2.30.83 defect class — and one test runs the real AM011 fixer end
+  to end. Test infrastructure only; no analyzer or package behaviour changes. Rollout across the
+  remaining fixers is follow-on work.
+
 ## [2.30.89] - 2026-07-28
 
 AutoMapper 15 and 16 added to the package compatibility contract (no rule ID, severity, or behaviour changes).

--- a/docs/TEST_LIMITATIONS.md
+++ b/docs/TEST_LIMITATIONS.md
@@ -12,6 +12,25 @@ Known harness caveats remain documented in the test project warning baseline:
 - trust validation tests intentionally read repository files;
 - AutoMapper 14 remains pinned for compatibility coverage while AutoMapper 15 introduces licensing/API changes.
 
+## Runtime verification of code-fix output
+
+Fixer tests assert string equality between the produced document and a hand-written expected document.
+That proves a fix matches what the test author wrote down; it does not prove the result is a mapping
+AutoMapper accepts. The 2.30.83 `Stack<T>` ordering defect is the failure class: syntactically valid,
+compile-clean, matching its expected text, and wrong at runtime.
+
+`Infrastructure/CodeFixRuntimeVerifier` closes that gap by compiling fix output against the real
+AutoMapper assembly, loading it, registering every declared `Profile`, and calling
+`AssertConfigurationIsValid()`. `MapThroughFixedCode` additionally executes a mapping so ordering and
+conversion behaviour can be asserted on real values.
+
+`CodeFixRuntimeVerificationTests` proves the harness fails for the right reasons — output that does not
+compile, output AutoMapper rejects semantically, and incorrect `Stack<T>` ordering — and runs the real
+AM011 fixer end to end, executing what it produces rather than comparing it to text.
+
+**Rollout is partial.** The harness exists and is proven; the 16 shipped fixers are not yet all routed
+through it. Extending coverage fixer by fixer is follow-on work.
+
 ## Documented analyzer boundaries
 
 `IncludeMembers` resolution (AM004/AM006/AM011) models only the directions that can **suppress** a

--- a/tests/AutoMapperAnalyzer.Tests/Infrastructure/CodeFixRuntimeVerificationTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Infrastructure/CodeFixRuntimeVerificationTests.cs
@@ -1,0 +1,287 @@
+using System.Collections;
+using System.Collections.Immutable;
+using AutoMapperAnalyzer.Analyzers.DataIntegrity;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using AutoMapperAnalyzer.Tests.Infrastructure;
+
+namespace AutoMapperAnalyzer.Tests.Infrastructure;
+
+/// <summary>
+///     Executes representative code-fix output against real AutoMapper instead of comparing it to
+///     expected text. Fixer tests elsewhere assert string equality, which cannot distinguish a fix that
+///     AutoMapper accepts from one that merely looks right.
+/// </summary>
+public class CodeFixRuntimeVerificationTests
+{
+    [Fact]
+    public void RuntimeVerifier_ShouldAcceptExplicitForMemberFix()
+    {
+        // Shape produced by the AM004/AM011 "map from similar source property" action.
+        const string fixedCode = """
+            using AutoMapper;
+
+            namespace TestNamespace
+            {
+                public class Source
+                {
+                    public string Email { get; set; } = string.Empty;
+                }
+
+                public class Destination
+                {
+                    public required string ContactEmail { get; set; }
+                }
+
+                public class TestProfile : Profile
+                {
+                    public TestProfile()
+                    {
+                        CreateMap<Source, Destination>()
+                            .ForMember(dest => dest.ContactEmail, opt => opt.MapFrom(src => src.Email));
+                    }
+                }
+            }
+            """;
+
+        CodeFixRuntimeVerifier.AssertConfiguresValidMapper(
+            fixedCode,
+            "AM004/AM011 explicit ForMember fix"
+        );
+    }
+
+    [Fact]
+    public void RuntimeVerifier_ShouldAcceptIgnoreFix()
+    {
+        // Shape produced by the AM006/AM011 explicit Ignore action.
+        const string fixedCode = """
+            using AutoMapper;
+
+            namespace TestNamespace
+            {
+                public class Source
+                {
+                    public string Name { get; set; } = string.Empty;
+                }
+
+                public class Destination
+                {
+                    public string Name { get; set; } = string.Empty;
+                    public string Unmapped { get; set; } = string.Empty;
+                }
+
+                public class TestProfile : Profile
+                {
+                    public TestProfile()
+                    {
+                        CreateMap<Source, Destination>()
+                            .ForMember(dest => dest.Unmapped, opt => opt.Ignore());
+                    }
+                }
+            }
+            """;
+
+        CodeFixRuntimeVerifier.AssertConfiguresValidMapper(fixedCode, "AM006/AM011 Ignore fix");
+    }
+
+    [Fact]
+    public void RuntimeVerifier_ShouldRejectConfigurationAutoMapperDoesNotAccept()
+    {
+        // Compiles cleanly and would pass any string comparison, but leaves a required destination
+        // member unmapped. Proves the verifier fails for semantic reasons, not just compiler errors.
+        const string invalidFix = """
+            using AutoMapper;
+
+            namespace TestNamespace
+            {
+                public class Source
+                {
+                    public string Other { get; set; } = string.Empty;
+                }
+
+                public class Destination
+                {
+                    public string Missing { get; set; } = string.Empty;
+                }
+
+                public class TestProfile : Profile
+                {
+                    public TestProfile()
+                    {
+                        CreateMap<Source, Destination>();
+                    }
+                }
+            }
+            """;
+
+        InvalidOperationException failure = Assert.Throws<InvalidOperationException>(() =>
+            CodeFixRuntimeVerifier.AssertConfiguresValidMapper(invalidFix)
+        );
+
+        Assert.Contains(
+            "AutoMapper rejected the configuration",
+            failure.Message,
+            StringComparison.Ordinal
+        );
+    }
+
+    [Fact]
+    public void RuntimeVerifier_ShouldSurfaceCodeFixOutputThatDoesNotCompile()
+    {
+        const string uncompilableFix = """
+            using AutoMapper;
+
+            namespace TestNamespace
+            {
+                public class TestProfile : Profile
+                {
+                    public TestProfile()
+                    {
+                        CreateMap<Missing, AlsoMissing>();
+                    }
+                }
+            }
+            """;
+
+        InvalidOperationException failure = Assert.Throws<InvalidOperationException>(() =>
+            CodeFixRuntimeVerifier.AssertConfiguresValidMapper(uncompilableFix)
+        );
+
+        Assert.Contains("did not compile", failure.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RuntimeVerifier_ShouldObserveStackConversionOrder()
+    {
+        // The 2.30.83 defect class: AM021's Stack<T> element-conversion fix was compile-clean and
+        // matched its expected text while silently reversing LIFO order. Only executing the mapping
+        // distinguishes correct ordering from plausible-looking output.
+        const string fixedCode = """
+            using System.Collections.Generic;
+            using System.Linq;
+            using AutoMapper;
+
+            namespace TestNamespace
+            {
+                public class Source
+                {
+                    public Stack<int> Values { get; set; } = new Stack<int>();
+                }
+
+                public class Destination
+                {
+                    public Stack<string> Values { get; set; } = new Stack<string>();
+                }
+
+                public class TestProfile : Profile
+                {
+                    public TestProfile()
+                    {
+                        CreateMap<Source, Destination>()
+                            .ForMember(
+                                dest => dest.Values,
+                                opt => opt.MapFrom(src =>
+                                    new Stack<string>(src.Values.Select(value => value.ToString()).Reverse())));
+                    }
+                }
+            }
+            """;
+
+        object mapped = CodeFixRuntimeVerifier.MapThroughFixedCode(
+            fixedCode,
+            "Source",
+            "Destination",
+            sourceType =>
+            {
+                object instance = Activator.CreateInstance(sourceType)!;
+                var stack = new Stack<int>();
+                stack.Push(1);
+                stack.Push(2);
+                stack.Push(3);
+                sourceType.GetProperty("Values")!.SetValue(instance, stack);
+                return instance;
+            },
+            "AM021 Stack<T> element conversion"
+        );
+
+        var values = (IEnumerable)mapped.GetType().GetProperty("Values")!.GetValue(mapped)!;
+        List<string> ordered = values.Cast<object>().Select(value => value.ToString()!).ToList();
+
+        // Source pops 3,2,1 - the converted destination must pop in the same order.
+        Assert.Equal(["3", "2", "1"], ordered);
+    }
+
+    [Fact]
+    public async Task RealFixerOutput_ShouldProduceAMapperAutoMapperAccepts()
+    {
+        // End-to-end: run the real AM011 fixer over source, then execute what it produced. Every other
+        // fixer test stops at comparing the fixed text to an expected document.
+        const string source = """
+            using AutoMapper;
+
+            namespace TestNamespace
+            {
+                public class Source
+                {
+                    public string Email { get; set; } = string.Empty;
+                }
+
+                public class Destination
+                {
+                    public required string Email { get; set; }
+                    public required string ContactName { get; set; }
+                }
+
+                public class TestProfile : Profile
+                {
+                    public TestProfile()
+                    {
+                        CreateMap<Source, Destination>();
+                    }
+                }
+            }
+            """;
+
+        Document document = AggregateFixTestHarness.CreateDocument(source, "RuntimeFixerProof");
+        ImmutableArray<Diagnostic> diagnostics =
+            await AggregateFixTestHarness.GetDiagnosticsAsync<AM011_UnmappedRequiredPropertyAnalyzer>(document);
+
+        Assert.NotEmpty(diagnostics);
+
+        IReadOnlyList<CodeFixActionInspector.ActionInfo> actions =
+            CodeFixActionInspector.Flatten(await GetTopLevelActionsAsync(document, diagnostics));
+        string ignoreKey = actions
+            .Select(action => action.EquivalenceKey)
+            .First(key => key != null && key.Contains("Ignore", StringComparison.OrdinalIgnoreCase))!;
+
+        Document fixedDocument = await CodeFixActionInspector.ApplyActionByKeyAsync(
+            document,
+            new AM011_UnmappedRequiredPropertyCodeFixProvider(),
+            diagnostics,
+            ignoreKey);
+
+        string fixedText = (await fixedDocument.GetTextAsync()).ToString();
+
+        // The fixer's own output must configure a mapper AutoMapper accepts.
+        CodeFixRuntimeVerifier.AssertConfiguresValidMapper(
+            fixedText,
+            $"AM011 fixer output for equivalence key '{ignoreKey}'");
+    }
+
+    private static async Task<List<CodeAction>> GetTopLevelActionsAsync(
+        Document document,
+        ImmutableArray<Diagnostic> diagnostics)
+    {
+        var topLevel = new List<CodeAction>();
+        var context = new CodeFixContext(
+            document,
+            diagnostics[0].Location.SourceSpan,
+            diagnostics,
+            (action, _) => topLevel.Add(action),
+            CancellationToken.None);
+
+        await new AM011_UnmappedRequiredPropertyCodeFixProvider().RegisterCodeFixesAsync(context);
+        return topLevel;
+    }
+}

--- a/tests/AutoMapperAnalyzer.Tests/Infrastructure/CodeFixRuntimeVerifier.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Infrastructure/CodeFixRuntimeVerifier.cs
@@ -1,0 +1,163 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using AutoMapper;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Emit;
+
+namespace AutoMapperAnalyzer.Tests.Infrastructure;
+
+/// <summary>
+///     Executes code-fix output instead of comparing it to expected text.
+///     <para>
+///     Every fixer in this repository is verified by string equality against a hand-written expected
+///     document. That proves the fix matches what the test author wrote down; it does not prove the
+///     result is a mapping AutoMapper accepts. The 2.30.83 <c>Stack&lt;T&gt;</c> ordering defect is the
+///     failure class this closes: syntactically valid, compile-clean, and wrong at runtime.
+///     </para>
+///     <para>
+///     Source is compiled against the real AutoMapper assembly, loaded, and every discovered
+///     <see cref="Profile" /> is registered and validated with <c>AssertConfigurationIsValid()</c>.
+///     </para>
+/// </summary>
+internal static class CodeFixRuntimeVerifier
+{
+    /// <summary>
+    ///     Compiles the source, registers every Profile it declares, and asserts AutoMapper accepts the
+    ///     resulting configuration. Fails with the compiler or AutoMapper diagnostics when it does not.
+    /// </summary>
+    public static void AssertConfiguresValidMapper(string source, string? because = null)
+    {
+        Assembly assembly = CompileAndLoad(source, because);
+        MapperConfiguration configuration = BuildConfiguration(assembly);
+
+        try
+        {
+            configuration.AssertConfigurationIsValid();
+        }
+        catch (Exception exception)
+        {
+            throw new InvalidOperationException(
+                Describe("AutoMapper rejected the configuration produced by the code fix", because)
+                    + Environment.NewLine
+                    + exception.Message,
+                exception
+            );
+        }
+    }
+
+    /// <summary>
+    ///     Compiles and validates the source, then maps <paramref name="sourceValue" /> to
+    ///     <typeparamref name="TResult" /> so callers can assert on the mapped values themselves.
+    ///     Ordering and conversion defects only surface when the mapping actually runs.
+    /// </summary>
+    public static object MapThroughFixedCode(
+        string source,
+        string sourceTypeName,
+        string destinationTypeName,
+        Func<Type, object> sourceValue,
+        string? because = null
+    )
+    {
+        Assembly assembly = CompileAndLoad(source, because);
+        MapperConfiguration configuration = BuildConfiguration(assembly);
+        configuration.AssertConfigurationIsValid();
+
+        Type sourceType = ResolveType(assembly, sourceTypeName);
+        Type destinationType = ResolveType(assembly, destinationTypeName);
+
+        return configuration
+            .CreateMapper()
+            .Map(sourceValue(sourceType), sourceType, destinationType);
+    }
+
+    private static MapperConfiguration BuildConfiguration(Assembly assembly)
+    {
+        List<Profile> profiles = assembly
+            .GetTypes()
+            .Where(type => !type.IsAbstract && typeof(Profile).IsAssignableFrom(type))
+            .Select(type => (Profile)Activator.CreateInstance(type)!)
+            .ToList();
+
+        Assert.True(profiles.Count > 0, "Fixed code declared no AutoMapper Profile to validate.");
+
+        return new MapperConfiguration(configuration =>
+        {
+            foreach (Profile profile in profiles)
+            {
+                configuration.AddProfile(profile);
+            }
+        });
+    }
+
+    private static Type ResolveType(Assembly assembly, string typeName)
+    {
+        Type? type = assembly
+            .GetTypes()
+            .FirstOrDefault(candidate =>
+                string.Equals(candidate.Name, typeName, StringComparison.Ordinal)
+                || string.Equals(candidate.FullName, typeName, StringComparison.Ordinal)
+            );
+
+        Assert.True(type != null, $"Fixed code does not declare a type named '{typeName}'.");
+        return type!;
+    }
+
+    private static Assembly CompileAndLoad(string source, string? because)
+    {
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            "AutoMapperAnalyzer.RuntimeFixVerification." + Guid.NewGuid().ToString("N"),
+            [CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview))],
+            BuildReferences(),
+            new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable
+            )
+        );
+
+        using var peStream = new MemoryStream();
+        EmitResult emitResult = compilation.Emit(peStream);
+
+        if (!emitResult.Success)
+        {
+            ImmutableArray<Diagnostic> errors = emitResult
+                .Diagnostics.Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+                .ToImmutableArray();
+
+            throw new InvalidOperationException(
+                Describe("Code-fix output did not compile", because)
+                    + Environment.NewLine
+                    + string.Join(
+                        Environment.NewLine,
+                        errors.Select(diagnostic => diagnostic.ToString())
+                    )
+            );
+        }
+
+        peStream.Position = 0;
+        return Assembly.Load(peStream.ToArray());
+    }
+
+    private static List<MetadataReference> BuildReferences()
+    {
+        var references = new List<MetadataReference>();
+        string trustedPlatformAssemblies =
+            (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") ?? string.Empty;
+
+        foreach (string assemblyPath in trustedPlatformAssemblies.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(assemblyPath))
+            {
+                references.Add(MetadataReference.CreateFromFile(assemblyPath));
+            }
+        }
+
+        references.Add(MetadataReference.CreateFromFile(typeof(Profile).Assembly.Location));
+        return references;
+    }
+
+    private static string Describe(string headline, string? because)
+    {
+        return because == null ? headline + "." : headline + " (" + because + ").";
+    }
+}


### PR DESCRIPTION
## The gap

Every fixer in this repository is verified by **string equality** against a hand-written expected document. That proves a fix matches what the test author wrote down — not that the result is a mapping AutoMapper accepts.

The 2.30.83 `Stack<T>` ordering defect is precisely this blind spot: syntactically valid, compile-clean, matching its expected text, and **wrong at runtime**. Today's `IncludeMembers` work made the same point repeatedly — independent review found ~10 real defects by *executing* AutoMapper 14, while a 1795-test suite that compares strings found none of them.

## What this adds

`Infrastructure/CodeFixRuntimeVerifier`:

- `AssertConfiguresValidMapper(source)` — compiles fix output against the real AutoMapper assembly, loads it, registers every declared `Profile`, and calls `AssertConfigurationIsValid()`.
- `MapThroughFixedCode(...)` — additionally **executes a mapping**, so ordering and conversion behaviour can be asserted on real values rather than inferred from syntax.

Reuses the `CSharpCompilation.Emit` + trusted-platform-assemblies pattern already proven in `AggregateFixTestHarness`.

## The harness is proven, not assumed

A verification harness that only ever passes is worthless. Its self-tests fail for three distinct reasons:

| Test | Proves it detects |
| --- | --- |
| `ShouldSurfaceCodeFixOutputThatDoesNotCompile` | output that doesn't compile |
| `ShouldRejectConfigurationAutoMapperDoesNotAccept` | compile-clean output AutoMapper rejects **semantically** |
| `ShouldObserveStackConversionOrder` | reversed `Stack<T>` LIFO order — the 2.30.83 defect class |

Plus `RealFixerOutput_ShouldProduceAMapperAutoMapperAccepts`, which runs the **real AM011 fixer** end to end and executes what it produces.

## Scope

- **No version bump.** Test infrastructure only — no analyzer, fixer, or package behaviour changes. Releasing an identical package would be noise.
- **Rollout is partial.** The harness exists and is proven; the 16 shipped fixers are not yet all routed through it. Recorded as partial in `docs/TEST_LIMITATIONS.md` rather than implied complete.

## Validation

- 1801 tests green on `net10.0` (+6); `dotnet build -warnaserror` clean.
- Verifier `--check-catalog --check-snapshots --check-compatibility` up to date.
- Independent Codex cross-review: **no actionable defects**.