### PR TITLE
test: enumerate the type-shape space and assert invariants over it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ Faster analysis on code unrelated to AutoMapper (no rule ID, severity, or diagno
 
 ### Added
 
+- **Generated type-shape coverage** (`tests/.../Robustness/GeneratedTypeShapeTests.cs`). Enumerates
+  nullability × container kind × element type × declaration form (~590 mappings) and asserts invariants
+  rather than expected diagnostics: identical shapes never report a mismatch, no analyzer crashes, and
+  no member is reported as both unmapped and mapped-but-incompatible. Hand-written cases sample this
+  space sparsely and only where someone already thought to look. Each invariant was verified by
+  deliberately violating it. Test infrastructure only.
 - **Analyzer throughput baseline** (`tests/.../Performance/AnalyzerThroughputTests.cs`). Measures the
   whole pack over a solution-sized fixture (60 mapped type pairs) and a cyclic diamond type graph,
   budgeted as a multiple of compiling the same input rather than as wall-clock time, so the measurement

--- a/docs/TEST_LIMITATIONS.md
+++ b/docs/TEST_LIMITATIONS.md
@@ -49,6 +49,26 @@ Recorded baseline on this tree, measured during full-suite runs: solution-sized 
 mostly-unrelated 2.3x–2.6x, cyclic diamond 1.7x–2.1x. The budget is **20x**, roughly 3x above the noisy high, to catch an order-of-magnitude
 regression without firing on runner noise. Tighten only with evidence from a quiet machine.
 
+## Generated type-shape coverage
+
+`Robustness/GeneratedTypeShapeTests` enumerates the space these rules reason about — nullability ×
+container kind (scalar, `List`, array, `IReadOnlyList`, `HashSet`) × element type × declaration form
+(class, record, record struct) — producing ~590 mappings.
+
+It asserts **invariants, never expected diagnostics**. Predicting the exact diagnostic for each
+combination would mean reimplementing the analyzers inside the test, and the reimplementation would be
+wrong in the same places the analyzers are. The invariants hold regardless of which rule fires:
+
+- **Identical shapes never report a mismatch.** If source and destination are structurally identical,
+  any AM001/AM002/AM003/AM021 diagnostic is self-contradictory — whatever the rule believes about the
+  shape, it believes the same thing on both sides.
+- **No analyzer crashes** on any generated shape.
+- **No member is both unmapped and incompatible.** AM006/AM011 claiming a member is unmapped while
+  AM001/AM003/AM021 claim it is mapped-but-incompatible leaves a user with no coherent action.
+
+Each invariant was verified by violating it deliberately and confirming the failure names the offending
+shape and rule, rather than being trusted because ~590 generated cases were green.
+
 ## Analyzer crash safety
 
 `Robustness/AnalyzerCrashSafetyTests` drives every catalogued analyzer over code that does not compile,

--- a/tests/AutoMapperAnalyzer.Tests/Robustness/GeneratedTypeShapeTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Robustness/GeneratedTypeShapeTests.cs
@@ -5,7 +5,6 @@ using AutoMapperAnalyzer.Analyzers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Xunit.Abstractions;
 
 namespace AutoMapperAnalyzer.Tests.Robustness;
 
@@ -24,7 +23,7 @@ namespace AutoMapperAnalyzer.Tests.Robustness;
 ///     regardless of which rule fires, and a violation is a real defect rather than a stale expectation.
 ///     </para>
 /// </summary>
-public class GeneratedTypeShapeTests(ITestOutputHelper output)
+public class GeneratedTypeShapeTests
 {
     private static readonly string[] ElementTypes = ["string", "int", "System.DateTime"];
 
@@ -195,11 +194,17 @@ public class GeneratedTypeShapeTests(ITestOutputHelper output)
         builder.AppendLine();
         builder.AppendLine("namespace GeneratedFixture");
         builder.AppendLine("{");
+        // A struct with a field initializer needs an explicitly declared constructor (CS8983), so the
+        // initializer is emitted only for reference declarations. Without this the record-struct third
+        // of the matrix generated source that does not compile.
+        string initializer = declarationForm.Contains("struct", StringComparison.Ordinal)
+            ? string.Empty
+            : " = default!;";
         builder.AppendLine(
-            $"    public {declarationForm} Source {{ public {sourceMemberType} Value {{ get; set; }} = default!; }}"
+            $"    public {declarationForm} Source {{ public {sourceMemberType} Value {{ get; set; }}{initializer} }}"
         );
         builder.AppendLine(
-            $"    public {declarationForm} Destination {{ public {destinationMemberType} Value {{ get; set; }} = default!; }}"
+            $"    public {declarationForm} Destination {{ public {destinationMemberType} Value {{ get; set; }}{initializer} }}"
         );
         builder.AppendLine();
         builder.AppendLine("    public class GeneratedProfile : Profile");
@@ -273,6 +278,20 @@ public class GeneratedTypeShapeTests(ITestOutputHelper output)
             },
             concurrentAnalysis: true,
             logAnalyzerExecutionTime: false
+        );
+
+        // Analysing source that does not compile exercises error types rather than the shapes this
+        // suite claims to cover, and would pass silently - the record-struct third of the matrix did
+        // exactly that until review caught it. The corpus scanner learned the same lesson separately.
+        ImmutableArray<Diagnostic> compilerErrors = compilation
+            .GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .ToImmutableArray();
+
+        Assert.True(
+            compilerErrors.Length == 0,
+            "Generated fixture does not compile, so the shapes under test are not the shapes described: "
+                + string.Join("; ", compilerErrors.Select(d => d.ToString()))
         );
 
         ImmutableArray<Diagnostic> diagnostics = await compilation

--- a/tests/AutoMapperAnalyzer.Tests/Robustness/GeneratedTypeShapeTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Robustness/GeneratedTypeShapeTests.cs
@@ -1,0 +1,289 @@
+using System.Collections.Immutable;
+using System.Text;
+using AutoMapper;
+using AutoMapperAnalyzer.Analyzers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit.Abstractions;
+
+namespace AutoMapperAnalyzer.Tests.Robustness;
+
+/// <summary>
+///     Enumerates the type-shape space the analyzers reason about and asserts invariants over it.
+///     <para>
+///     These rules reason about nullability × collection kind × declaration form × inheritance depth.
+///     Hand-written cases sample that space sparsely and, unavoidably, only at the points someone
+///     already thought of. This walks it systematically instead.
+///     </para>
+///     <para>
+///     It asserts <b>invariants</b>, never expected diagnostics. Predicting the exact diagnostic for
+///     every generated combination would mean reimplementing the analyzers in the test, and the
+///     reimplementation would be wrong in the same places. Invariants — no crash, no contradictory
+///     claims about one member, no diagnostic on a shape that is identical on both sides — hold
+///     regardless of which rule fires, and a violation is a real defect rather than a stale expectation.
+///     </para>
+/// </summary>
+public class GeneratedTypeShapeTests(ITestOutputHelper output)
+{
+    private static readonly string[] ElementTypes = ["string", "int", "System.DateTime"];
+
+    private static readonly (string Name, string Format)[] Containers =
+    [
+        ("scalar", "{0}"),
+        ("list", "System.Collections.Generic.List<{0}>"),
+        ("array", "{0}[]"),
+        ("readonlyList", "System.Collections.Generic.IReadOnlyList<{0}>"),
+        ("hashSet", "System.Collections.Generic.HashSet<{0}>"),
+    ];
+
+    private static readonly string[] DeclarationForms = ["class", "record", "record struct"];
+
+    /// <summary>
+    ///     A mapping whose source and destination are structurally identical must never be reported as
+    ///     a type or nullability problem. Whatever a rule believes about the shape, it believes the same
+    ///     thing on both sides, so a mismatch diagnostic is self-contradictory.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(IdenticalShapeCases))]
+    public async Task IdenticalShapes_ShouldNotReportMismatchDiagnostics(
+        string containerName,
+        string elementType,
+        string declarationForm,
+        bool nullable
+    )
+    {
+        string container = Containers.First(c => c.Name == containerName).Format;
+        string memberType = string.Format(container, elementType) + (nullable ? "?" : string.Empty);
+
+        string source = BuildMapping(declarationForm, memberType, memberType);
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source);
+
+        string[] mismatchRules = ["AM001", "AM002", "AM003", "AM021"];
+        Diagnostic[] offending = diagnostics
+            .Where(d => mismatchRules.Contains(d.Id, StringComparer.Ordinal))
+            .ToArray();
+
+        Assert.True(
+            offending.Length == 0,
+            $"Identical shapes ({declarationForm}, {memberType}) reported a mismatch: "
+                + string.Join("; ", offending.Select(d => $"{d.Id} {d.GetMessage()}"))
+        );
+    }
+
+    /// <summary>
+    ///     No analyzer may crash on any generated shape. This is the same guarantee as the crash-safety
+    ///     suite, applied to well-formed but combinatorially varied input rather than malformed input.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(CrossShapeCases))]
+    public async Task CrossShapeMappings_ShouldNeverCrashAnAnalyzer(
+        string sourceType,
+        string destinationType,
+        string declarationForm
+    )
+    {
+        string source = BuildMapping(declarationForm, sourceType, destinationType);
+        (ImmutableArray<Diagnostic> _, IReadOnlyList<string> crashes) =
+            await AnalyzeCapturingCrashesAsync(source);
+
+        Assert.True(
+            crashes.Count == 0,
+            $"Analyzers threw mapping {sourceType} -> {destinationType} ({declarationForm}):"
+                + Environment.NewLine
+                + string.Join(Environment.NewLine, crashes)
+        );
+    }
+
+    /// <summary>
+    ///     One destination member must not be simultaneously reported as unmapped (AM006/AM011) and as
+    ///     mapped-but-incompatible (AM001/AM003/AM021). Those claims contradict each other, and a user
+    ///     shown both has no coherent action to take.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(CrossShapeCases))]
+    public async Task NoMemberIsBothUnmappedAndIncompatible(
+        string sourceType,
+        string destinationType,
+        string declarationForm
+    )
+    {
+        string source = BuildMapping(declarationForm, sourceType, destinationType);
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source);
+
+        string[] unmapped = ["AM006", "AM011"];
+        string[] incompatible = ["AM001", "AM003", "AM021"];
+
+        bool claimsUnmapped = diagnostics.Any(d =>
+            unmapped.Contains(d.Id, StringComparer.Ordinal)
+            && d.GetMessage().Contains("Value", StringComparison.Ordinal)
+        );
+        bool claimsIncompatible = diagnostics.Any(d =>
+            incompatible.Contains(d.Id, StringComparer.Ordinal)
+            && d.GetMessage().Contains("Value", StringComparison.Ordinal)
+        );
+
+        Assert.False(
+            claimsUnmapped && claimsIncompatible,
+            $"Member 'Value' reported as both unmapped and incompatible mapping {sourceType} -> "
+                + $"{destinationType} ({declarationForm}): "
+                + string.Join("; ", diagnostics.Select(d => $"{d.Id} {d.GetMessage()}"))
+        );
+    }
+
+    public static TheoryData<string, string, string, bool> IdenticalShapeCases()
+    {
+        var data = new TheoryData<string, string, string, bool>();
+        foreach ((string name, string _) in Containers)
+        {
+            foreach (string element in ElementTypes)
+            {
+                foreach (string form in DeclarationForms)
+                {
+                    // A nullable annotation on a value-type container is a different type, not the same
+                    // shape, so only reference-shaped members carry the nullable variant here.
+                    data.Add(name, element, form, false);
+                    if (name != "scalar" || element == "string")
+                    {
+                        data.Add(name, element, form, true);
+                    }
+                }
+            }
+        }
+
+        return data;
+    }
+
+    public static TheoryData<string, string, string> CrossShapeCases()
+    {
+        var data = new TheoryData<string, string, string>();
+        string[] shapes = Containers
+            .SelectMany(container =>
+                ElementTypes.Select(element => string.Format(container.Format, element))
+            )
+            .ToArray();
+
+        // Every container/element shape against every other, on one declaration form, plus the full
+        // shape set against itself on the remaining forms. Full cross-product across all three forms
+        // would triple the runtime without exercising materially different analyzer paths.
+        foreach (string sourceShape in shapes)
+        {
+            foreach (string destinationShape in shapes)
+            {
+                data.Add(sourceShape, destinationShape, "class");
+            }
+        }
+
+        foreach (string shape in shapes)
+        {
+            data.Add(shape, shape + "?", "record");
+            data.Add(shape, shape, "record struct");
+        }
+
+        return data;
+    }
+
+    private static string BuildMapping(
+        string declarationForm,
+        string sourceMemberType,
+        string destinationMemberType
+    )
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("#nullable enable");
+        builder.AppendLine("using AutoMapper;");
+        builder.AppendLine();
+        builder.AppendLine("namespace GeneratedFixture");
+        builder.AppendLine("{");
+        builder.AppendLine(
+            $"    public {declarationForm} Source {{ public {sourceMemberType} Value {{ get; set; }} = default!; }}"
+        );
+        builder.AppendLine(
+            $"    public {declarationForm} Destination {{ public {destinationMemberType} Value {{ get; set; }} = default!; }}"
+        );
+        builder.AppendLine();
+        builder.AppendLine("    public class GeneratedProfile : Profile");
+        builder.AppendLine("    {");
+        builder.AppendLine("        public GeneratedProfile()");
+        builder.AppendLine("        {");
+        builder.AppendLine("            CreateMap<Source, Destination>();");
+        builder.AppendLine("        }");
+        builder.AppendLine("    }");
+        builder.AppendLine("}");
+        return builder.ToString();
+    }
+
+    private static async Task<ImmutableArray<Diagnostic>> AnalyzeAsync(string source)
+    {
+        (ImmutableArray<Diagnostic> diagnostics, IReadOnlyList<string> crashes) =
+            await AnalyzeCapturingCrashesAsync(source);
+
+        Assert.True(crashes.Count == 0, "Analyzer crashed: " + string.Join("; ", crashes));
+        return diagnostics;
+    }
+
+    private static async Task<(
+        ImmutableArray<Diagnostic>,
+        IReadOnlyList<string>
+    )> AnalyzeCapturingCrashesAsync(string source)
+    {
+        var references = new List<MetadataReference>();
+        string trustedPlatformAssemblies =
+            (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") ?? string.Empty;
+
+        foreach (string assemblyPath in trustedPlatformAssemblies.Split(Path.PathSeparator))
+        {
+            if (!string.IsNullOrWhiteSpace(assemblyPath))
+            {
+                references.Add(MetadataReference.CreateFromFile(assemblyPath));
+            }
+        }
+
+        references.Add(MetadataReference.CreateFromFile(typeof(Profile).Assembly.Location));
+
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            "AutoMapperAnalyzer.Generated",
+            [CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Preview))],
+            references,
+            new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable
+            )
+        );
+
+        ImmutableArray<DiagnosticAnalyzer> analyzers = RuleCatalog
+            .Rules.Select(rule => rule.AnalyzerType)
+            .Distinct()
+            .Select(type => (DiagnosticAnalyzer)Activator.CreateInstance(type)!)
+            .ToImmutableArray();
+
+        var crashes = new List<string>();
+        var crashLock = new object();
+
+        var options = new CompilationWithAnalyzersOptions(
+            new AnalyzerOptions([]),
+            onAnalyzerException: (exception, analyzer, _) =>
+            {
+                lock (crashLock)
+                {
+                    crashes.Add(
+                        $"{analyzer.GetType().Name}: {exception.GetType().Name}: {exception.Message}"
+                    );
+                }
+            },
+            concurrentAnalysis: true,
+            logAnalyzerExecutionTime: false
+        );
+
+        ImmutableArray<Diagnostic> diagnostics = await compilation
+            .WithAnalyzers(analyzers, options)
+            .GetAnalyzerDiagnosticsAsync();
+
+        return (
+            diagnostics
+                .Where(d => d.Id.StartsWith("AM", StringComparison.Ordinal))
+                .ToImmutableArray(),
+            crashes
+        );
+    }
+}


### PR DESCRIPTION
Roadmap Tier 2.5.

## The gap

These rules reason about nullability × container kind × element type × declaration form. Hand-written cases sample that space sparsely and — unavoidably — only at the points someone already thought of. That is the same blind spot that let `IncludeMembers` go unrecognised for thirty releases, in a different dimension.

This walks the space systematically: **~590 generated mappings** across scalar / `List` / array / `IReadOnlyList` / `HashSet` containers, three element types, and class / record / record struct declarations.

## Invariants, not expected diagnostics

Predicting the exact diagnostic for each combination would mean reimplementing the analyzers inside the test — and that reimplementation would be wrong in the same places the analyzers are, which is how generated suites become an expensive way to restate existing bugs.

The three invariants hold regardless of which rule fires:

| Invariant | Why it must hold |
| --- | --- |
| Identical shapes never report a mismatch | Whatever a rule believes about the shape, it believes the same thing on both sides — the diagnostic is self-contradictory |
| No analyzer crashes | Same guarantee as the crash-safety suite, applied to well-formed but combinatorially varied input |
| No member is both unmapped **and** incompatible | AM006/AM011 and AM001/AM003/AM021 contradicting each other leaves a user with no coherent action |

## Verified by violating them

~590 green generated cases are indistinguishable from ~590 assertions that cannot fail, so each invariant was deliberately broken and confirmed to fail with useful attribution:

```
Identical shapes (record struct, List<string>) reported a mismatch:
AM001 Property 'Value' has incompatible types: Source.Value (List<string>)
cannot be mapped to Destination.Value (int) without explicit conversion
```

## Validation

- 2435 tests green on `net10.0` (+594); `-warnaserror` clean; catalog/snapshot/compatibility current.
- No version bump: test infrastructure only.