### PR TITLE
test: isolate throughput timing from test parallelism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
   whole pack over a solution-sized fixture (60 mapped type pairs) and a cyclic diamond type graph,
   budgeted as a multiple of compiling the same input rather than as wall-clock time, so the measurement
   moves with the runner. Nothing previously measured analyzer cost, on code that runs on every keystroke
-  in consuming solutions. Recorded baseline: 2.8x–5.9x solution-sized, ~1.5x–1.9x diamond; budget 20x.
+  in consuming solutions. Timing tests run in their own non-parallel collection, because sharing a machine with ~1800 parallel tests measured CPU contention as much as analyzer cost; isolating them cut one fixture's spread from ~3.1x to ~1.1x. Fixtures compile with nullable enabled so AM002's analysis is exercised. Recorded baseline during full-suite runs: 4.6x–5.7x solution-sized, 2.3x–2.6x mostly-unrelated, 1.7x–2.1x diamond; budget 20x.
   Test infrastructure only.
 - **Analyzer crash-safety suite** (`tests/.../Robustness/AnalyzerCrashSafetyTests.cs`). Drives every
   catalogued analyzer over 20 hostile inputs — incomplete generics, dangling fluent chains, selectors

--- a/docs/TEST_LIMITATIONS.md
+++ b/docs/TEST_LIMITATIONS.md
@@ -39,8 +39,14 @@ specific analyzers; the **mostly-unrelated** fixture (~2400 ordinary method call
 pairs) is the realistic consumer shape, because every analyzer registers on `InvocationExpression` and
 therefore visits every call in a solution, the vast majority of which have nothing to do with mapping.
 
-Recorded baseline on this tree: solution-sized 2.8x–5.9x, cyclic diamond ~1.5x–1.9x, mostly-unrelated
-~2.0x–2.3x across repeated runs on one machine. The budget is **20x**, roughly 3x above the noisy high, to catch an order-of-magnitude
+The timing tests run in their own non-parallel xUnit collection. Without that they share a machine with
+~1800 other tests, and xUnit runs collections in parallel — the first recorded baseline swung 2.8x–5.9x
+on one fixture largely because some runs measured CPU contention rather than analyzer cost. Isolating
+them narrowed that fixture's spread to about 1.1x. The fixtures also compile with nullable annotations
+enabled, so AM002's nullable analysis is genuinely part of what is measured rather than a warning.
+
+Recorded baseline on this tree, measured during full-suite runs: solution-sized 4.6x–5.7x,
+mostly-unrelated 2.3x–2.6x, cyclic diamond 1.7x–2.1x. The budget is **20x**, roughly 3x above the noisy high, to catch an order-of-magnitude
 regression without firing on runner noise. Tighten only with evidence from a quiet machine.
 
 ## Analyzer crash safety

--- a/tests/AutoMapperAnalyzer.Tests/Performance/AnalyzerThroughputTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Performance/AnalyzerThroughputTests.cs
@@ -26,8 +26,20 @@ namespace AutoMapperAnalyzer.Tests.Performance;
 ///     not to police small movements.
 ///     </para>
 /// </summary>
+[CollectionDefinition(AnalyzerThroughputTests.TimingCollection, DisableParallelization = true)]
+public sealed class TimingCollectionDefinition;
+
+/// <inheritdoc cref="AnalyzerThroughputTests" />
+[Collection(AnalyzerThroughputTests.TimingCollection)]
 public class AnalyzerThroughputTests(ITestOutputHelper output)
 {
+    /// <summary>
+    ///     Timing tests share a machine with roughly 1800 other tests. xUnit runs collections in
+    ///     parallel by default, so without isolation these measure contention for CPU as much as
+    ///     analyzer cost — which is most of the run-to-run spread the first baseline recorded.
+    /// </summary>
+    internal const string TimingCollection = "analyzer-timing";
+
     private const int TypePairCount = 60;
 
     /// <summary>
@@ -354,7 +366,13 @@ public class AnalyzerThroughputTests(ITestOutputHelper output)
             "AutoMapperAnalyzer.Throughput",
             [CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview))],
             references,
-            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+            // The fixtures use nullable annotations deliberately, so AM002's nullable analysis is part
+            // of what is being measured. Without an enabled nullable context those annotations are
+            // warnings and the analysis they exist to exercise never runs.
+            new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable
+            )
         );
     }
 }


### PR DESCRIPTION
Follow-up to #209, from its review.

## The timing tests were measuring the wrong thing

They shared a machine with ~1800 other tests, and xUnit runs collections in parallel. So they measured contention for CPU as much as analyzer cost.

That explains a spread I recorded in #209 and wrote off as generic runner noise: the solution-sized fixture ranged **2.8x–5.9x**. The low readings were simply runs that happened not to contend. I had documented that range as the baseline.

Moving the tests into a non-parallel collection:

| Fixture | Before (spread) | After (spread) |
| --- | --- | --- |
| Solution-sized | 2.8x–5.9x (3.1) | 4.6x–5.7x (1.1) |
| Mostly unrelated | — | 2.3x–2.6x (0.3) |
| Cyclic diamond | 1.5x–1.9x | 1.7x–2.1x (0.4) |

Measured during **full-suite** runs, which is where the contention actually happens. The documented baseline is updated to the isolated figures, since the previous range described scheduling more than the analyzers.

## Nullable context

The fixtures declare `string?` deliberately, so AM002's nullable analysis is part of what should be measured. Without an enabled nullable context those annotations were only `CS8632` warnings and that analysis never ran on them. Now enabled.

## Budget unchanged

Still 20x — roughly 3.5x above the isolated high. That is the headroom a regression detector wants; the isolation removed the need for headroom against scheduling noise, but the budget exists to catch order-of-magnitude regressions, not to track small movements.

## Validation

- 1841 tests green; timing stability checked across three consecutive full-suite runs.
- No version bump: test infrastructure only.