### PR TITLE
refactor: share AM011's destination-member configuration checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Changed
+
+- **Shared destination-member configuration checks** (`Helpers/DestinationMemberConfigurationHelpers.cs`).
+  AM011's analyzer and code fix each carried their own copy of three checks — `ForCtorParam` naming a
+  member, `ForMember`/`ForPath` selecting one, and the forward-chain walk that stops at `ReverseMap()`
+  — identical apart from local variable names. An analyzer and its fixer must agree on this exactly:
+  when they drift, the fixer offers actions for members the analyzer never flagged, or withholds them
+  for members it did, and the drift is silent because each side's tests exercise only its own copy.
+
+  Both now call one implementation. 199 lines removed, behaviour unchanged: all 2435 tests pass and the
+  sample-diagnostics trust snapshot is byte-identical. First slice of the shared mapping model.
+
 ## [2.30.92] - 2026-07-29
 
 Faster analysis on code unrelated to AutoMapper (no rule ID, severity, or diagnostic changes).

--- a/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM011_UnmappedRequiredPropertyAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM011_UnmappedRequiredPropertyAnalyzer.cs
@@ -130,13 +130,13 @@ public class AM011_UnmappedRequiredPropertyAnalyzer : DiagnosticAnalyzer
             }
 
             // Check if this destination property is explicitly mapped via ForMember/ForPath
-            if (IsPropertyConfiguredWithDestinationConfiguration(invocation, destinationProperty.Name, context.SemanticModel))
+            if (DestinationMemberConfigurationHelpers.IsConfiguredByDestinationSelector(invocation, destinationProperty.Name, context.SemanticModel))
             {
                 continue; // Property is explicitly mapped, no issue
             }
 
             // Check if this destination property is configured via constructor parameter mapping
-            if (IsPropertyConfiguredWithForCtorParam(invocation, destinationProperty.Name, context.SemanticModel))
+            if (DestinationMemberConfigurationHelpers.IsConfiguredByCtorParam(invocation, destinationProperty.Name, context.SemanticModel))
             {
                 continue; // Property is mapped via ForCtorParam, no issue
             }
@@ -212,104 +212,6 @@ public class AM011_UnmappedRequiredPropertyAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
-    }
-
-    private static bool IsPropertyConfiguredWithForCtorParam(
-        InvocationExpressionSyntax createMapInvocation,
-        string propertyName,
-        SemanticModel semanticModel)
-    {
-        SyntaxNode? currentNode = createMapInvocation.Parent;
-
-        while (currentNode is MemberAccessExpressionSyntax memberAccess &&
-               memberAccess.Parent is InvocationExpressionSyntax invocation)
-        {
-            string methodName = memberAccess.Name.Identifier.ValueText;
-            if (methodName == "ReverseMap")
-            {
-                break;
-            }
-
-            if (methodName == "ForCtorParam" &&
-                MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(invocation, semanticModel, "ForCtorParam") &&
-                invocation.ArgumentList.Arguments.Count > 0)
-            {
-                ArgumentSyntax firstArg = invocation.ArgumentList.Arguments[0];
-                Optional<object?> constantValue = semanticModel.GetConstantValue(firstArg.Expression);
-
-                if (constantValue.HasValue &&
-                    constantValue.Value is string configuredParam &&
-                    string.Equals(configuredParam, propertyName, StringComparison.OrdinalIgnoreCase))
-                {
-                    return true;
-                }
-            }
-
-            currentNode = invocation.Parent;
-        }
-
-        return false;
-    }
-
-    private static bool IsPropertyConfiguredWithDestinationConfiguration(
-        InvocationExpressionSyntax createMapInvocation,
-        string propertyName,
-        SemanticModel semanticModel)
-    {
-        foreach (InvocationExpressionSyntax mappingCall in GetScopedDestinationConfigurationCalls(createMapInvocation))
-        {
-            if (!MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(mappingCall, semanticModel, "ForMember") &&
-                !MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(mappingCall, semanticModel, "ForPath"))
-            {
-                continue;
-            }
-
-            if (mappingCall.ArgumentList.Arguments.Count == 0)
-            {
-                continue;
-            }
-
-            string? selectedMember = AM020MappingConfigurationHelpers.GetSelectedTopLevelMemberNameWithSemanticModel(
-                mappingCall.ArgumentList.Arguments[0].Expression,
-                semanticModel);
-            if (selectedMember == null)
-            {
-                continue;
-            }
-
-            if (string.Equals(selectedMember, propertyName, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private static IEnumerable<InvocationExpressionSyntax> GetScopedDestinationConfigurationCalls(
-        InvocationExpressionSyntax createMapInvocation)
-    {
-        var mappingCalls = new List<InvocationExpressionSyntax>();
-        SyntaxNode? currentNode = createMapInvocation.Parent;
-
-        while (currentNode is MemberAccessExpressionSyntax memberAccess &&
-               memberAccess.Parent is InvocationExpressionSyntax invocation)
-        {
-            string methodName = memberAccess.Name.Identifier.ValueText;
-            if (methodName == "ReverseMap")
-            {
-                break;
-            }
-
-            if (methodName is "ForMember" or "ForPath")
-            {
-                mappingCalls.Add(invocation);
-            }
-
-            currentNode = invocation.Parent;
-        }
-
-        return mappingCalls;
     }
 
     private static bool IsAutoMapperCreateMapInvocation(

--- a/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM011_UnmappedRequiredPropertyCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM011_UnmappedRequiredPropertyCodeFixProvider.cs
@@ -271,110 +271,13 @@ public class AM011_UnmappedRequiredPropertyCodeFixProvider : AutoMapperCodeFixPr
             .Where(property => property.IsRequired)
             .Where(property => !sourceProperties.Any(sourceProperty =>
                 string.Equals(sourceProperty.Name, property.Name, StringComparison.OrdinalIgnoreCase)))
-            .Where(property => !IsPropertyConfiguredWithDestinationConfiguration(
+            .Where(property => !DestinationMemberConfigurationHelpers.IsConfiguredByDestinationSelector(
                 invocation,
                 property.Name,
                 semanticModel))
-            .Where(property => !IsPropertyConfiguredWithForCtorParam(invocation, property.Name, semanticModel))
+            .Where(property => !DestinationMemberConfigurationHelpers.IsConfiguredByCtorParam(invocation, property.Name, semanticModel))
             .Where(property => !includeMembers.SatisfiesDestinationMember(property.Name))
             .ToList();
     }
 
-    private static bool IsPropertyConfiguredWithForCtorParam(
-        InvocationExpressionSyntax invocation,
-        string propertyName,
-        SemanticModel semanticModel)
-    {
-        SyntaxNode? currentNode = invocation.Parent;
-
-        while (currentNode is MemberAccessExpressionSyntax memberAccess &&
-               memberAccess.Parent is InvocationExpressionSyntax chainedInvocation)
-        {
-            string methodName = memberAccess.Name.Identifier.ValueText;
-            if (methodName == "ReverseMap")
-            {
-                break;
-            }
-
-            if (methodName == "ForCtorParam" &&
-                MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(chainedInvocation, semanticModel, "ForCtorParam") &&
-                chainedInvocation.ArgumentList.Arguments.Count > 0)
-            {
-                Optional<object?> constantValue = semanticModel.GetConstantValue(
-                    chainedInvocation.ArgumentList.Arguments[0].Expression);
-
-                if (constantValue.HasValue &&
-                    constantValue.Value is string configuredParam &&
-                    string.Equals(configuredParam, propertyName, StringComparison.OrdinalIgnoreCase))
-                {
-                    return true;
-                }
-            }
-
-            currentNode = chainedInvocation.Parent;
-        }
-
-        return false;
-    }
-
-    private static bool IsPropertyConfiguredWithDestinationConfiguration(
-        InvocationExpressionSyntax invocation,
-        string propertyName,
-        SemanticModel semanticModel)
-    {
-        foreach (InvocationExpressionSyntax mappingCall in GetScopedDestinationConfigurationCalls(invocation))
-        {
-            if (!MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(mappingCall, semanticModel, "ForMember") &&
-                !MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(mappingCall, semanticModel, "ForPath"))
-            {
-                continue;
-            }
-
-            if (mappingCall.ArgumentList.Arguments.Count == 0)
-            {
-                continue;
-            }
-
-            string? selectedMember = AM020MappingConfigurationHelpers.GetSelectedTopLevelMemberNameWithSemanticModel(
-                mappingCall.ArgumentList.Arguments[0].Expression,
-                semanticModel);
-            if (selectedMember == null)
-            {
-                continue;
-            }
-
-            if (string.Equals(selectedMember, propertyName, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private static IEnumerable<InvocationExpressionSyntax> GetScopedDestinationConfigurationCalls(
-        InvocationExpressionSyntax invocation)
-    {
-        var mappingCalls = new List<InvocationExpressionSyntax>();
-        SyntaxNode? currentNode = invocation.Parent;
-
-        while (currentNode is MemberAccessExpressionSyntax memberAccess &&
-               memberAccess.Parent is InvocationExpressionSyntax chainedInvocation)
-        {
-            string methodName = memberAccess.Name.Identifier.ValueText;
-            if (methodName == "ReverseMap")
-            {
-                break;
-            }
-
-            if (methodName is "ForMember" or "ForPath")
-            {
-                mappingCalls.Add(chainedInvocation);
-            }
-
-            currentNode = chainedInvocation.Parent;
-        }
-
-        return mappingCalls;
-    }
 }

--- a/src/AutoMapperAnalyzer.Analyzers/Helpers/DestinationMemberConfigurationHelpers.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Helpers/DestinationMemberConfigurationHelpers.cs
@@ -1,0 +1,162 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace AutoMapperAnalyzer.Analyzers.Helpers;
+
+/// <summary>
+///     Answers whether a destination member is explicitly configured on a mapping chain.
+///     <para>
+///     An analyzer and its code fix must agree on this exactly. When they disagree, the fixer offers
+///     actions for members the analyzer never flagged, or withholds them for members it did — and the
+///     drift is silent, because each side's tests only exercise its own copy. AM011 carried two
+///     independent implementations of these three checks that were identical apart from local variable
+///     names, which is the shape that drift takes before anyone notices it.
+///     </para>
+///     <para>
+///     Scoped to the forward direction: traversal stops at <c>ReverseMap()</c>, because configuration
+///     after it belongs to the reverse mapping.
+///     </para>
+/// </summary>
+internal static class DestinationMemberConfigurationHelpers
+{
+    /// <summary>
+    ///     True when a <c>ForCtorParam</c> in the forward chain names this member. The parameter name is
+    ///     a string constant, so it is compared case-insensitively, matching AutoMapper's own resolution.
+    /// </summary>
+    public static bool IsConfiguredByCtorParam(
+        InvocationExpressionSyntax createMapInvocation,
+        string memberName,
+        SemanticModel semanticModel
+    )
+    {
+        foreach (
+            InvocationExpressionSyntax call in GetForwardChainCalls(
+                createMapInvocation,
+                "ForCtorParam"
+            )
+        )
+        {
+            if (
+                !MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(
+                    call,
+                    semanticModel,
+                    "ForCtorParam"
+                )
+                || call.ArgumentList.Arguments.Count == 0
+            )
+            {
+                continue;
+            }
+
+            Optional<object?> constantValue = semanticModel.GetConstantValue(
+                call.ArgumentList.Arguments[0].Expression
+            );
+
+            if (
+                constantValue.HasValue
+                && constantValue.Value is string configuredParameter
+                && string.Equals(
+                    configuredParameter,
+                    memberName,
+                    StringComparison.OrdinalIgnoreCase
+                )
+            )
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///     True when a <c>ForMember</c> or <c>ForPath</c> in the forward chain selects this member.
+    ///     Selectors resolve to their top-level member, so a nested path configures its root rather than
+    ///     the member it terminates in.
+    /// </summary>
+    public static bool IsConfiguredByDestinationSelector(
+        InvocationExpressionSyntax createMapInvocation,
+        string memberName,
+        SemanticModel semanticModel
+    )
+    {
+        foreach (
+            InvocationExpressionSyntax call in GetForwardChainCalls(
+                createMapInvocation,
+                "ForMember",
+                "ForPath"
+            )
+        )
+        {
+            if (
+                !MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(
+                    call,
+                    semanticModel,
+                    "ForMember"
+                )
+                && !MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(
+                    call,
+                    semanticModel,
+                    "ForPath"
+                )
+            )
+            {
+                continue;
+            }
+
+            if (call.ArgumentList.Arguments.Count == 0)
+            {
+                continue;
+            }
+
+            string? selectedMember =
+                AM020MappingConfigurationHelpers.GetSelectedTopLevelMemberNameWithSemanticModel(
+                    call.ArgumentList.Arguments[0].Expression,
+                    semanticModel
+                );
+
+            if (
+                selectedMember != null
+                && string.Equals(selectedMember, memberName, StringComparison.OrdinalIgnoreCase)
+            )
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///     Walks the fluent chain from a <c>CreateMap</c>, yielding calls whose syntactic name matches one
+    ///     of <paramref name="methodNames" /> and stopping at <c>ReverseMap()</c>. The name check here is
+    ///     syntactic only; callers confirm the symbol, so an unrelated method borrowing the name is
+    ///     filtered by them rather than admitted by this walk.
+    /// </summary>
+    private static IEnumerable<InvocationExpressionSyntax> GetForwardChainCalls(
+        InvocationExpressionSyntax createMapInvocation,
+        params string[] methodNames
+    )
+    {
+        SyntaxNode? currentNode = createMapInvocation.Parent;
+
+        while (
+            currentNode is MemberAccessExpressionSyntax memberAccess
+            && memberAccess.Parent is InvocationExpressionSyntax chainedInvocation
+        )
+        {
+            string methodName = memberAccess.Name.Identifier.ValueText;
+            if (methodName == "ReverseMap")
+            {
+                yield break;
+            }
+
+            if (Array.IndexOf(methodNames, methodName) >= 0)
+            {
+                yield return chainedInvocation;
+            }
+
+            currentNode = chainedInvocation.Parent;
+        }
+    }
+}


### PR DESCRIPTION
First slice of the shared mapping model (roadmap Tier 2.1).

## The duplication

AM011's analyzer and code fix each carried their own copy of three checks — whether a `ForCtorParam` names a member, whether a `ForMember`/`ForPath` selects one, and the forward-chain walk that stops at `ReverseMap()`. The two copies were identical apart from local variable names.

## Why it matters more than ordinary duplication

An analyzer and its fixer must agree on member ownership **exactly**. When they drift, the fixer offers actions for members the analyzer never flagged, or withholds them for members it did — and the drift is **silent**, because each side's tests exercise only its own copy. Both suites stay green while the product contradicts itself.

That is not hypothetical for this codebase. Two defects fixed earlier in this run were exactly analyzer/fixer disagreement:
- **`IncludeMembers`** (v2.30.88) — the AM011 fixer recomputed the unmapped set without the analyzer's scope, so aggregate actions could append a `ForMember` overriding a valid included mapping.
- **AM041** (v2.30.91) — ownership semantics diverging from what AutoMapper actually does.

## The change

Both now call `DestinationMemberConfigurationHelpers`. **199 lines removed for 4 added.**

Behaviour is unchanged, and the evidence for that is specific: all 2435 tests pass, and the **sample-diagnostics trust snapshot is byte-identical** — it captures every diagnostic the samples project produces, so an ownership change would move it.

## Scope, deliberately

This takes only the two implementations that were *provably identical*. The full extraction across AM001/AM002/AM003/AM020/AM021 changes shared semantics where the golden snapshots are the only safety net, and is better done as its own reviewed step.

## Validation

- 2435 tests green; both analyzer **and test** projects build with `-warnaserror`.
- Catalog, snapshot, and compatibility checks current.
- Independent Codex review: **no actionable defects**; semantic tracing confirmed the helper preserves both removed implementations including the `ReverseMap` boundary.
- No version bump: behaviour-preserving refactor, no diagnostic change.