### PR TITLE
refactor: name the shared mapping helpers for what they are

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Changed
 
+- **`AM020MappingConfigurationHelpers` renamed to `MappingConfigurationHelpers`.** It is consumed by 13
+  files across AM001, AM002, AM003, AM005, AM006, AM020, AM021, and AM022 — it has not been AM020-specific
+  for a long time, and the name told every other rule that it was someone else's rule-specific code.
+  That is the likely reason AM011 carried its own copies of checks this class already provided. Pure
+  rename; no behaviour change.
+- **`ShouldStopAtReverseMapBoundary` is shared**, replacing byte-identical copies in AM005 and the
+  configuration helpers, and now carries the explanation of *why* the predicate inverts on a
+  `ReverseMap()` invocation rather than leaving it to be re-derived.
 - **Shared destination-member configuration checks** (`Helpers/DestinationMemberConfigurationHelpers.cs`).
   AM011's analyzer and code fix each carried their own copy of three checks — `ForCtorParam` naming a
   member, `ForMember`/`ForPath` selecting one, and the forward-chain walk that stops at `ReverseMap()`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -241,7 +241,7 @@ private static void AnalyzePropertyMappings(
         // member instead is a common mistake: ForMember(d => d.DisplayName, o => o.MapFrom(s => s.Name))
         // configures DisplayName, and must not suppress analysis of a conventionally mapped
         // destination Name. This helper covers ForMember, ForPath, and ForCtorParam.
-        if (AM020MappingConfigurationHelpers.IsDestinationPropertyExplicitlyConfigured(
+        if (MappingConfigurationHelpers.IsDestinationPropertyExplicitlyConfigured(
             invocation, destProp.Name, context.SemanticModel))
             continue;
 

--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM020_NestedObjectMappingAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM020_NestedObjectMappingAnalyzer.cs
@@ -87,7 +87,7 @@ public class AM020_NestedObjectMappingAnalyzer : DiagnosticAnalyzer
         ITypeSymbol destinationType,
         HashSet<string> reportedMappings)
     {
-        if (AM020MappingConfigurationHelpers.HasCustomConstructionOrConversion(invocation, context.SemanticModel))
+        if (MappingConfigurationHelpers.HasCustomConstructionOrConversion(invocation, context.SemanticModel))
         {
             return;
         }
@@ -124,7 +124,7 @@ public class AM020_NestedObjectMappingAnalyzer : DiagnosticAnalyzer
                 }
 
                 // Check if property is explicitly mapped via ForMember/ForPath in forward direction
-                if (AM020MappingConfigurationHelpers.IsDestinationPropertyExplicitlyConfigured(
+                if (MappingConfigurationHelpers.IsDestinationPropertyExplicitlyConfigured(
                         invocation,
                         destinationProperty.Name,
                         context.SemanticModel))

--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM020_NestedObjectMappingCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM020_NestedObjectMappingCodeFixProvider.cs
@@ -620,7 +620,7 @@ public class AM020_NestedObjectMappingCodeFixProvider : AutoMapperCodeFixProvide
         var missingMappings = new List<(INamedTypeSymbol Source, INamedTypeSymbol Destination)>();
         var registry = CreateMapRegistry.FromCompilation(semanticModel.Compilation);
 
-        if (AM020MappingConfigurationHelpers.HasCustomConstructionOrConversion(createMapInvocation, semanticModel))
+        if (MappingConfigurationHelpers.HasCustomConstructionOrConversion(createMapInvocation, semanticModel))
         {
             return missingMappings;
         }
@@ -644,7 +644,7 @@ public class AM020_NestedObjectMappingCodeFixProvider : AutoMapperCodeFixProvide
                 continue;
             }
 
-            if (AM020MappingConfigurationHelpers.IsDestinationPropertyExplicitlyConfigured(
+            if (MappingConfigurationHelpers.IsDestinationPropertyExplicitlyConfigured(
                     createMapInvocation,
                     destProp.Name,
                     semanticModel))

--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM021_CollectionElementMismatchAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM021_CollectionElementMismatchAnalyzer.cs
@@ -83,7 +83,7 @@ public class AM021_CollectionElementMismatchAnalyzer : DiagnosticAnalyzer
     {
         var reportedProperties = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        if (AM020MappingConfigurationHelpers.HasCustomConstructionOrConversion(invocation, context.SemanticModel))
+        if (MappingConfigurationHelpers.HasCustomConstructionOrConversion(invocation, context.SemanticModel))
         {
             return reportedProperties;
         }
@@ -110,7 +110,7 @@ public class AM021_CollectionElementMismatchAnalyzer : DiagnosticAnalyzer
             }
 
             // Check for explicit property mapping that might handle collection conversion
-            if (AM020MappingConfigurationHelpers.IsDestinationPropertyExplicitlyConfigured(
+            if (MappingConfigurationHelpers.IsDestinationPropertyExplicitlyConfigured(
                     invocation,
                     destinationProperty.Name,
                     context.SemanticModel))

--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM021_CollectionElementMismatchCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM021_CollectionElementMismatchCodeFixProvider.cs
@@ -88,8 +88,8 @@ public class AM021_CollectionElementMismatchCodeFixProvider : AutoMapperCodeFixP
                 continue;
             }
 
-            if (AM020MappingConfigurationHelpers.HasCustomConstructionOrConversion(invocation, operationContext.SemanticModel) ||
-                AM020MappingConfigurationHelpers.IsDestinationPropertyExplicitlyConfigured(
+            if (MappingConfigurationHelpers.HasCustomConstructionOrConversion(invocation, operationContext.SemanticModel) ||
+                MappingConfigurationHelpers.IsDestinationPropertyExplicitlyConfigured(
                     invocation,
                     destinationPropertyNameValue,
                     operationContext.SemanticModel))

--- a/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM022_InfiniteRecursionAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/ComplexMappings/AM022_InfiniteRecursionAnalyzer.cs
@@ -326,7 +326,7 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
                 : null;
         }
 
-        return AM020MappingConfigurationHelpers.GetSelectedTopLevelMemberNameWithSemanticModel(
+        return MappingConfigurationHelpers.GetSelectedTopLevelMemberNameWithSemanticModel(
             destinationSelector,
             semanticModel);
     }
@@ -995,14 +995,14 @@ public class AM022_InfiniteRecursionAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            string? destinationPropertyName = AM020MappingConfigurationHelpers
+            string? destinationPropertyName = MappingConfigurationHelpers
                 .GetDestinationPropertyNameForConstructorParameter(
                     destinationType,
                     sourceType,
                     parameterName,
                     configuredParameterNames,
                     semanticModel) ??
-                AM020MappingConfigurationHelpers
+                MappingConfigurationHelpers
                     .GetPositionalRecordPropertyNameForConstructorParameter(
                         destinationType,
                         sourceType,

--- a/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM005_CaseSensitivityMismatchAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM005_CaseSensitivityMismatchAnalyzer.cs
@@ -89,7 +89,7 @@ public class AM005_CaseSensitivityMismatchAnalyzer : DiagnosticAnalyzer
         ITypeSymbol destinationType,
         HashSet<string> reportedMismatches)
     {
-        if (AM020MappingConfigurationHelpers.HasCustomConstructionOrConversion(mappingInvocation, context.SemanticModel))
+        if (MappingConfigurationHelpers.HasCustomConstructionOrConversion(mappingInvocation, context.SemanticModel))
         {
             return;
         }
@@ -127,7 +127,7 @@ public class AM005_CaseSensitivityMismatchAnalyzer : DiagnosticAnalyzer
             }
 
             // Check if explicit mapping is configured for this property
-            if (AM020MappingConfigurationHelpers.IsDestinationPropertyExplicitlyConfigured(
+            if (MappingConfigurationHelpers.IsDestinationPropertyExplicitlyConfigured(
                     mappingInvocation,
                     caseInsensitiveMatch.Name,
                     context.SemanticModel))
@@ -140,7 +140,7 @@ public class AM005_CaseSensitivityMismatchAnalyzer : DiagnosticAnalyzer
                     mappingInvocation,
                     sourceProperty.Name,
                     context.SemanticModel,
-                    ShouldStopAtReverseMapBoundary(mappingInvocation, context.SemanticModel)))
+                    MappingConfigurationHelpers.ShouldStopAtReverseMapBoundary(mappingInvocation, context.SemanticModel)))
             {
                 continue;
             }
@@ -207,10 +207,4 @@ public class AM005_CaseSensitivityMismatchAnalyzer : DiagnosticAnalyzer
         return null;
     }
 
-    private static bool ShouldStopAtReverseMapBoundary(
-        InvocationExpressionSyntax mappingInvocation,
-        SemanticModel semanticModel)
-    {
-        return !MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(mappingInvocation, semanticModel, "ReverseMap");
-    }
 }

--- a/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM006_UnmappedDestinationPropertyAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/DataIntegrity/AM006_UnmappedDestinationPropertyAnalyzer.cs
@@ -355,7 +355,7 @@ public class AM006_UnmappedDestinationPropertyAnalyzer : DiagnosticAnalyzer
             }
 
             ArgumentSyntax destinationArgument = mappingCall.ArgumentList.Arguments[0];
-            string? selectedMember = AM020MappingConfigurationHelpers.GetSelectedTopLevelMemberNameWithSemanticModel(
+            string? selectedMember = MappingConfigurationHelpers.GetSelectedTopLevelMemberNameWithSemanticModel(
                 destinationArgument.Expression,
                 semanticModel);
             if (selectedMember == null)

--- a/src/AutoMapperAnalyzer.Analyzers/Helpers/DestinationMemberConfigurationHelpers.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Helpers/DestinationMemberConfigurationHelpers.cs
@@ -110,7 +110,7 @@ internal static class DestinationMemberConfigurationHelpers
             }
 
             string? selectedMember =
-                AM020MappingConfigurationHelpers.GetSelectedTopLevelMemberNameWithSemanticModel(
+                MappingConfigurationHelpers.GetSelectedTopLevelMemberNameWithSemanticModel(
                     call.ArgumentList.Arguments[0].Expression,
                     semanticModel
                 );

--- a/src/AutoMapperAnalyzer.Analyzers/Helpers/MappingConfigurationHelpers.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Helpers/MappingConfigurationHelpers.cs
@@ -28,7 +28,7 @@ internal readonly struct MappableSourceMember
 ///     Shared helpers for identifying whether destination members are explicitly configured
 ///     and whether mapping construction/conversion methods apply to the forward direction.
 /// </summary>
-internal static class AM020MappingConfigurationHelpers
+internal static class MappingConfigurationHelpers
 {
     public static bool IsDestinationPropertyExplicitlyConfigured(
         InvocationExpressionSyntax createMapInvocation,
@@ -685,7 +685,15 @@ internal static class AM020MappingConfigurationHelpers
             _ => false
         };
     }
-    private static bool ShouldStopAtReverseMapBoundary(
+    /// <summary>
+    ///     Whether chain traversal from this invocation should stop at <c>ReverseMap()</c>.
+    ///     <para>
+    ///     It should, unless the invocation *is* the <c>ReverseMap()</c> call: analysis rooted at the
+    ///     forward map must not read configuration that belongs to the reverse mapping, while analysis
+    ///     rooted at <c>ReverseMap()</c> is reading exactly that configuration and must continue past it.
+    ///     </para>
+    /// </summary>
+    public static bool ShouldStopAtReverseMapBoundary(
         InvocationExpressionSyntax mappingInvocation,
         SemanticModel semanticModel)
     {

--- a/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM001_PropertyTypeMismatchAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM001_PropertyTypeMismatchAnalyzer.cs
@@ -104,7 +104,7 @@ public class AM001_PropertyTypeMismatchAnalyzer : DiagnosticAnalyzer
         ITypeSymbol destinationType,
         HashSet<string> reportedMismatches)
     {
-        if (AM020MappingConfigurationHelpers.HasCustomConstructionOrConversion(invocation, context.SemanticModel))
+        if (MappingConfigurationHelpers.HasCustomConstructionOrConversion(invocation, context.SemanticModel))
         {
             return;
         }
@@ -129,7 +129,7 @@ public class AM001_PropertyTypeMismatchAnalyzer : DiagnosticAnalyzer
             }
 
             // Check if explicit mapping is configured for this property
-            if (AM020MappingConfigurationHelpers.IsDestinationPropertyExplicitlyConfigured(
+            if (MappingConfigurationHelpers.IsDestinationPropertyExplicitlyConfigured(
                     invocation,
                     destProp.Name,
                     context.SemanticModel))

--- a/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM001_PropertyTypeMismatchCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM001_PropertyTypeMismatchCodeFixProvider.cs
@@ -129,7 +129,7 @@ public class AM001_PropertyTypeMismatchCodeFixProvider : AutoMapperCodeFixProvid
                 continue;
             }
 
-            if (AM020MappingConfigurationHelpers.IsDestinationPropertyExplicitlyConfigured(
+            if (MappingConfigurationHelpers.IsDestinationPropertyExplicitlyConfigured(
                     invocation, destProperty.Name, operationContext.SemanticModel))
             {
                 continue;

--- a/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM002_NullableCompatibilityAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM002_NullableCompatibilityAnalyzer.cs
@@ -135,7 +135,7 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
         ITypeSymbol sourceType,
         ITypeSymbol destinationType)
     {
-        if (AM020MappingConfigurationHelpers.HasCustomConstructionOrConversion(invocation, context.SemanticModel))
+        if (MappingConfigurationHelpers.HasCustomConstructionOrConversion(invocation, context.SemanticModel))
         {
             return;
         }
@@ -213,7 +213,7 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
             }
 
             MappableSourceMember? sourceMember =
-                AM020MappingConfigurationHelpers.GetMappableSourceMember(
+                MappingConfigurationHelpers.GetMappableSourceMember(
                     sourceType,
                     destinationProperty.Name);
             if (sourceMember == null)
@@ -339,11 +339,11 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
         if (isConstructorParameterConfiguration)
         {
             string? selectedConstructorParameter =
-                AM020MappingConfigurationHelpers.GetSelectedTopLevelMemberNameWithSemanticModel(
+                MappingConfigurationHelpers.GetSelectedTopLevelMemberNameWithSemanticModel(
                     effectiveMappingCall.ArgumentList.Arguments[0].Expression,
                     semanticModel);
             IReadOnlyList<ITypeSymbol> constructorParameterTypes =
-                AM020MappingConfigurationHelpers.GetConstructorParameterTypes(
+                MappingConfigurationHelpers.GetConstructorParameterTypes(
                     destinationType,
                     sourceType,
                     selectedConstructorParameter ?? string.Empty,
@@ -502,7 +502,7 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
             }
 
             string? configuredConstructorParameterName =
-                AM020MappingConfigurationHelpers.GetSelectedTopLevelMemberNameWithSemanticModel(
+                MappingConfigurationHelpers.GetSelectedTopLevelMemberNameWithSemanticModel(
                     mappingCall.ArgumentList.Arguments[0].Expression,
                     semanticModel);
             if (!string.IsNullOrWhiteSpace(configuredConstructorParameterName))
@@ -563,7 +563,7 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
 
         if (effectiveMemberConfiguration == null)
         {
-            return AM020MappingConfigurationHelpers.HasMappableSourceMember(
+            return MappingConfigurationHelpers.HasMappableSourceMember(
                 sourceType,
                 destinationPropertyName);
         }
@@ -597,7 +597,7 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
                    "ConvertUsing",
                    semanticModel,
                    directExecutionOnly: true) ||
-               AM020MappingConfigurationHelpers.HasMappableSourceMember(
+               MappingConfigurationHelpers.HasMappableSourceMember(
                    sourceType,
                    destinationPropertyName);
     }
@@ -619,7 +619,7 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
                 "ForMember"))
         {
             string? selectedMember =
-                AM020MappingConfigurationHelpers.GetSelectedTopLevelMemberNameWithSemanticModel(
+                MappingConfigurationHelpers.GetSelectedTopLevelMemberNameWithSemanticModel(
                     destinationExpression,
                     semanticModel);
             return string.Equals(
@@ -655,7 +655,7 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
         foreach (string constructorParameterName in configuredConstructorParameterNames)
         {
             bool targetsDestinationProperty =
-                AM020MappingConfigurationHelpers.GetConstructorParameterTypes(
+                MappingConfigurationHelpers.GetConstructorParameterTypes(
                     destinationType,
                     sourceType,
                     constructorParameterName,
@@ -668,7 +668,7 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
             if (!targetsDestinationProperty)
             {
                 string? assignedPropertyName =
-                    AM020MappingConfigurationHelpers.GetDestinationPropertyNameForConstructorParameter(
+                    MappingConfigurationHelpers.GetDestinationPropertyNameForConstructorParameter(
                         destinationType,
                         sourceType,
                         constructorParameterName,
@@ -684,7 +684,7 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
                         return false;
                     }
 
-                    if (!AM020MappingConfigurationHelpers.CanMapDestinationPropertyAfterConstruction(
+                    if (!MappingConfigurationHelpers.CanMapDestinationPropertyAfterConstruction(
                             destinationType,
                             destinationProperty.Name))
                     {
@@ -705,7 +705,7 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
             }
 
             IReadOnlyList<ITypeSymbol> constructorParameterTypes =
-                AM020MappingConfigurationHelpers.GetConstructorParameterTypes(
+                MappingConfigurationHelpers.GetConstructorParameterTypes(
                     destinationType,
                     sourceType,
                     constructorParameterName,
@@ -757,7 +757,7 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
         foreach (string constructorParameterName in configuredConstructorParameterNames)
         {
             string? assignedPropertyName =
-                AM020MappingConfigurationHelpers.GetDestinationPropertyNameForConstructorParameter(
+                MappingConfigurationHelpers.GetDestinationPropertyNameForConstructorParameter(
                     destinationType,
                     sourceType,
                     constructorParameterName,
@@ -772,7 +772,7 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
             }
 
             IReadOnlyList<ITypeSymbol> constructorParameterTypes =
-                AM020MappingConfigurationHelpers.GetConstructorParameterTypes(
+                MappingConfigurationHelpers.GetConstructorParameterTypes(
                     destinationType,
                     sourceType,
                     constructorParameterName,
@@ -830,7 +830,7 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
             }
 
             string? selectedConstructorParameter =
-                AM020MappingConfigurationHelpers.GetSelectedTopLevelMemberNameWithSemanticModel(
+                MappingConfigurationHelpers.GetSelectedTopLevelMemberNameWithSemanticModel(
                     mappingCall.ArgumentList.Arguments[0].Expression,
                     semanticModel);
             if (string.IsNullOrWhiteSpace(selectedConstructorParameter))
@@ -838,7 +838,7 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            if (AM020MappingConfigurationHelpers.GetConstructorParameterTypes(
+            if (MappingConfigurationHelpers.GetConstructorParameterTypes(
                     destinationType,
                     sourceType,
                     selectedConstructorParameter!,
@@ -855,7 +855,7 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
             if (destinationProperty == null)
             {
                 string? assignedPropertyName =
-                    AM020MappingConfigurationHelpers.GetDestinationPropertyNameForConstructorParameter(
+                    MappingConfigurationHelpers.GetDestinationPropertyNameForConstructorParameter(
                         destinationType,
                         sourceType,
                         selectedConstructorParameter!,
@@ -869,7 +869,7 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
             }
 
             if (destinationProperty != null &&
-                !AM020MappingConfigurationHelpers.CanMapDestinationPropertyAfterConstruction(
+                !MappingConfigurationHelpers.CanMapDestinationPropertyAfterConstruction(
                     destinationType,
                     destinationProperty.Name))
             {
@@ -895,7 +895,7 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
         if (MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(mappingCall, semanticModel, "ForMember"))
         {
             string? selectedMember =
-                AM020MappingConfigurationHelpers.GetSelectedTopLevelMemberNameWithSemanticModel(
+                MappingConfigurationHelpers.GetSelectedTopLevelMemberNameWithSemanticModel(
                     destinationExpression,
                     semanticModel);
             return string.Equals(selectedMember, destinationPropertyName, StringComparison.OrdinalIgnoreCase);
@@ -904,7 +904,7 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
         if (MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(mappingCall, semanticModel, "ForCtorParam"))
         {
             string? selectedConstructorParameter =
-                AM020MappingConfigurationHelpers.GetSelectedTopLevelMemberNameWithSemanticModel(
+                MappingConfigurationHelpers.GetSelectedTopLevelMemberNameWithSemanticModel(
                     destinationExpression,
                     semanticModel);
             if (string.Equals(
@@ -912,7 +912,7 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
                     destinationPropertyName,
                     StringComparison.OrdinalIgnoreCase))
             {
-                return AM020MappingConfigurationHelpers.GetConstructorParameterTypes(
+                return MappingConfigurationHelpers.GetConstructorParameterTypes(
                     destinationType,
                     sourceType,
                     selectedConstructorParameter ?? string.Empty,
@@ -920,7 +920,7 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
             }
 
             string? assignedPropertyName =
-                AM020MappingConfigurationHelpers.GetDestinationPropertyNameForConstructorParameter(
+                MappingConfigurationHelpers.GetDestinationPropertyNameForConstructorParameter(
                     destinationType,
                     sourceType,
                     selectedConstructorParameter ?? string.Empty,
@@ -930,7 +930,7 @@ public class AM002_NullableCompatibilityAnalyzer : DiagnosticAnalyzer
                        assignedPropertyName,
                        destinationPropertyName,
                        StringComparison.OrdinalIgnoreCase) &&
-                   !AM020MappingConfigurationHelpers.CanMapDestinationPropertyAfterConstruction(
+                   !MappingConfigurationHelpers.CanMapDestinationPropertyAfterConstruction(
                        destinationType,
                        destinationPropertyName);
         }

--- a/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM002_NullableCompatibilityCodeFixProvider.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM002_NullableCompatibilityCodeFixProvider.cs
@@ -189,7 +189,7 @@ public class AM002_NullableCompatibilityCodeFixProvider : AutoMapperCodeFixProvi
             }
 
             string? constructorParameterName =
-                AM020MappingConfigurationHelpers.GetSelectedTopLevelMemberNameWithSemanticModel(
+                MappingConfigurationHelpers.GetSelectedTopLevelMemberNameWithSemanticModel(
                     existingConfiguration.ArgumentList.Arguments[0].Expression,
                     semanticModel);
             ITypeSymbol[] matchingParameterTypes = namedDestinationType.InstanceConstructors
@@ -347,7 +347,7 @@ public class AM002_NullableCompatibilityCodeFixProvider : AutoMapperCodeFixProvi
                 configurationInvocation.ArgumentList.Arguments.Count > 0)
             {
                 string? configuredConstructorParameterName =
-                    AM020MappingConfigurationHelpers.GetSelectedTopLevelMemberNameWithSemanticModel(
+                    MappingConfigurationHelpers.GetSelectedTopLevelMemberNameWithSemanticModel(
                         configurationInvocation.ArgumentList.Arguments[0].Expression,
                         semanticModel);
                 if (!string.IsNullOrWhiteSpace(configuredConstructorParameterName))
@@ -454,7 +454,7 @@ public class AM002_NullableCompatibilityCodeFixProvider : AutoMapperCodeFixProvi
         if (MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(chainedInvocation, semanticModel, "ForMember"))
         {
             string? selectedMember =
-                AM020MappingConfigurationHelpers.GetSelectedTopLevelMemberNameWithSemanticModel(
+                MappingConfigurationHelpers.GetSelectedTopLevelMemberNameWithSemanticModel(
                     destinationExpression,
                     semanticModel);
             return string.Equals(selectedMember, propertyName, StringComparison.OrdinalIgnoreCase);
@@ -463,7 +463,7 @@ public class AM002_NullableCompatibilityCodeFixProvider : AutoMapperCodeFixProvi
         if (MappingChainAnalysisHelper.IsAutoMapperMethodInvocation(chainedInvocation, semanticModel, "ForCtorParam"))
         {
             string? selectedConstructorParameter =
-                AM020MappingConfigurationHelpers.GetSelectedTopLevelMemberNameWithSemanticModel(
+                MappingConfigurationHelpers.GetSelectedTopLevelMemberNameWithSemanticModel(
                     destinationExpression,
                     semanticModel);
             if (sourceType == null || destinationType == null)
@@ -476,7 +476,7 @@ public class AM002_NullableCompatibilityCodeFixProvider : AutoMapperCodeFixProvi
                     propertyName,
                     StringComparison.OrdinalIgnoreCase))
             {
-                return AM020MappingConfigurationHelpers.GetConstructorParameterTypes(
+                return MappingConfigurationHelpers.GetConstructorParameterTypes(
                     destinationType,
                     sourceType,
                     selectedConstructorParameter ?? string.Empty,
@@ -484,7 +484,7 @@ public class AM002_NullableCompatibilityCodeFixProvider : AutoMapperCodeFixProvi
             }
 
             string? assignedPropertyName =
-                AM020MappingConfigurationHelpers.GetDestinationPropertyNameForConstructorParameter(
+                MappingConfigurationHelpers.GetDestinationPropertyNameForConstructorParameter(
                     destinationType,
                     sourceType,
                     selectedConstructorParameter ?? string.Empty,
@@ -494,7 +494,7 @@ public class AM002_NullableCompatibilityCodeFixProvider : AutoMapperCodeFixProvi
                        assignedPropertyName,
                        propertyName,
                        StringComparison.OrdinalIgnoreCase) &&
-                   !AM020MappingConfigurationHelpers.CanMapDestinationPropertyAfterConstruction(
+                   !MappingConfigurationHelpers.CanMapDestinationPropertyAfterConstruction(
                        destinationType,
                        propertyName);
         }

--- a/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM003_CollectionTypeIncompatibilityAnalyzer.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/TypeSafety/AM003_CollectionTypeIncompatibilityAnalyzer.cs
@@ -114,7 +114,7 @@ public class AM003_CollectionTypeIncompatibilityAnalyzer : DiagnosticAnalyzer
         ITypeSymbol destinationType,
         HashSet<string> reportedMismatches)
     {
-        if (AM020MappingConfigurationHelpers.HasCustomConstructionOrConversion(invocation, context.SemanticModel))
+        if (MappingConfigurationHelpers.HasCustomConstructionOrConversion(invocation, context.SemanticModel))
         {
             return;
         }
@@ -137,7 +137,7 @@ public class AM003_CollectionTypeIncompatibilityAnalyzer : DiagnosticAnalyzer
             }
 
             // Check for explicit property mapping that might handle collection conversion
-            if (AM020MappingConfigurationHelpers.IsDestinationPropertyExplicitlyConfigured(
+            if (MappingConfigurationHelpers.IsDestinationPropertyExplicitlyConfigured(
                     invocation,
                     destinationProperty.Name,
                     context.SemanticModel))

--- a/tests/AutoMapperAnalyzer.Tests/Helpers/MappingConfigurationHelpersTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Helpers/MappingConfigurationHelpersTests.cs
@@ -6,10 +6,10 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace AutoMapperAnalyzer.Tests.Helpers;
 
-public class AM020MappingConfigurationHelpersTests
+public class MappingConfigurationHelpersTests
 {
     private static readonly Type HelperType = typeof(AM020_NestedObjectMappingAnalyzer).Assembly
-        .GetType("AutoMapperAnalyzer.Analyzers.Helpers.AM020MappingConfigurationHelpers")!;
+        .GetType("AutoMapperAnalyzer.Analyzers.Helpers.MappingConfigurationHelpers")!;
 
     private static readonly MethodInfo GetSelectedTopLevelMemberNameMethod = HelperType.GetMethod(
         "GetSelectedTopLevelMemberName",
@@ -92,7 +92,7 @@ public class AM020MappingConfigurationHelpersTests
 
         SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(source);
         CSharpCompilation compilation = CSharpCompilation.Create(
-            "AM020MappingConfigurationHelpersTests",
+            "MappingConfigurationHelpersTests",
             [syntaxTree],
             [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
         SemanticModel semanticModel = compilation.GetSemanticModel(syntaxTree);


### PR DESCRIPTION
Roadmap Tier 2.1, phase C — and the finding is more interesting than the change.

## `AM020MappingConfigurationHelpers` is not AM020-specific

It is consumed by **13 files** spanning AM001, AM002, AM003, AM005, AM006, AM020, AM021, AM022 and their fixers. It has been the de facto shared mapping model for a long time. The name kept announcing otherwise.

**A class that looks like another rule's private helper does not get reused — it gets reimplemented.** That is the most plausible explanation for the duplication removed in #213: AM011 carried its own copies of `ForCtorParam` / `ForMember` ownership checks that this class already provided, while a dozen other files called it directly.

Renamed to `MappingConfigurationHelpers`, so the next person looking for "is this member configured" finds the shared model instead of assuming it belongs to someone else's rule.

## `ShouldStopAtReverseMapBoundary`

Existed twice, byte-identical, in AM005 and in the configuration helpers. Now shared — and it finally carries the reasoning it never had:

> The predicate inverts on a `ReverseMap()` invocation because analysis rooted at the forward map must not read configuration belonging to the reverse mapping, while analysis rooted at `ReverseMap()` is reading exactly that configuration and must continue past it.

That is not obvious from a one-line negation, and it is the kind of thing someone re-derives incorrectly.

## What I deliberately did not do

Extracting a byte-identical one-line predicate is not, on its own, worth a change — it would be churn. It is included here because it belongs to the same coherent point about the shared model being discoverable, not as a standalone "deduplication".

## Validation

- 2435 tests pass **unchanged**; sample-diagnostics trust snapshot **byte-identical**.
- Both analyzer and test projects build with `-warnaserror`.
- Catalog, snapshot, and compatibility checks current.
- No version bump: pure rename plus one predicate move, no diagnostic change.