### PR TITLE
refactor: remove dead ForMember helpers and add analyzer crash-safety suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+### Added
+
+- **Analyzer crash-safety suite** (`tests/.../Robustness/AnalyzerCrashSafetyTests.cs`). Drives every
+  catalogued analyzer over 20 hostile inputs — incomplete generics, dangling fluent chains, selectors
+  that select nothing, unresolved types and converters, open-generic `typeof` — plus a multi-shape
+  cyclic type graph and trivial/empty compilations, failing if any analyzer throws.
+
+  Per-rule tests feed analyzers well-formed code; an analyzer in an IDE mostly reads incomplete syntax
+  and error types, where an exception becomes `AD0001` and discredits all 23 rules at once. Exceptions
+  are captured via `onAnalyzerException` so the result does not depend on the compilation's diagnostic
+  options. No crashes were found on the current tree; the suite was verified against an injected
+  exception rather than trusted because it was green.
+
+  No try/catch wrapper was added to the analyzers: Roslyn already contains analyzer exceptions, and
+  swallowing them would hide real defects from this suite. Test infrastructure only.
+
 ## [2.30.91] - 2026-07-28
 
 AM041 respects independent `MapperConfiguration` containers (no rule ID or severity changes).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -237,9 +237,12 @@ private static void AnalyzePropertyMappings(
 
         if (destProp == null) continue;
 
-        // Check if ForMember/ForPath is configured, honouring the ReverseMap boundary
-        if (MappingChainAnalysisHelper.IsSourcePropertyHandledByCustomMapping(
-            invocation, sourceProp.Name, context.SemanticModel, stopAtReverseMapBoundary: true))
+        // Skip only when this DESTINATION member is explicitly configured. Checking the source
+        // member instead is a common mistake: ForMember(d => d.DisplayName, o => o.MapFrom(s => s.Name))
+        // configures DisplayName, and must not suppress analysis of a conventionally mapped
+        // destination Name. This helper covers ForMember, ForPath, and ForCtorParam.
+        if (AM020MappingConfigurationHelpers.IsDestinationPropertyExplicitlyConfigured(
+            invocation, destProp.Name, context.SemanticModel))
             continue;
 
         // Analyze compatibility...

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -237,9 +237,9 @@ private static void AnalyzePropertyMappings(
 
         if (destProp == null) continue;
 
-        // Check if ForMember is configured
-        if (AutoMapperAnalysisHelpers.IsPropertyConfiguredWithForMember(
-            invocation, sourceProp.Name, context.SemanticModel))
+        // Check if ForMember/ForPath is configured, honouring the ReverseMap boundary
+        if (MappingChainAnalysisHelper.IsSourcePropertyHandledByCustomMapping(
+            invocation, sourceProp.Name, context.SemanticModel, stopAtReverseMapBoundary: true))
             continue;
 
         // Analyze compatibility...
@@ -475,12 +475,6 @@ public static class AutoMapperAnalysisHelpers
         ITypeSymbol type,
         bool requireGetter = true,
         bool requireSetter = true);
-
-    // Check if property is configured with ForMember
-    public static bool IsPropertyConfiguredWithForMember(
-        InvocationExpressionSyntax invocation,
-        string propertyName,
-        SemanticModel semanticModel);
 
     // Type compatibility checking
     public static bool AreTypesCompatible(

--- a/docs/TEST_LIMITATIONS.md
+++ b/docs/TEST_LIMITATIONS.md
@@ -12,6 +12,26 @@ Known harness caveats remain documented in the test project warning baseline:
 - trust validation tests intentionally read repository files;
 - AutoMapper 14 remains pinned for compatibility coverage while AutoMapper 15 introduces licensing/API changes.
 
+## Analyzer crash safety
+
+`Robustness/AnalyzerCrashSafetyTests` drives every catalogued analyzer over code that does not compile,
+is half-typed, or is hostile in shape — incomplete generic argument lists, dangling fluent chains,
+selectors that select nothing, unresolved converters, open-generic `typeof`, and a type graph that is
+cyclic through several shapes at once — and fails if any analyzer throws.
+
+Per-rule tests feed analyzers well-formed code because they are testing diagnostics. An analyzer runs on
+every keystroke, so it spends much of its life reading incomplete syntax and error types. An exception
+there surfaces as `AD0001` in the user's Error List, and one AD0001 discredits all 23 rules at once
+because the user cannot tell which analyzer misbehaved.
+
+Exceptions are captured through `onAnalyzerException` rather than read from `AD0001`, so the result does
+not depend on the compilation's diagnostic options. **There is deliberately no try/catch wrapper in the
+analyzers**: Roslyn already contains analyzer exceptions, and swallowing them locally would hide real
+defects from this suite while making the IDE quieter. These tests exist to find crashes, not mask them.
+
+No crashes were found on the current tree. The suite was verified against an injected exception to
+confirm it fails, with the offending analyzer named, rather than passing vacuously.
+
 ## Third-party corpus scanning
 
 Every other verification path here reads code this project authored: the samples project, the test

--- a/src/AutoMapperAnalyzer.Analyzers/Helpers/AutoMapperAnalysisHelpers.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Helpers/AutoMapperAnalysisHelpers.cs
@@ -369,69 +369,6 @@ public static class AutoMapperAnalysisHelpers
     }
 
     /// <summary>
-    ///     Gets all ForMember calls from a CreateMap invocation chain.
-    /// </summary>
-    /// <param name="createMapInvocation">The CreateMap invocation.</param>
-    /// <returns>A collection of ForMember invocations.</returns>
-    public static IEnumerable<InvocationExpressionSyntax> GetForMemberCalls(
-        InvocationExpressionSyntax createMapInvocation)
-    {
-        if (createMapInvocation == null)
-        {
-            return Enumerable.Empty<InvocationExpressionSyntax>();
-        }
-
-        var forMemberCalls = new List<InvocationExpressionSyntax>();
-        SyntaxNode? currentNode = createMapInvocation.Parent;
-
-        while (currentNode is MemberAccessExpressionSyntax memberAccess &&
-               memberAccess.Parent is InvocationExpressionSyntax invocation)
-        {
-            if (memberAccess.Name.Identifier.Text == "ForMember")
-            {
-                forMemberCalls.Add(invocation);
-            }
-
-            currentNode = invocation.Parent;
-        }
-
-        return forMemberCalls;
-    }
-
-    /// <summary>
-    ///     Checks if a property is configured with ForMember in the mapping configuration.
-    /// </summary>
-    /// <param name="createMapInvocation">The CreateMap invocation.</param>
-    /// <param name="propertyName">The property name to check.</param>
-    /// <param name="semanticModel">The semantic model.</param>
-    /// <returns>True if the property has a ForMember configuration; otherwise, false.</returns>
-    public static bool IsPropertyConfiguredWithForMember(
-        InvocationExpressionSyntax createMapInvocation,
-        string propertyName,
-        SemanticModel semanticModel)
-    {
-        IEnumerable<InvocationExpressionSyntax> forMemberCalls = GetForMemberCalls(createMapInvocation);
-
-        foreach (InvocationExpressionSyntax? forMember in forMemberCalls)
-        {
-            if (forMember.ArgumentList?.Arguments.Count > 0)
-            {
-                ExpressionSyntax firstArg = forMember.ArgumentList.Arguments[0].Expression;
-
-                // Check if it's a lambda expression selecting this property
-                if (firstArg is SimpleLambdaExpressionSyntax lambda &&
-                    lambda.Body is MemberAccessExpressionSyntax memberAccess &&
-                    memberAccess.Name.Identifier.Text == propertyName)
-                {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
-    /// <summary>
     ///     Gets the underlying type, removing nullable wrappers.
     /// </summary>
     public static ITypeSymbol GetUnderlyingType(ITypeSymbol type)

--- a/tests/AutoMapperAnalyzer.Tests/Helpers/AutoMapperAnalysisHelpersTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Helpers/AutoMapperAnalysisHelpersTests.cs
@@ -11,57 +11,6 @@ namespace AutoMapperAnalyzer.Tests.Helpers;
 /// </summary>
 public class AutoMapperAnalysisHelpersTests
 {
-    #region GetForMemberCalls Tests
-
-    [Fact]
-    public void GetForMemberCalls_ShouldReturnEmpty_WhenInvocationIsNull()
-    {
-        IEnumerable<InvocationExpressionSyntax> result = AutoMapperAnalysisHelpers.GetForMemberCalls(null!);
-
-        Assert.Empty(result);
-    }
-
-    // NOTE: GetForMemberCalls requires complex syntax tree navigation that is difficult to unit test
-    // in isolation. This method is tested indirectly through the analyzer integration tests.
-
-    #endregion
-
-    #region IsPropertyConfiguredWithForMember Tests
-
-    [Fact]
-    public void IsPropertyConfiguredWithForMember_ShouldReturnFalse_WhenPropertyIsNotConfigured()
-    {
-        const string code = @"
-            using AutoMapper;
-            public class Source { public string Name { get; set; } }
-            public class Destination { public string Name { get; set; } }
-            public class TestProfile : Profile
-            {
-                public TestProfile()
-                {
-                    CreateMap<Source, Destination>();
-                }
-            }";
-
-        CSharpCompilation compilation = CreateCompilation(code);
-        SyntaxTree tree = compilation.SyntaxTrees.First();
-        SemanticModel semanticModel = compilation.GetSemanticModel(tree);
-        InvocationExpressionSyntax createMapInvocation = tree.GetRoot()
-            .DescendantNodes()
-            .OfType<InvocationExpressionSyntax>()
-            .First(inv => inv.Expression.ToString().Contains("CreateMap"));
-
-        bool result = AutoMapperAnalysisHelpers.IsPropertyConfiguredWithForMember(
-            createMapInvocation, "Name", semanticModel);
-
-        Assert.False(result);
-    }
-
-    // NOTE: Testing the positive case for IsPropertyConfiguredWithForMember requires complex syntax
-    // tree structures that are tested indirectly through the analyzer integration tests.
-
-    #endregion
-
     #region Helper Methods
 
     private static CSharpCompilation CreateCompilation(string code)

--- a/tests/AutoMapperAnalyzer.Tests/Robustness/AnalyzerCrashSafetyTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Robustness/AnalyzerCrashSafetyTests.cs
@@ -1,0 +1,254 @@
+using System.Collections.Immutable;
+using AutoMapper;
+using AutoMapperAnalyzer.Analyzers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace AutoMapperAnalyzer.Tests.Robustness;
+
+/// <summary>
+///     Drives every shipped analyzer over code that does not compile, is half-typed, or is otherwise
+///     hostile, and fails if any analyzer throws.
+///     <para>
+///     Per-rule tests feed analyzers well-formed code because they are testing diagnostics. But an
+///     analyzer runs on every keystroke, so it spends much of its life reading incomplete syntax and
+///     error types. An exception there surfaces as <c>AD0001</c> in the user's Error List, and one
+///     AD0001 discredits all 23 rules at once — the user cannot tell which analyzer misbehaved.
+///     </para>
+///     <para>
+///     There is deliberately no try/catch wrapper in the analyzers. Roslyn already contains analyzer
+///     exceptions; swallowing them locally would hide real defects from this suite while making the IDE
+///     quieter. These tests exist to find crashes, not to mask them.
+///     </para>
+/// </summary>
+public class AnalyzerCrashSafetyTests
+{
+    /// <summary>
+    ///     Shapes chosen to hit the paths the analyzers actually walk: type-argument resolution, fluent
+    ///     chain traversal, member selectors, recursion guards, and nullable/generic unwrapping — each
+    ///     under syntax or symbols that do not resolve.
+    /// </summary>
+    public static TheoryData<string, string> HostileSources()
+    {
+        return new TheoryData<string, string>
+        {
+            { "incomplete generic argument list", "CreateMap<Source, >();" },
+            { "unterminated invocation", "CreateMap<Source, Destination>(" },
+            { "missing type arguments", "CreateMap<>();" },
+            { "no type arguments at all", "CreateMap();" },
+            { "undefined types", "CreateMap<Missing, AlsoMissing>();" },
+            { "half-typed member selector", "CreateMap<Source, Destination>().ForMember(d => d." },
+            {
+                "member selector on nothing",
+                "CreateMap<Source, Destination>().ForMember(d => , o => o.Ignore());"
+            },
+            {
+                "unresolved options call",
+                "CreateMap<Source, Destination>().ForMember(d => d.Name, o => o.NotAThing());"
+            },
+            { "dangling fluent chain", "CreateMap<Source, Destination>()." },
+            { "ReverseMap on nothing", "CreateMap<Source, Destination>().ReverseMap()." },
+            {
+                "ForCtorParam without arguments",
+                "CreateMap<Source, Destination>().ForCtorParam();"
+            },
+            {
+                "ForPath with empty path",
+                "CreateMap<Source, Destination>().ForPath(d => , o => o.Ignore());"
+            },
+            {
+                "IncludeMembers with no selector",
+                "CreateMap<Source, Destination>().IncludeMembers();"
+            },
+            {
+                "IncludeMembers with unresolved selector",
+                "CreateMap<Source, Destination>().IncludeMembers(s => s.Nope);"
+            },
+            {
+                "ConvertUsing unresolved converter",
+                "CreateMap<Source, Destination>().ConvertUsing<NoSuchConverter>();"
+            },
+            { "typeof with missing type", "CreateMap(typeof(Missing), typeof(Destination));" },
+            {
+                "open generic typeof",
+                "CreateMap(typeof(System.Collections.Generic.List<>), typeof(Destination));"
+            },
+            { "self-referential map", "CreateMap<Source, Source>();" },
+            {
+                "nested unresolved generics",
+                "CreateMap<System.Collections.Generic.List<Missing>, Destination>();"
+            },
+            {
+                "duplicated dangling chain",
+                "CreateMap<Source, Destination>().ForMember().ForMember().ReverseMap();"
+            },
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(HostileSources))]
+    public async Task EveryAnalyzer_ShouldNotThrow_OnHostileInput(
+        string description,
+        string mappingStatement
+    )
+    {
+        string source = $$"""
+            using AutoMapper;
+
+            namespace TestNamespace
+            {
+                public class Inner { public string Name { get; set; } }
+                public class Source { public string Name { get; set; } public Inner Inner { get; set; } }
+                public class Destination { public string Name { get; set; } public required string Req { get; set; } }
+
+                public class TestProfile : Profile
+                {
+                    public TestProfile()
+                    {
+                        {{mappingStatement}}
+                    }
+                }
+            }
+            """;
+
+        IReadOnlyList<string> failures = await RunEveryAnalyzerAsync(source);
+
+        Assert.True(
+            failures.Count == 0,
+            $"Analyzers threw on hostile input ({description}):{Environment.NewLine}"
+                + string.Join(Environment.NewLine, failures)
+        );
+    }
+
+    /// <summary>
+    ///     A type graph that is cyclic through several shapes at once. Recursion guards are per-analyzer
+    ///     and easy to get subtly wrong; a stack overflow cannot be caught, so this fails the run rather
+    ///     than reporting an exception.
+    /// </summary>
+    [Fact]
+    public async Task EveryAnalyzer_ShouldNotThrow_OnCyclicTypeGraph()
+    {
+        const string source = """
+            using System.Collections.Generic;
+            using AutoMapper;
+
+            namespace TestNamespace
+            {
+                public class A { public B B { get; set; } public List<A> Selves { get; set; } }
+                public class B { public C C { get; set; } public A BackToA { get; set; } }
+                public class C { public A A { get; set; } public Dictionary<string, B> Map { get; set; } }
+
+                public class ADto { public BDto B { get; set; } public List<ADto> Selves { get; set; } }
+                public class BDto { public CDto C { get; set; } public ADto BackToA { get; set; } }
+                public class CDto { public ADto A { get; set; } public Dictionary<string, BDto> Map { get; set; } }
+
+                public class TestProfile : Profile
+                {
+                    public TestProfile()
+                    {
+                        CreateMap<A, ADto>().ReverseMap();
+                        CreateMap<B, BDto>().ReverseMap();
+                        CreateMap<C, CDto>().ReverseMap();
+                    }
+                }
+            }
+            """;
+
+        IReadOnlyList<string> failures = await RunEveryAnalyzerAsync(source);
+
+        Assert.True(
+            failures.Count == 0,
+            "Analyzers threw on a cyclic type graph:"
+                + Environment.NewLine
+                + string.Join(Environment.NewLine, failures)
+        );
+    }
+
+    [Fact]
+    public async Task EveryAnalyzer_ShouldNotThrow_OnEmptyAndTrivialCompilations()
+    {
+        foreach (string source in new[] { string.Empty, "using AutoMapper;", "class C { }" })
+        {
+            IReadOnlyList<string> failures = await RunEveryAnalyzerAsync(source);
+            Assert.True(
+                failures.Count == 0,
+                $"Analyzers threw on a trivial compilation ('{source}'):"
+                    + Environment.NewLine
+                    + string.Join(Environment.NewLine, failures)
+            );
+        }
+    }
+
+    /// <summary>
+    ///     Runs every analyzer in the catalog and returns a failure line per thrown exception. Analyzer
+    ///     exceptions are captured directly rather than read from AD0001, so the result does not depend
+    ///     on the compilation's diagnostic options.
+    /// </summary>
+    private static async Task<IReadOnlyList<string>> RunEveryAnalyzerAsync(string source)
+    {
+        var references = new List<MetadataReference>();
+        string trustedPlatformAssemblies =
+            (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") ?? string.Empty;
+
+        foreach (string assemblyPath in trustedPlatformAssemblies.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(assemblyPath))
+            {
+                references.Add(MetadataReference.CreateFromFile(assemblyPath));
+            }
+        }
+
+        references.Add(MetadataReference.CreateFromFile(typeof(Profile).Assembly.Location));
+
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            "AutoMapperAnalyzer.CrashSafety",
+            [CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview))],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+        );
+
+        ImmutableArray<DiagnosticAnalyzer> analyzers = RuleCatalog
+            .Rules.Select(rule => rule.AnalyzerType)
+            .Distinct()
+            .Select(type => (DiagnosticAnalyzer)Activator.CreateInstance(type)!)
+            .ToImmutableArray();
+
+        var failures = new List<string>();
+        var failureLock = new object();
+
+        var options = new CompilationWithAnalyzersOptions(
+            new AnalyzerOptions([]),
+            onAnalyzerException: (exception, analyzer, _) =>
+            {
+                lock (failureLock)
+                {
+                    failures.Add(
+                        $"{analyzer.GetType().Name}: {exception.GetType().Name}: {exception.Message}"
+                    );
+                }
+            },
+            concurrentAnalysis: true,
+            logAnalyzerExecutionTime: false
+        );
+
+        ImmutableArray<Diagnostic> diagnostics = await compilation
+            .WithAnalyzers(analyzers, options)
+            .GetAnalyzerDiagnosticsAsync();
+
+        // Belt and braces: an AD0001 that arrives without the callback firing is still a crash.
+        foreach (
+            Diagnostic diagnostic in diagnostics.Where(diagnostic =>
+                string.Equals(diagnostic.Id, "AD0001", StringComparison.Ordinal)
+            )
+        )
+        {
+            lock (failureLock)
+            {
+                failures.Add("AD0001: " + diagnostic.GetMessage());
+            }
+        }
+
+        return failures;
+    }
+}


### PR DESCRIPTION
Two Tier-2 items from the roadmap, both test/quality work with no analyzer behaviour change.

## 1. Remove the dead ForMember configuration helpers

`AutoMapperAnalysisHelpers.IsPropertyConfiguredWithForMember` had **no production callers**. The one call that appeared to use it (AM006) passes four arguments and binds to a private four-argument shadow in that same file, which additionally handles `ForPath` and the `ReverseMap` boundary. `GetForMemberCalls` existed only to serve the dead method.

The dead code is the small part. **`docs/ARCHITECTURE.md` presented the dead three-argument signature as the canonical way to check member configuration** — in both its worked example and its helper-API listing. Anyone following that guidance would have written a check that ignores `ForPath` and silently crosses `ReverseMap` boundaries, which is precisely the bug class this repo has spent thirty releases eliminating. The example now points at `MappingChainAnalysisHelper.IsSourcePropertyHandledByCustomMapping`, which is what the analyzers actually use.

123 lines removed, 3 added. No behaviour change — the removed code was unreachable from every analyzer and fixer.

## 2. Analyzer crash-safety suite

Per-rule tests feed analyzers well-formed code, because they are testing diagnostics. An analyzer in an IDE runs on every keystroke and spends much of its life reading half-typed syntax and error types. An exception there becomes `AD0001`, and **one AD0001 discredits all 23 rules at once** — the user cannot tell which analyzer misbehaved, only that the pack is unreliable.

`Robustness/AnalyzerCrashSafetyTests` drives every catalogued analyzer over 20 hostile shapes, chosen to hit the paths the analyzers actually walk:

| Path exercised | Example input |
| --- | --- |
| Type-argument resolution | `CreateMap<Source, >()`, `CreateMap<>()`, open-generic `typeof` |
| Fluent chain traversal | `CreateMap<S,D>().`, `.ForMember().ForMember().ReverseMap()` |
| Member selectors | `ForMember(d => d.`, `ForPath(d => , …)` |
| Recursion guards | type graph cyclic through three shapes plus collections and dictionaries |
| Nullable/generic unwrapping | `List<Missing>` as a type argument |

Plus empty and trivial compilations.

Exceptions are captured through `onAnalyzerException` rather than read from `AD0001`, so a crash cannot be hidden by the compilation's diagnostic options.

### It was verified by failing

**No crashes were found on the current tree.** A green suite that has never been shown to fail proves nothing, so I injected an exception into an analyzer and confirmed the suite fails and names the culprit:

```
Analyzers threw on hostile input (missing type arguments):
AM006_UnmappedDestinationPropertyAnalyzer: InvalidOperationException: deliberate crash probe
```

### No try/catch wrapper — deliberate

The roadmap suggested pairing this with an exception-swallowing wrapper around the 21 registration sites. I did not add one. Roslyn already contains analyzer exceptions; swallowing them locally would hide real defects from this very suite while only making the IDE quieter. That trades diagnosability for polish, and the playbook's rule is to add behaviour only where tests reveal a real problem. If a crash is ever found, the wrapper can be reconsidered with evidence.

## Validation

- 1838 tests green on `net10.0` (+22); `dotnet build -warnaserror` clean.
- Catalog, snapshot, and compatibility checks current; `git diff --check` clean.
- No version bump: neither change affects analyzer or package behaviour.
