### PR TITLE
perf: analyzer throughput baseline, and the symbol-binding gate it made measurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Changed
+
+- **Syntactic gate before symbol binding** in `MappingChainAnalysisHelper.IsAutoMapperMethodInvocation`.
+  The analyzers register on every `InvocationExpression` in a compilation, so the helper was binding
+  symbols for calls that could not match by name. The invoked name is now compared syntactically first;
+  shapes whose name cannot be read fall through to the semantic check, so the gate can only skip work,
+  never change an answer. All 1841 tests pass unchanged.
+
+  Measured with the new throughput fixtures: ~12% lower analysis time on mostly-unrelated code
+  (mean 2.47x → 2.17x) and ~7% on mapping-dense code. **Directional, not conclusive** — the per-run
+  ranges overlap at three samples each. It ships because the mechanism is sound and the risk is zero,
+  not because the measurement proved it.
+
 ### Added
 
 - **Analyzer throughput baseline** (`tests/.../Performance/AnalyzerThroughputTests.cs`). Measures the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- **Analyzer throughput baseline** (`tests/.../Performance/AnalyzerThroughputTests.cs`). Measures the
+  whole pack over a solution-sized fixture (60 mapped type pairs) and a cyclic diamond type graph,
+  budgeted as a multiple of compiling the same input rather than as wall-clock time, so the measurement
+  moves with the runner. Nothing previously measured analyzer cost, on code that runs on every keystroke
+  in consuming solutions. Recorded baseline: 2.8x–5.9x solution-sized, ~1.5x–1.9x diamond; budget 20x.
+  Test infrastructure only.
 - **Analyzer crash-safety suite** (`tests/.../Robustness/AnalyzerCrashSafetyTests.cs`). Drives every
   catalogued analyzer over 20 hostile inputs — incomplete generics, dangling fluent chains, selectors
   that select nothing, unresolved types and converters, open-generic `typeof` — plus a multi-shape

--- a/docs/TEST_LIMITATIONS.md
+++ b/docs/TEST_LIMITATIONS.md
@@ -12,6 +12,32 @@ Known harness caveats remain documented in the test project warning baseline:
 - trust validation tests intentionally read repository files;
 - AutoMapper 14 remains pinned for compatibility coverage while AutoMapper 15 introduces licensing/API changes.
 
+## Analyzer throughput
+
+`Performance/AnalyzerThroughputTests` measures the whole pack over a synthetic solution-sized fixture
+(60 mapped type pairs, mixed nullable/collection/nested/enum/required shapes) and over a cyclic diamond
+type graph that exercises AM022's traversal.
+
+Nothing else here measures analyzer cost — every other test asserts diagnostics — so a change making the
+pack several times slower would ship silently, on code that runs on every keystroke in every consuming
+solution.
+
+**The budget is a ratio, not a wall clock.** Analysis is timed against compiling the same input on the
+same machine, so the measurement moves with the runner instead of against it. An absolute threshold
+measures the CI agent more than the analyzers and is the usual reason timing tests get deleted.
+
+Two methodology points, both learned by getting them wrong first:
+
+- Roslyn memoises `GetDiagnostics()`, so timing a warmed compile against a fresh analyzer run measures
+  caching. Each side gets its own cold `Compilation`, after a discarded warm-up pass for JIT.
+- A fixture that produces no diagnostics makes the timing meaningless. The tests assert AM diagnostics
+  were produced; that guard caught the diamond fixture being a DAG rather than cyclic, which meant AM022
+  — the analyzer it exists to stress — never ran.
+
+Recorded baseline on this tree: solution-sized 2.8x–5.9x, cyclic diamond ~1.5x–1.9x across repeated runs
+on one machine. The budget is **20x**, roughly 3x above the noisy high, to catch an order-of-magnitude
+regression without firing on runner noise. Tighten only with evidence from a quiet machine.
+
 ## Analyzer crash safety
 
 `Robustness/AnalyzerCrashSafetyTests` drives every catalogued analyzer over code that does not compile,

--- a/docs/TEST_LIMITATIONS.md
+++ b/docs/TEST_LIMITATIONS.md
@@ -34,8 +34,13 @@ Two methodology points, both learned by getting them wrong first:
   were produced; that guard caught the diamond fixture being a DAG rather than cyclic, which meant AM022
   — the analyzer it exists to stress — never ran.
 
-Recorded baseline on this tree: solution-sized 2.8x–5.9x, cyclic diamond ~1.5x–1.9x across repeated runs
-on one machine. The budget is **20x**, roughly 3x above the noisy high, to catch an order-of-magnitude
+Three fixtures are measured. The mapping-dense one (60 type pairs) and the cyclic diamond stress
+specific analyzers; the **mostly-unrelated** fixture (~2400 ordinary method calls around 60 mapped
+pairs) is the realistic consumer shape, because every analyzer registers on `InvocationExpression` and
+therefore visits every call in a solution, the vast majority of which have nothing to do with mapping.
+
+Recorded baseline on this tree: solution-sized 2.8x–5.9x, cyclic diamond ~1.5x–1.9x, mostly-unrelated
+~2.0x–2.3x across repeated runs on one machine. The budget is **20x**, roughly 3x above the noisy high, to catch an order-of-magnitude
 regression without firing on runner noise. Tighten only with evidence from a quiet machine.
 
 ## Analyzer crash safety

--- a/src/AutoMapperAnalyzer.Analyzers/Helpers/MappingChainAnalysisHelper.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Helpers/MappingChainAnalysisHelper.cs
@@ -42,6 +42,15 @@ public static class MappingChainAnalysisHelper
         SemanticModel semanticModel,
         string methodName)
     {
+        // RegisterSyntaxNodeAction fires on every invocation in the compilation, not just mapping
+        // configuration, so this binds symbols for calls that cannot possibly match. Compare the
+        // invoked name syntactically first: unrecognised shapes fall through to the semantic check, so
+        // the gate can only skip work, never change an answer.
+        if (!InvokedNameCouldMatch(invocation, methodName))
+        {
+            return false;
+        }
+
         SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(invocation);
 
         if (IsAutoMapperMethod(symbolInfo.Symbol as IMethodSymbol, methodName))
@@ -58,6 +67,25 @@ public static class MappingChainAnalysisHelper
         }
 
         return false;
+    }
+
+    /// <summary>
+    ///     Cheap syntactic gate for an invocation's simple name. Returns true for shapes whose name
+    ///     cannot be read, so an unfamiliar construct is still resolved semantically rather than
+    ///     silently skipped.
+    /// </summary>
+    private static bool InvokedNameCouldMatch(InvocationExpressionSyntax invocation, string methodName)
+    {
+        SimpleNameSyntax? invokedName = invocation.Expression switch
+        {
+            MemberAccessExpressionSyntax memberAccess => memberAccess.Name,
+            MemberBindingExpressionSyntax memberBinding => memberBinding.Name,
+            SimpleNameSyntax simpleName => simpleName,
+            _ => null
+        };
+
+        return invokedName == null ||
+               string.Equals(invokedName.Identifier.ValueText, methodName, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/tests/AutoMapperAnalyzer.Tests/Performance/AnalyzerThroughputTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Performance/AnalyzerThroughputTests.cs
@@ -1,0 +1,283 @@
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Text;
+using AutoMapper;
+using AutoMapperAnalyzer.Analyzers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit.Abstractions;
+
+namespace AutoMapperAnalyzer.Tests.Performance;
+
+/// <summary>
+///     Measures how long the whole analyzer pack takes over a synthetic solution-sized input.
+///     <para>
+///     Twenty-three analyzers run on every keystroke in every consuming solution, and analyzer cost is a
+///     common reason teams uninstall a package. Nothing in this repository measured that, so a change
+///     that made the pack several times slower would ship silently — every existing test asserts
+///     diagnostics, never time.
+///     </para>
+///     <para>
+///     The budget is expressed as a multiple of the compiler's own work on the same input, not as a wall
+///     clock figure. An absolute threshold measures the CI runner more than the analyzers and is the
+///     usual reason timing tests get deleted; a ratio is stable across machines because both sides move
+///     together. The bound is deliberately loose — it exists to catch an order-of-magnitude regression,
+///     not to police small movements.
+///     </para>
+/// </summary>
+public class AnalyzerThroughputTests(ITestOutputHelper output)
+{
+    private const int TypePairCount = 60;
+
+    /// <summary>
+    ///     Budget set from measurement, not taste. On this tree the solution-sized fixture measured
+    ///     2.8x-5.9x across repeated runs on one machine and the cyclic diamond measured ~1.5x; the
+    ///     spread is run-to-run noise, not workload difference.
+    ///     <para>
+    ///     20x therefore sits roughly 3x above the noisy high. That is deliberately generous: a timing
+    ///     test that fires on runner noise gets deleted, and this exists to catch an order-of-magnitude
+    ///     regression - a pack suddenly several times more expensive - not small movements. Tighten it
+    ///     only with recorded evidence from a quiet machine.
+    ///     </para>
+    /// </summary>
+    private const double MaxAnalyzerToCompilerRatio = 20.0;
+
+    [Fact]
+    public async Task AnalyzerPack_ShouldStayWithinItsBudget_OnASolutionSizedInput()
+    {
+        Measurement measurement = await MeasureAsync(BuildSyntheticSolution());
+        Report("solution-sized", $"{TypePairCount} type pairs", measurement);
+
+        Assert.True(
+            measurement.Ratio <= MaxAnalyzerToCompilerRatio,
+            $"Analyzing took {measurement.AnalyzerMs:F0} ms against {measurement.CompilerMs:F0} ms to "
+                + $"compile the same input ({measurement.Ratio:F2}x, budget {MaxAnalyzerToCompilerRatio:F1}x) "
+                + $"over {TypePairCount} mapped type pairs. Investigate before shipping: this runs on "
+                + "every keystroke in consuming solutions."
+        );
+    }
+
+    /// <summary>
+    ///     AM022 walks the mapped type graph, so a diamond graph is its worst case: many distinct paths
+    ///     between the same endpoints. Depth is capped in the analyzer, but a regression in a visited
+    ///     set or memo key shows up here long before it shows up as a user complaint.
+    /// </summary>
+    [Fact]
+    public async Task RecursionAnalysis_ShouldStayWithinItsBudget_OnADiamondTypeGraph()
+    {
+        Measurement measurement = await MeasureAsync(BuildDiamondGraph(levels: 8));
+        Report("diamond graph", "8 levels", measurement);
+
+        Assert.True(
+            measurement.Ratio <= MaxAnalyzerToCompilerRatio,
+            $"Analyzing took {measurement.AnalyzerMs:F0} ms against {measurement.CompilerMs:F0} ms to "
+                + $"compile the same input ({measurement.Ratio:F2}x, budget {MaxAnalyzerToCompilerRatio:F1}x) "
+                + "on a diamond type graph. A recursion guard or memo-key regression is the usual cause."
+        );
+    }
+
+    private readonly record struct Measurement(double CompilerMs, double AnalyzerMs, int AmDiagnostics)
+    {
+        internal double Ratio => AnalyzerMs / Math.Max(CompilerMs, 0.5);
+    }
+
+    /// <summary>
+    ///     Times compilation and analysis on separate, freshly built compilations.
+    ///     <para>
+    ///     Roslyn memoises: calling GetDiagnostics twice on one Compilation returns cached results, so
+    ///     comparing a warmed compile against a fresh analyzer run measures caching rather than analyzer
+    ///     cost. Each side therefore gets its own cold Compilation, after a discarded warm-up pass that
+    ///     absorbs JIT. Analysis necessarily includes the compiler work it depends on, so the ratio reads
+    ///     as "how many times the compile cost does the pack add", and is at least 1 by construction.
+    ///     </para>
+    /// </summary>
+    private async Task<Measurement> MeasureAsync(string source)
+    {
+        ImmutableArray<DiagnosticAnalyzer> analyzers = RuleCatalog
+            .Rules.Select(rule => rule.AnalyzerType)
+            .Distinct()
+            .Select(type => (DiagnosticAnalyzer)Activator.CreateInstance(type)!)
+            .ToImmutableArray();
+
+        // Warm-up on throwaway compilations so JIT and first-use initialisation are not attributed to
+        // either measurement.
+        _ = CreateCompilation(source).GetDiagnostics();
+        _ = await CreateCompilation(source).WithAnalyzers(analyzers).GetAnalyzerDiagnosticsAsync();
+
+        CSharpCompilation compileOnly = CreateCompilation(source);
+        var compilerTimer = Stopwatch.StartNew();
+        _ = compileOnly.GetDiagnostics();
+        compilerTimer.Stop();
+
+        CSharpCompilation analyzed = CreateCompilation(source);
+        var analyzerTimer = Stopwatch.StartNew();
+        ImmutableArray<Diagnostic> diagnostics = await analyzed
+            .WithAnalyzers(analyzers)
+            .GetAnalyzerDiagnosticsAsync();
+        analyzerTimer.Stop();
+
+        return new Measurement(
+            compilerTimer.Elapsed.TotalMilliseconds,
+            analyzerTimer.Elapsed.TotalMilliseconds,
+            diagnostics.Count(d => d.Id.StartsWith("AM", StringComparison.Ordinal))
+        );
+    }
+
+    private void Report(string label, string shape, Measurement measurement)
+    {
+        output.WriteLine($"fixture:        {label} ({shape})");
+        output.WriteLine($"compile only:   {measurement.CompilerMs:F0} ms");
+        output.WriteLine($"compile+analyze:{measurement.AnalyzerMs:F0} ms");
+        output.WriteLine(
+            $"ratio:          {measurement.Ratio:F2}x (budget {MaxAnalyzerToCompilerRatio:F1}x)"
+        );
+        output.WriteLine($"AM diagnostics: {measurement.AmDiagnostics}");
+
+        // A run that produced nothing would make the timing meaningless.
+        Assert.True(measurement.AmDiagnostics > 0, "Fixture produced no AM diagnostics; timing is not meaningful.");
+    }
+
+    /// <summary>
+    ///     Mixed shapes so the measurement exercises the whole pack rather than one rule: nullable
+    ///     mismatches, collection containers, nested objects, enums, required members, and duplicate
+    ///     registrations all appear.
+    /// </summary>
+    private static string BuildSyntheticSolution()
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("using System;");
+        builder.AppendLine("using System.Collections.Generic;");
+        builder.AppendLine("using AutoMapper;");
+        builder.AppendLine();
+        builder.AppendLine("namespace ThroughputFixture");
+        builder.AppendLine("{");
+        builder.AppendLine("    public enum StatusA { Draft, Live }");
+        builder.AppendLine("    public enum StatusB { Draft, Published }");
+
+        for (var i = 0; i < TypePairCount; i++)
+        {
+            builder.AppendLine(
+                $$"""
+                    public class Nested{{i}} { public string Value { get; set; } = string.Empty; }
+                    public class NestedDto{{i}} { public string Value { get; set; } = string.Empty; }
+
+                    public class Source{{i}}
+                    {
+                        public int Id { get; set; }
+                        public string? Name { get; set; }
+                        public List<string> Tags { get; set; } = new();
+                        public Nested{{i}} Nested { get; set; } = new();
+                        public StatusA Status { get; set; }
+                        public string Dropped{{i}} { get; set; } = string.Empty;
+                    }
+
+                    public class Destination{{i}}
+                    {
+                        public int Id { get; set; }
+                        public string Name { get; set; } = string.Empty;
+                        public HashSet<string> Tags { get; set; } = new();
+                        public NestedDto{{i}} Nested { get; set; } = new();
+                        public StatusB Status { get; set; }
+                        public required string Missing{{i}} { get; set; }
+                    }
+                """
+            );
+        }
+
+        builder.AppendLine("    public class ThroughputProfile : Profile");
+        builder.AppendLine("    {");
+        builder.AppendLine("        public ThroughputProfile()");
+        builder.AppendLine("        {");
+        for (var i = 0; i < TypePairCount; i++)
+        {
+            builder.AppendLine($"            CreateMap<Source{i}, Destination{i}>().ReverseMap();");
+        }
+
+        builder.AppendLine("        }");
+        builder.AppendLine("    }");
+        builder.AppendLine("}");
+        return builder.ToString();
+    }
+
+    private static string BuildDiamondGraph(int levels)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("using System.Collections.Generic;");
+        builder.AppendLine("using AutoMapper;");
+        builder.AppendLine();
+        builder.AppendLine("namespace DiamondFixture");
+        builder.AppendLine("{");
+
+        for (var level = 0; level < levels; level++)
+        {
+            string next = level == levels - 1 ? "Leaf" : $"Node{level + 1}";
+            builder.AppendLine(
+                $$"""
+                    public class Node{{level}}
+                    {
+                        public {{next}} Left { get; set; } = new();
+                        public {{next}} Right { get; set; } = new();
+                        public List<{{next}}> Many { get; set; } = new();
+                    }
+
+                    public class Node{{level}}Dto
+                    {
+                        public {{next}}Dto Left { get; set; } = new();
+                        public {{next}}Dto Right { get; set; } = new();
+                        public List<{{next}}Dto> Many { get; set; } = new();
+                    }
+                """
+            );
+        }
+
+        builder.AppendLine(
+            // The leaf closes the cycle back to the root. Without this the graph is a DAG and AM022 -
+            // the analyzer this fixture exists to stress - never engages.
+            "    public class Leaf { public string Value { get; set; } = string.Empty; public Node0 Root { get; set; } = new(); }"
+        );
+        builder.AppendLine(
+            "    public class LeafDto { public string Value { get; set; } = string.Empty; public Node0Dto Root { get; set; } = new(); }"
+        );
+        builder.AppendLine("    public class DiamondProfile : Profile");
+        builder.AppendLine("    {");
+        builder.AppendLine("        public DiamondProfile()");
+        builder.AppendLine("        {");
+        for (var level = 0; level < levels; level++)
+        {
+            builder.AppendLine(
+                $"            CreateMap<Node{level}, Node{level}Dto>().ReverseMap();"
+            );
+        }
+
+        builder.AppendLine("            CreateMap<Leaf, LeafDto>().ReverseMap();");
+        builder.AppendLine("        }");
+        builder.AppendLine("    }");
+        builder.AppendLine("}");
+        return builder.ToString();
+    }
+
+    private static CSharpCompilation CreateCompilation(string source)
+    {
+        var references = new List<MetadataReference>();
+        string trustedPlatformAssemblies =
+            (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") ?? string.Empty;
+
+        foreach (string assemblyPath in trustedPlatformAssemblies.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(assemblyPath))
+            {
+                references.Add(MetadataReference.CreateFromFile(assemblyPath));
+            }
+        }
+
+        references.Add(MetadataReference.CreateFromFile(typeof(Profile).Assembly.Location));
+
+        return CSharpCompilation.Create(
+            "AutoMapperAnalyzer.Throughput",
+            [CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview))],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+        );
+    }
+}

--- a/tests/AutoMapperAnalyzer.Tests/Performance/AnalyzerThroughputTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Performance/AnalyzerThroughputTests.cs
@@ -77,6 +77,27 @@ public class AnalyzerThroughputTests(ITestOutputHelper output)
         );
     }
 
+    /// <summary>
+    ///     The realistic consumer shape: a large codebase where AutoMapper profiles are a small
+    ///     fraction of the code. Every analyzer registers on InvocationExpression, so the pack visits
+    ///     every method call in the solution — the overwhelming majority of which have nothing to do
+    ///     with mapping. A mapping-dense fixture cannot show what that costs.
+    /// </summary>
+    [Fact]
+    public async Task AnalyzerPack_ShouldStayWithinItsBudget_OnMostlyUnrelatedCode()
+    {
+        Measurement measurement = await MeasureAsync(BuildMostlyUnrelatedSolution());
+        Report("mostly unrelated", $"{TypePairCount} type pairs among ~{TypePairCount * 40} calls", measurement);
+
+        Assert.True(
+            measurement.Ratio <= MaxAnalyzerToCompilerRatio,
+            $"Analyzing took {measurement.AnalyzerMs:F0} ms against {measurement.CompilerMs:F0} ms to "
+                + $"compile the same input ({measurement.Ratio:F2}x, budget {MaxAnalyzerToCompilerRatio:F1}x) "
+                + "on code that is mostly unrelated to AutoMapper. The pack visits every invocation in a "
+                + "consuming solution, so this is the shape that matters most."
+        );
+    }
+
     private readonly record struct Measurement(double CompilerMs, double AnalyzerMs, int AmDiagnostics)
     {
         internal double Ratio => AnalyzerMs / Math.Max(CompilerMs, 0.5);
@@ -192,6 +213,62 @@ public class AnalyzerThroughputTests(ITestOutputHelper output)
         for (var i = 0; i < TypePairCount; i++)
         {
             builder.AppendLine($"            CreateMap<Source{i}, Destination{i}>().ReverseMap();");
+        }
+
+        builder.AppendLine("        }");
+        builder.AppendLine("    }");
+        builder.AppendLine("}");
+        return builder.ToString();
+    }
+
+    /// <summary>
+    ///     Mapping profiles surrounded by ordinary code: dozens of unrelated method calls per mapped
+    ///     type, which is what a real solution looks like to an analyzer registered on every invocation.
+    /// </summary>
+    private static string BuildMostlyUnrelatedSolution()
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("using System;");
+        builder.AppendLine("using System.Collections.Generic;");
+        builder.AppendLine("using System.Linq;");
+        builder.AppendLine("using AutoMapper;");
+        builder.AppendLine();
+        builder.AppendLine("namespace UnrelatedFixture");
+        builder.AppendLine("{");
+
+        for (var i = 0; i < TypePairCount; i++)
+        {
+            builder.AppendLine($$"""
+                    public class Source{{i}} { public int Id { get; set; } public string? Name { get; set; } }
+                    public class Destination{{i}} { public int Id { get; set; } public string Name { get; set; } = string.Empty; }
+
+                    public class Service{{i}}
+                    {
+                        private readonly List<string> _items = new();
+
+                        public string Work(string input)
+                        {
+                            var trimmed = input.Trim();
+                            var upper = trimmed.ToUpperInvariant();
+                            var parts = upper.Split(',').Select(p => p.Trim()).Where(p => p.Length > 0).ToList();
+                            _items.AddRange(parts);
+                            var joined = string.Join("|", _items.Distinct().OrderBy(p => p));
+                            var replaced = joined.Replace("A", "B").Replace("C", "D");
+                            var formatted = string.Format("{0}:{1}", replaced, _items.Count);
+                            var built = new System.Text.StringBuilder().Append(formatted).Append('!').ToString();
+                            return built.Substring(0, Math.Min(built.Length, 64)).PadRight(8, '.');
+                        }
+                    }
+                """);
+        }
+
+        builder.AppendLine("    public class UnrelatedProfile : Profile");
+        builder.AppendLine("    {");
+        builder.AppendLine("        public UnrelatedProfile()");
+        builder.AppendLine("        {");
+        for (var i = 0; i < TypePairCount; i++)
+        {
+            builder.AppendLine($"            CreateMap<Source{i}, Destination{i}>();");
         }
 
         builder.AppendLine("        }");


### PR DESCRIPTION
Roadmap Tier 2.6 (throughput baseline) plus the Tier 3 perf item it was built to make measurable.

## Why a baseline first

Twenty-three analyzers run on every keystroke in every consuming solution, and analyzer cost is a common reason teams remove a package. Nothing here measured it — every existing test asserts diagnostics, never time — so a change making the pack several times slower would have shipped silently.

## The budget is a ratio, not a wall clock

Analysis is timed against compiling the same input on the same machine, so the measurement moves *with* the runner instead of against it. An absolute threshold measures the CI agent more than the analyzers, and that is how timing tests end up deleted.

**Two methodology mistakes worth recording, because both produced confident wrong numbers:**

1. My first version reported **18x and 160x** — alarming figures that would have justified optimisation work. They were artifacts: Roslyn memoises `GetDiagnostics()`, so I timed a *warmed* compile against a *fresh* analyzer run. Each side now gets its own cold `Compilation` after a discarded warm-up.
2. The diamond fixture was a **DAG, not cyclic**, so AM022 — the analyzer it exists to stress — never engaged. The guard asserting the fixture produces AM diagnostics is what caught it.

Had I trusted either, I would have optimised against noise.

## Three fixtures

| Fixture | Shape | Baseline |
| --- | --- | --- |
| Solution-sized | 60 mapped type pairs, mixed nullable/collection/nested/enum/required | 2.8x–5.9x |
| Cyclic diamond | 8 levels, cycle closed through the leaf | 1.5x–1.9x |
| **Mostly unrelated** | ~2400 ordinary calls around 60 mapped pairs | 2.0x–2.3x |

The third matters most: every analyzer registers on `InvocationExpression`, so the pack visits *every* method call in a solution, the overwhelming majority unrelated to mapping. A mapping-dense fixture cannot show what that costs.

Budget **20x**, ~3x above the noisy high — sized to catch an order-of-magnitude regression without firing on runner noise.

## The perf change, and honest evidence

`IsAutoMapperMethodInvocation` bound symbols before checking whether the invoked name could match at all. AM050 already did the cheap check first; the shared helper did not. The name is now compared syntactically first, and shapes whose name cannot be read fall through to the semantic check — **the gate can only skip work, never change an answer**. All 1841 tests pass unchanged.

Measured:

| Fixture | Without gate | With gate |
| --- | --- | --- |
| Mapping-dense | mean 5.77x | mean 5.39x (~7%) |
| Mostly unrelated | mean 2.47x | mean 2.17x (~12%) |

**Directional, not conclusive.** Three samples per arm with overlapping ranges. The larger effect on unrelated code matches the mechanism, which is the reason to believe it. It ships because the mechanism is sound and the risk is zero — not because the numbers proved it.

## Deliberately excluded

The AM022 `GetTypePairKey` string-allocation change from the same shortlist is **not** included. It is too small to separate from noise at this fixture size, and shipping unmeasured micro-optimisation into a recursion analyzer with delicate memo semantics is a bad trade. The baseline now exists to evaluate it properly if it is ever worth revisiting.

## Validation

- 1841 tests green on `net10.0`; `-warnaserror` clean; catalog/snapshot/compatibility current.
- Throughput assertions stable across repeated runs (checked 3–4 consecutive runs per fixture).
- No version bump: the perf change is behaviour-preserving and the fixtures are test infrastructure.
