### PR TITLE
docs: record what enabling Trusted Publishing needs, without breaking publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Documentation
+
+- **Trusted Publishing readiness** in `docs/CI-CD.md`. Publishing still uses a long-lived API key;
+  NuGet.org's OIDC-based Trusted Publishing would remove that stored secret. It is documented rather
+  than enabled because the workflow change alone breaks releases: NuGet issues the short-lived key only
+  against a policy that must already exist on nuget.org, and only the package owner can create it, so
+  switching `release.yml` first would fail every tag at the push step. The exact policy fields and the
+  ready-to-apply workflow diff are recorded so enabling it is a single step once the policy exists.
+
 ## [2.30.95] - 2026-07-29
 
 Corrects the provenance verification instructions shipped in 2.30.94 (no rule ID, severity, or

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -121,6 +121,56 @@ The split exists because GitHub cannot resolve local reusable workflows (`uses: 
 - **Current**: 2.30.95
 - **Pre-release**: 2.30.95-preview, 2.30.95-beta
 
+### Trusted Publishing (not enabled — requires an account-side policy first)
+
+Publishing currently uses a long-lived API key in `secrets.NUGET_API_KEY`. NuGet.org supports Trusted
+Publishing, which replaces that with a short-lived OIDC-issued key, removing the stored secret entirely.
+
+**This is deliberately not wired up**, because the workflow change alone would break releases. NuGet
+issues the temporary key only when an incoming OIDC token matches a policy that must already exist on
+nuget.org, and only the package owner can create it. Switching `release.yml` first would mean the next
+tag builds, tests, verifies compatibility, and then fails at the push step.
+
+**Step 1 — create the policy (nuget.org, owner only).** Sign in, open the account menu → *Trusted
+Publishing*, and add a policy:
+
+| Field | Value |
+| --- | --- |
+| Repository Owner | `georgepwall1991` |
+| Repository | `automapper-analyser` |
+| Workflow File | `release.yml` (file name only, no path) |
+| Environment | leave empty — this workflow uses no GitHub environment |
+
+If the *Trusted Publishing* option is absent, the feature has not reached the account yet; it is being
+rolled out gradually. Policies on private repositories start in a 7-day provisional state and become
+permanent after the first successful publish.
+
+**Step 2 — apply this change to the publish job in `release.yml`:**
+
+```yaml
+    permissions:
+      contents: read
+      id-token: write        # OIDC token issuance for the token exchange
+
+    steps:
+      - name: NuGet login (OIDC to short-lived key)
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: ${{ secrets.NUGET_USER }}   # nuget.org profile name, not an email address
+
+      - name: Publish exact verified package to NuGet
+        run: >-
+          dotnet nuget push "${{ steps.package.outputs.path }}"
+          --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
+          --source https://api.nuget.org/v3/index.json
+          --skip-duplicate
+```
+
+The issued key lasts one hour and is single-use, so the login step must stay immediately before the
+push rather than early in the job. `secrets.NUGET_API_KEY` can be deleted once a release has published
+successfully this way.
+
 ### Coverage
 
 `codecov.yml` declares a project target of 80% with 2% slack. `scripts/check-coverage.sh` enforces that

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -145,31 +145,46 @@ If the *Trusted Publishing* option is absent, the feature has not reached the ac
 rolled out gradually. Policies on private repositories start in a 7-day provisional state and become
 permanent after the first successful publish.
 
-**Step 2 — apply this change to the publish job in `release.yml`:**
+**Step 2 — add `NUGET_USER`** to repository secrets: the nuget.org *profile name*, not an email
+address. `NuGet/login@v1` requires it and fails the login if it is empty.
+
+**Step 3 — edit the `publish` job in `release.yml`.** Three edits, not a wholesale replacement — the
+job already has `steps:` including the checkout and artifact download that produce
+`steps.package.outputs.path`.
+
+Add a job-level `permissions` block. Job-level permissions **replace** the workflow defaults rather
+than adding to them, so `contents: write` must be restated: the same job creates the GitHub release
+with `softprops/action-gh-release`, which fails without it.
 
 ```yaml
+  publish:
+    name: Publish verified package
+    needs: [package, compatibility]
+    runs-on: ubuntu-latest
     permissions:
-      contents: read
-      id-token: write        # OIDC token issuance for the token exchange
+      contents: write      # required by the GitHub release step later in this job
+      id-token: write      # OIDC token issuance for the NuGet token exchange
+```
 
-    steps:
+Insert the login step immediately before the existing push step. The issued key is single-use and
+expires after an hour, so it must not be requested earlier in the job:
+
+```yaml
       - name: NuGet login (OIDC to short-lived key)
         uses: NuGet/login@v1
         id: nuget-login
         with:
-          user: ${{ secrets.NUGET_USER }}   # nuget.org profile name, not an email address
-
-      - name: Publish exact verified package to NuGet
-        run: >-
-          dotnet nuget push "${{ steps.package.outputs.path }}"
-          --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
-          --source https://api.nuget.org/v3/index.json
-          --skip-duplicate
+          user: ${{ secrets.NUGET_USER }}
 ```
 
-The issued key lasts one hour and is single-use, so the login step must stay immediately before the
-push rather than early in the job. `secrets.NUGET_API_KEY` can be deleted once a release has published
-successfully this way.
+Then change only the `--api-key` argument of the existing push step, leaving the rest as-is:
+
+```yaml
+          --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
+```
+
+`NUGET_API_KEY` can be deleted from repository secrets once a release has published successfully this
+way.
 
 ### Coverage
 
@@ -209,7 +224,8 @@ Configure these in GitHub repository settings:
 
 | Secret | Description | Required For |
 |--------|-------------|--------------|
-| `NUGET_API_KEY` | NuGet.org API key for publishing | Release pipeline |
+| `NUGET_API_KEY` | NuGet.org API key for publishing. Removable after migrating to Trusted Publishing | Release pipeline |
+| `NUGET_USER` | nuget.org profile name (not an email address). Only needed after migrating to Trusted Publishing | Release pipeline, post-migration |
 | `CODECOV_TOKEN` | Codecov upload token | Coverage reporting |
 
 ### Environment Variables


### PR DESCRIPTION
Final roadmap item — documented rather than implemented, for a specific reason.

## Why not just enable it

Publishing uses a long-lived API key in `secrets.NUGET_API_KEY`. Trusted Publishing would replace it with a short-lived OIDC-issued key and remove the stored secret entirely. That is worth having.

But **the workflow change alone breaks releases.** NuGet issues the temporary key only when the incoming OIDC token matches a policy that *already exists on nuget.org*, and only the package owner can create that policy through the website. Switching `release.yml` first means the next tag builds, tests, passes the compatibility matrix, attests provenance — and then fails at the push step.

That would break the pipeline that published eight versions today, in exchange for nothing until someone signs in and completes a form I cannot reach.

## What this adds instead

`docs/CI-CD.md` now carries the exact enabling steps:

- The policy fields for this repository (owner `georgepwall1991`, repo `automapper-analyser`, workflow file `release.yml` — **file name only**, no environment).
- The ready-to-apply workflow diff.
- The constraint that the login step must sit **immediately before** the push, because the issued key is single-use and expires after an hour.
- That the feature is rolling out gradually and may simply be absent from the account — making this wait-and-retry rather than a task.

Enabling it becomes a single step once the policy exists.

## Verified, not remembered

I checked the requirements against Microsoft's current documentation rather than relying on what I recalled — including the file-name-only detail and the single-use key lifetime, both of which are easy to get wrong from memory.

## Validation

- 2441 tests green. Documentation only; no workflow, package, or analyzer change.