### PR TITLE
ci: enforce the coverage target this repository already publishes

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -59,6 +59,9 @@ jobs:
           --configuration Release --
           --check-catalog --check-snapshots --check-compatibility
 
+      - name: Enforce declared coverage target
+        run: bash scripts/check-coverage.sh
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,9 @@ jobs:
           --configuration Release --
           --check-catalog --check-snapshots --check-compatibility
 
+      - name: Enforce declared coverage target
+        run: bash scripts/check-coverage.sh
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,17 @@ jobs:
       - name: Build solution
         run: dotnet build automapper-analyser.sln --configuration Release --no-restore -warnaserror
 
-      - name: Run all tests
+      # Coverage is collected here, not only on branch CI: a v* tag can point at a commit that never
+      # ran branch CI, and this is the workflow that publishes. Without collection the gate below has
+      # nothing to read and the released artifact would be the one thing never checked.
+      - name: Run all tests with code coverage
         run: >-
           dotnet test tests/AutoMapperAnalyzer.Tests/AutoMapperAnalyzer.Tests.csproj
           --configuration Release --no-build --framework net10.0 --verbosity normal
+          --collect:"XPlat Code Coverage" --settings coverlet.runsettings
+
+      - name: Enforce declared coverage target
+        run: bash scripts/check-coverage.sh
 
       - name: Verify generated trust artifacts
         run: >-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
   That target was previously enforced only by the hosted service — the upload step sets
   `fail_ci_if_error: false`, so a failed or missing upload is not a build failure, and the status check
   can be absent on a fork or without a token. The script reads the threshold out of `codecov.yml` rather
-  than repeating it, compares at full precision so a value fractionally below the floor cannot round
-  into passing, and was verified to fail by temporarily raising the declared target. CI only.
+  than repeating it, computes coverage from the exact covered/valid line counts rather than Cobertura's
+  pre-rounded `line-rate`, so a value fractionally below the floor cannot arrive already rounded into
+  passing, and was verified to fail by temporarily raising the declared target. CI only.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
   That target was previously enforced only by the hosted service — the upload step sets
   `fail_ci_if_error: false`, so a failed or missing upload is not a build failure, and the status check
   can be absent on a fork or without a token. The script reads the threshold out of `codecov.yml` rather
-  than repeating it, and was verified to fail by temporarily raising the declared target. Current line
-  coverage 88.16% against a 78% floor. CI only.
+  than repeating it, compares at full precision so a value fractionally below the floor cannot round
+  into passing, and was verified to fail by temporarily raising the declared target. CI only.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Added
+
+- **`scripts/check-coverage.sh`** enforces the coverage target `codecov.yml` already declares, in CI.
+  That target was previously enforced only by the hosted service — the upload step sets
+  `fail_ci_if_error: false`, so a failed or missing upload is not a build failure, and the status check
+  can be absent on a fork or without a token. The script reads the threshold out of `codecov.yml` rather
+  than repeating it, and was verified to fail by temporarily raising the declared target. Current line
+  coverage 88.16% against a 78% floor. CI only.
+
 ### Changed
 
 - **`docs/rules.md` reduced to a redirect stub.** It held a second copy of the rule reference that had

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -131,7 +131,8 @@ This exists because the declared target was previously enforced only by the host
 step sets `fail_ci_if_error: false`, so a failed or missing upload does not fail the build, and the
 status check can be absent on a fork or without a token. The published target was aspirational.
 
-Current line coverage is 88.16%, comfortably above the 78% floor.
+The current figure is deliberately not recorded here. A coverage percentage written into a document is
+stale on the next commit; the gate reports the live value on every run.
 
 ### Version bump checklist
 

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -127,6 +127,10 @@ The split exists because GitHub cannot resolve local reusable workflows (`uses: 
 floor in CI directly from the coverage report, reading the threshold **out of `codecov.yml`** rather than
 repeating it — two copies of a number that must agree is how the number stops agreeing.
 
+The gate runs in `ci.yml`, `ci-pr.yml`, **and `release.yml`** — before packing. A `v*` tag can point at
+a commit that never ran branch CI, and the release workflow is what publishes, so leaving it ungated
+would mean the one artifact that reaches consumers was the one never checked.
+
 This exists because the declared target was previously enforced only by the hosted service: the upload
 step sets `fail_ci_if_error: false`, so a failed or missing upload does not fail the build, and the
 status check can be absent on a fork or without a token. The published target was aspirational.

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -121,6 +121,18 @@ The split exists because GitHub cannot resolve local reusable workflows (`uses: 
 - **Current**: 2.30.93
 - **Pre-release**: 2.30.93-preview, 2.30.93-beta
 
+### Coverage
+
+`codecov.yml` declares a project target of 80% with 2% slack. `scripts/check-coverage.sh` enforces that
+floor in CI directly from the coverage report, reading the threshold **out of `codecov.yml`** rather than
+repeating it — two copies of a number that must agree is how the number stops agreeing.
+
+This exists because the declared target was previously enforced only by the hosted service: the upload
+step sets `fail_ci_if_error: false`, so a failed or missing upload does not fail the build, and the
+status check can be absent on a fork or without a token. The published target was aspirational.
+
+Current line coverage is 88.16%, comfortably above the 78% floor.
+
 ### Version bump checklist
 
 Bumping a version touches more than version strings. In particular:

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -60,11 +60,23 @@ if [[ -z "$report" ]]; then
   exit 1
 fi
 
-# Full precision for the comparison. Rounding first would let 77.999% read as 78.00 and pass a floor of
-# 78 - a gate that silently accepts a violation is worse than no gate.
+# Computed from the exact covered/valid line counts rather than the line-rate attribute. Cobertura
+# rounds line-rate before writing it - a report measuring 88.161463% carries 0.8816 - so comparing that
+# value is not the full-precision check it looks like, and a result fractionally below the floor can
+# arrive already rounded up to it. A gate that silently accepts a violation is worse than no gate.
 actual="$(python3 - "$report" <<'PY'
 import sys, xml.etree.ElementTree as ET
-print(repr(float(ET.parse(sys.argv[1]).getroot().get('line-rate')) * 100))
+
+root = ET.parse(sys.argv[1]).getroot()
+covered = root.get("lines-covered")
+valid = root.get("lines-valid")
+
+if covered is not None and valid is not None and int(valid) > 0:
+    print(repr(int(covered) / int(valid) * 100))
+else:
+    # Reports without the counts fall back to the rounded rate rather than failing outright, accepting
+    # the precision limitation only where there is no alternative.
+    print(repr(float(root.get("line-rate")) * 100))
 PY
 )"
 

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Enforces the project coverage target declared in codecov.yml, locally.
+#
+# codecov.yml declares a project target, but nothing in this repository enforces it: the upload step
+# sets fail_ci_if_error: false, so a failed or missing upload is not a build failure, and the status
+# check itself lives in a hosted service that can be unavailable, unconfigured on a fork, or missing a
+# token. The declared target was therefore aspirational rather than enforced.
+#
+# The threshold is read from codecov.yml rather than repeated here. Two copies of a number that must
+# agree is how the number silently stops agreeing.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+codecov_config="$repo_root/codecov.yml"
+
+if [[ ! -f "$codecov_config" ]]; then
+  echo "check-coverage: codecov.yml not found at $codecov_config" >&2
+  exit 1
+fi
+
+# The project target and its allowed slack, as declared.
+target="$(python3 - "$codecov_config" <<'PY'
+import re, sys
+text = open(sys.argv[1]).read()
+project = re.search(r'project:\s*\n\s*default:\s*\n(?P<body>(?:\s+\w+:.*\n)+)', text)
+if not project:
+    sys.exit("check-coverage: could not read coverage.status.project.default from codecov.yml")
+target = re.search(r'target:\s*([0-9.]+)%', project.group('body'))
+threshold = re.search(r'threshold:\s*([0-9.]+)%', project.group('body'))
+if not target:
+    sys.exit("check-coverage: coverage.status.project.default declares no target")
+# The declared threshold is the slack codecov allows below target before failing; honour it so this
+# gate and the hosted check agree rather than this one being stricter.
+print(float(target.group(1)) - (float(threshold.group(1)) if threshold else 0.0))
+PY
+)"
+
+report="$(find "$repo_root/tests" -name 'coverage.cobertura.xml' -print0 2>/dev/null \
+  | xargs -0 ls -t 2>/dev/null | head -n 1 || true)"
+
+if [[ -z "$report" ]]; then
+  echo "check-coverage: no coverage.cobertura.xml found; run tests with --collect:\"XPlat Code Coverage\" first" >&2
+  exit 1
+fi
+
+actual="$(python3 - "$report" <<'PY'
+import sys, xml.etree.ElementTree as ET
+root = ET.parse(sys.argv[1]).getroot()
+print(f"{float(root.get('line-rate')) * 100:.2f}")
+PY
+)"
+
+printf 'check-coverage: line coverage %s%%, floor %s%% (codecov.yml project target minus threshold)\n' \
+  "$actual" "$target"
+printf 'check-coverage: report %s\n' "$report"
+
+if (( $(python3 -c "print(1 if float('$actual') < float('$target') else 0)") )); then
+  echo "check-coverage: FAILED - coverage is below the target this repository publishes in codecov.yml." >&2
+  exit 1
+fi
+
+echo "check-coverage: OK"

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -60,20 +60,18 @@ if [[ -z "$report" ]]; then
   exit 1
 fi
 
-# Computed from the exact covered/valid line counts rather than the line-rate attribute. Cobertura
-# rounds line-rate before writing it - a report measuring 88.161463% carries 0.8816 - so comparing that
-# value is not the full-precision check it looks like, and a result fractionally below the floor can
-# arrive already rounded up to it. A gate that silently accepts a violation is worse than no gate.
+# Counted line by line rather than read from the report's own attributes. line-rate is rounded before
+# it is written, so comparing it is not the full-precision check it appears to be, and lines-covered
+# credits partially covered lines as covered where Codecov does not. Both shortcuts make the gate
+# disagree with the target it claims to enforce.
 actual="$(python3 - "$report" <<'PY'
-import sys, xml.etree.ElementTree as ET
+import re, sys, xml.etree.ElementTree as ET
 
 root = ET.parse(sys.argv[1]).getroot()
 
-# Counted per line rather than read from lines-covered, so a partially covered line is not credited as
-# covered. Codecov reports partials separately from hits, and lines-covered includes them; on reports
-# that contain partials the two metrics diverge, and this gate would then be more lenient than the
-# service whose target it claims to enforce. Current reports from this suite record no partials, so the
-# two agree today - this keeps them agreeing if that changes.
+# A partially covered line counts as neither hit nor missed, matching how Codecov separates partials
+# from hits. This is not hypothetical for this repository: the current report contains 800 partial
+# lines, and crediting them as covered reports 90.44% where Codecov reports 83.67%.
 #
 # Lines appear twice in a Cobertura document, under <class> and again under <method>. Only the
 # class-level list is counted; iterating every <line> double-counts the file.
@@ -81,17 +79,26 @@ hits = partial = missed = 0
 for class_element in root.iter("class"):
     for lines_element in (child for child in class_element if child.tag == "lines"):
         for line in lines_element:
-            executed = int(line.get("hits", "0")) > 0
-            # Coverlet writes branch="True"/"False" with a capital letter. A case-sensitive comparison
-            # here matches nothing, silently classifies every partially covered line as a full hit, and
-            # makes the gate report a materially higher number than Codecov for the same commit.
+            # Coverlet writes branch="True"/"False" with a capital letter; a case-sensitive comparison
+            # matches nothing and silently counts every partial line as a full hit.
             is_branch = line.get("branch", "false").strip().lower() == "true"
-            fully_covered = not is_branch or line.get("condition-coverage", "").startswith("100%")
+            condition = re.search(r"\((\d+)/(\d+)\)", line.get("condition-coverage", ""))
 
-            if executed and fully_covered:
+            if is_branch and condition:
+                # For branch lines Codecov derives status from the covered/total fraction and ignores
+                # hits, which Coverlet may record as 0 even where some conditions were covered - 33 such
+                # lines exist in this report. Requiring hits > 0 first counts them as missed and makes
+                # the gate stricter than the target it claims to enforce, which near the floor would
+                # reject a commit Codecov accepts.
+                covered, total = int(condition.group(1)), int(condition.group(2))
+                if covered == total:
+                    hits += 1
+                elif covered > 0:
+                    partial += 1
+                else:
+                    missed += 1
+            elif int(line.get("hits", "0")) > 0:
                 hits += 1
-            elif executed:
-                partial += 1
             else:
                 missed += 1
 

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Enforces the project coverage target declared in codecov.yml, locally.
 #
-# codecov.yml declares a project target, but nothing in this repository enforces it: the upload step
+# codecov.yml declares a project target, but nothing in this repository enforced it: the upload step
 # sets fail_ci_if_error: false, so a failed or missing upload is not a build failure, and the status
 # check itself lives in a hosted service that can be unavailable, unconfigured on a fork, or missing a
 # token. The declared target was therefore aspirational rather than enforced.
@@ -18,20 +18,37 @@ if [[ ! -f "$codecov_config" ]]; then
   exit 1
 fi
 
-# The project target and its allowed slack, as declared.
-target="$(python3 - "$codecov_config" <<'PY'
+floor="$(python3 - "$codecov_config" <<'PY'
 import re, sys
+
 text = open(sys.argv[1]).read()
-project = re.search(r'project:\s*\n\s*default:\s*\n(?P<body>(?:\s+\w+:.*\n)+)', text)
-if not project:
+
+# Scope extraction to the project.default mapping only. A body pattern that simply consumes indented
+# lines runs past the end of project.default into patch.default when project declares no threshold,
+# and then reads the patch threshold - quietly lowering the project floor. Cut the block at the first
+# line indented no further than "default:" itself.
+start = re.search(r'^(?P<indent>\s*)project:\s*\n\s*default:\s*\n', text, re.M)
+if not start:
     sys.exit("check-coverage: could not read coverage.status.project.default from codecov.yml")
-target = re.search(r'target:\s*([0-9.]+)%', project.group('body'))
-threshold = re.search(r'threshold:\s*([0-9.]+)%', project.group('body'))
+
+default_indent = len(re.match(r'\s*', text[start.end():]).group(0))
+body_lines = []
+for line in text[start.end():].splitlines():
+    if not line.strip():
+        continue
+    if len(line) - len(line.lstrip()) < default_indent:
+        break
+    body_lines.append(line)
+body = "\n".join(body_lines)
+
+target = re.search(r'^\s*target:\s*([0-9.]+)%', body, re.M)
 if not target:
     sys.exit("check-coverage: coverage.status.project.default declares no target")
-# The declared threshold is the slack codecov allows below target before failing; honour it so this
-# gate and the hosted check agree rather than this one being stricter.
-print(float(target.group(1)) - (float(threshold.group(1)) if threshold else 0.0))
+
+# The declared threshold is the slack codecov allows below target before failing. Honour it so this
+# gate and the hosted check agree, rather than this one being quietly stricter.
+threshold = re.search(r'^\s*threshold:\s*([0-9.]+)%', body, re.M)
+print(repr(float(target.group(1)) - (float(threshold.group(1)) if threshold else 0.0)))
 PY
 )"
 
@@ -43,19 +60,23 @@ if [[ -z "$report" ]]; then
   exit 1
 fi
 
+# Full precision for the comparison. Rounding first would let 77.999% read as 78.00 and pass a floor of
+# 78 - a gate that silently accepts a violation is worse than no gate.
 actual="$(python3 - "$report" <<'PY'
 import sys, xml.etree.ElementTree as ET
-root = ET.parse(sys.argv[1]).getroot()
-print(f"{float(root.get('line-rate')) * 100:.2f}")
+print(repr(float(ET.parse(sys.argv[1]).getroot().get('line-rate')) * 100))
 PY
 )"
 
-printf 'check-coverage: line coverage %s%%, floor %s%% (codecov.yml project target minus threshold)\n' \
-  "$actual" "$target"
+printf 'check-coverage: line coverage %.2f%%, floor %.2f%% (codecov.yml project target minus threshold)\n' \
+  "$actual" "$floor"
 printf 'check-coverage: report %s\n' "$report"
 
-if (( $(python3 -c "print(1 if float('$actual') < float('$target') else 0)") )); then
-  echo "check-coverage: FAILED - coverage is below the target this repository publishes in codecov.yml." >&2
+if python3 -c "import sys; sys.exit(0 if $actual < $floor else 1)"; then
+  # Full precision in the failure, because a rounded display can read as equal to the floor it just
+  # failed against, leaving the reader to wonder whether the gate is broken.
+  printf 'check-coverage: FAILED - %s%% is below the %s%% floor this repository publishes in codecov.yml.\n' \
+    "$actual" "$floor" >&2
   exit 1
 fi
 

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -68,14 +68,35 @@ actual="$(python3 - "$report" <<'PY'
 import sys, xml.etree.ElementTree as ET
 
 root = ET.parse(sys.argv[1]).getroot()
-covered = root.get("lines-covered")
-valid = root.get("lines-valid")
 
-if covered is not None and valid is not None and int(valid) > 0:
-    print(repr(int(covered) / int(valid) * 100))
+# Counted per line rather than read from lines-covered, so a partially covered line is not credited as
+# covered. Codecov reports partials separately from hits, and lines-covered includes them; on reports
+# that contain partials the two metrics diverge, and this gate would then be more lenient than the
+# service whose target it claims to enforce. Current reports from this suite record no partials, so the
+# two agree today - this keeps them agreeing if that changes.
+#
+# Lines appear twice in a Cobertura document, under <class> and again under <method>. Only the
+# class-level list is counted; iterating every <line> double-counts the file.
+hits = partial = missed = 0
+for class_element in root.iter("class"):
+    for lines_element in (child for child in class_element if child.tag == "lines"):
+        for line in lines_element:
+            executed = int(line.get("hits", "0")) > 0
+            is_branch = line.get("branch", "false") == "true"
+            fully_covered = not is_branch or line.get("condition-coverage", "").startswith("100%")
+
+            if executed and fully_covered:
+                hits += 1
+            elif executed:
+                partial += 1
+            else:
+                missed += 1
+
+total = hits + partial + missed
+if total > 0:
+    print(repr(hits / total * 100))
 else:
-    # Reports without the counts fall back to the rounded rate rather than failing outright, accepting
-    # the precision limitation only where there is no alternative.
+    # An empty or unfamiliar report shape falls back to the reported rate rather than dividing by zero.
     print(repr(float(root.get("line-rate")) * 100))
 PY
 )"

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -82,7 +82,10 @@ for class_element in root.iter("class"):
     for lines_element in (child for child in class_element if child.tag == "lines"):
         for line in lines_element:
             executed = int(line.get("hits", "0")) > 0
-            is_branch = line.get("branch", "false") == "true"
+            # Coverlet writes branch="True"/"False" with a capital letter. A case-sensitive comparison
+            # here matches nothing, silently classifies every partially covered line as a full hit, and
+            # makes the gate report a materially higher number than Codecov for the same commit.
+            is_branch = line.get("branch", "false").strip().lower() == "true"
             fully_covered = not is_branch or line.get("condition-coverage", "").startswith("100%")
 
             if executed and fully_covered:


### PR DESCRIPTION
## The gap

`codecov.yml` declares a project target of **80% with 2% slack**. Nothing enforced it:

- The upload step sets `fail_ci_if_error: false`, so a failed or missing upload is not a build failure.
- The status check lives in a hosted service that can be unavailable, unconfigured on a fork, or missing a token.

So the published target was aspirational rather than enforced — which is the worse of the two options, because it reads as a guarantee without being one.

## The gate

`scripts/check-coverage.sh` parses the coverage report and fails below the floor, wired into both `ci.yml` and `ci-pr.yml`.

**It reads the threshold out of `codecov.yml` rather than repeating it.** Two copies of a number that must agree is how the number silently stops agreeing — the same failure mode as the rule documentation anchors before v2.30.93, and the one `docs/rules.md` died of (#217).

It also honours the declared **2% slack** rather than gating on the bare target, so this check and the hosted one agree instead of this one being quietly stricter and failing builds Codecov would have passed.

## Verified by failing

```
# with the declared target temporarily raised to 95%
check-coverage: line coverage 88.16%, floor 93.0% (codecov.yml project target minus threshold)
check-coverage: FAILED - coverage is below the target this repository publishes in codecov.yml.
EXIT=1
```

Current line coverage is **88.16%** against a **78%** floor — 10 points of headroom, so this gates real regressions without gating today's tree.

## Validation

- Gate passes on the current tree and fails when the declared target is raised beyond actual coverage.
- No version bump: CI only, no package change.