### PR TITLE
perf: cache the configuration chain walk once per mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+### Changed
+
+- **Configuration chain walk cached per mapping.** Callers ask "is this destination member configured?"
+  once per member, and each question re-walked the whole fluent chain binding every call in it — M
+  configuration calls against M members meant M-squared semantic binds for an answer that does not change
+  between questions.
+
+  Measured before and after with equal sampling (n=5 each): a 60-`ForMember` fixture improves from
+  5.12x to **3.82x** its compile cost with non-overlapping ranges, and the gap between 60-call and
+  20-call fixtures halves from 3.10 to 1.97. Short chains are ~18% worse (1.65x to 1.94x) because there
+  is little to memoise and the lookup costs more than the walk — a deliberate trade, recorded rather
+  than omitted.
+
+  Behaviour is unchanged: 2441 tests pass and the sample-diagnostics trust snapshot is byte-identical.
+
 ### Documentation
 
 - **Trusted Publishing readiness** in `docs/CI-CD.md`. Publishing still uses a long-lived API key;

--- a/docs/TEST_LIMITATIONS.md
+++ b/docs/TEST_LIMITATIONS.md
@@ -59,12 +59,19 @@ walks the fluent chain from its `CreateMap`, so a profile with many `ForMember` 
 chain once per member. Compile cost scales roughly linearly across 2 → 20 → 60 calls while analysis does
 not (2.1x → 2.1x → 4.0x–5.0x).
 
-That is the evidence for the remaining phase of the shared mapping model: caching member-configuration
-state once per `CreateMap` instead of re-deriving it per member. It is **not yet done**, because the
-absolute cost stays well inside budget at realistic profile sizes and the refactor changes shared
-semantics across AM001/AM002/AM003/AM020/AM021 where the golden snapshot is the only safety net. The
-measurement is recorded here so the trend is monitored rather than rediscovered, and so the decision to
-defer is reviewable rather than implicit. The budget is **20x**, roughly 3x above the noisy high, to catch an order-of-magnitude
+That measurement motivated caching the configuration chain walk once per `CreateMap` instead of
+re-deriving it for every member. Measured before and after with equal sampling (n=5 each):
+
+| Fixture | Before | After |
+| --- | --- | --- |
+| 60 `ForMember` calls | 5.12x (4.55–5.68) | **3.82x (3.37–4.16)** |
+| 20 `ForMember` calls | 1.65x (1.49–1.81) | 1.94x (1.77–2.08) |
+| Scaling gap (60/20) | 3.10 | **1.97** |
+
+The long-chain case improves 25% with non-overlapping ranges, and the superlinearity roughly halves.
+Short chains are about 18% worse: there is little to memoise, so the lookup costs more than the walk it
+replaces. That trade is deliberate — the budget exists to bound the pathological case, and the absolute
+cost on short chains is small — but it is a real regression and is recorded rather than omitted. The budget is **20x**, roughly 3x above the noisy high, to catch an order-of-magnitude
 regression without firing on runner noise. Tighten only with evidence from a quiet machine.
 
 ## Generated type-shape coverage

--- a/src/AutoMapperAnalyzer.Analyzers/Helpers/MappingConfigurationHelpers.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Helpers/MappingConfigurationHelpers.cs
@@ -537,10 +537,35 @@ internal static class MappingConfigurationHelpers
                 StringComparison.OrdinalIgnoreCase));
     }
 
-    private static IEnumerable<InvocationExpressionSyntax> GetMappingConfigurationCalls(
+    /// <summary>
+    ///     Per-mapping memo of the configuration calls in a fluent chain.
+    ///     <para>
+    ///     Callers ask "is this destination member configured?" once per member, and each question
+    ///     re-walked the whole chain binding every call in it. For a profile with M configuration calls
+    ///     and M members that is M-squared semantic binds for an answer that does not change between
+    ///     questions. Measured on a 60-call fixture, analysis cost roughly 5x its compile time while a
+    ///     20-call fixture cost under 2x - the gap is this walk.
+    ///     </para>
+    ///     <para>
+    ///     Keyed on the CreateMap syntax node, which belongs to one compilation and pairs with one
+    ///     semantic model, so a cached list can never be read against a different compilation. Entries
+    ///     are collected with their syntax tree. GetValue is atomic, which matters because analyzers run
+    ///     concurrently; a race produces a duplicate computation of the same list, never a wrong one.
+    ///     </para>
+    /// </summary>
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<
+        InvocationExpressionSyntax,
+        IReadOnlyList<InvocationExpressionSyntax>> ConfigurationCallCache = new();
+
+    private static IReadOnlyList<InvocationExpressionSyntax> GetMappingConfigurationCalls(
         InvocationExpressionSyntax createMapInvocation,
         SemanticModel semanticModel)
     {
+        if (ConfigurationCallCache.TryGetValue(createMapInvocation, out IReadOnlyList<InvocationExpressionSyntax>? cached))
+        {
+            return cached;
+        }
+
         var mappingCalls = new List<InvocationExpressionSyntax>();
 
         foreach (InvocationExpressionSyntax invocation in MappingChainAnalysisHelper.GetScopedChainInvocations(
@@ -556,7 +581,8 @@ internal static class MappingConfigurationHelpers
             }
         }
 
-        return mappingCalls;
+        IReadOnlyList<InvocationExpressionSyntax> result = mappingCalls;
+        return ConfigurationCallCache.GetValue(createMapInvocation, _ => result);
     }
 
     public static string? GetSelectedTopLevelMemberName(SyntaxNode expression)

--- a/src/AutoMapperAnalyzer.Analyzers/Helpers/MappingConfigurationHelpers.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Helpers/MappingConfigurationHelpers.cs
@@ -543,25 +543,38 @@ internal static class MappingConfigurationHelpers
     ///     Callers ask "is this destination member configured?" once per member, and each question
     ///     re-walked the whole chain binding every call in it. For a profile with M configuration calls
     ///     and M members that is M-squared semantic binds for an answer that does not change between
-    ///     questions. Measured on a 60-call fixture, analysis cost roughly 5x its compile time while a
-    ///     20-call fixture cost under 2x - the gap is this walk.
+    ///     questions.
     ///     </para>
     ///     <para>
-    ///     Keyed on the CreateMap syntax node, which belongs to one compilation and pairs with one
-    ///     semantic model, so a cached list can never be read against a different compilation. Entries
-    ///     are collected with their syntax tree. GetValue is atomic, which matters because analyzers run
-    ///     concurrently; a race produces a duplicate computation of the same list, never a wrong one.
+    ///     Keyed by compilation first, then by syntax node. Roslyn does not tie a syntax node to one
+    ///     compilation - an IDE reuses an unchanged tree across snapshots when a reference or another
+    ///     document changes - so a node-only key would serve results computed against a previous
+    ///     semantic model. A call that did not resolve as an AutoMapper method before a reference was
+    ///     added would stay cached as "not configuration", and the rules reading this would report
+    ///     stale diagnostics. Tests would not catch it, because a test builds one compilation.
+    ///     </para>
+    ///     <para>
+    ///     Both levels are weak, so entries are collected with their compilation and syntax tree.
+    ///     GetValue is atomic, which matters because analyzers run concurrently; a race duplicates a
+    ///     computation rather than producing a wrong result.
     ///     </para>
     /// </summary>
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<
-        InvocationExpressionSyntax,
-        IReadOnlyList<InvocationExpressionSyntax>> ConfigurationCallCache = new();
+        Compilation,
+        System.Runtime.CompilerServices.ConditionalWeakTable<
+            InvocationExpressionSyntax,
+            IReadOnlyList<InvocationExpressionSyntax>>> ConfigurationCallCache = new();
 
     private static IReadOnlyList<InvocationExpressionSyntax> GetMappingConfigurationCalls(
         InvocationExpressionSyntax createMapInvocation,
         SemanticModel semanticModel)
     {
-        if (ConfigurationCallCache.TryGetValue(createMapInvocation, out IReadOnlyList<InvocationExpressionSyntax>? cached))
+        System.Runtime.CompilerServices.ConditionalWeakTable<
+            InvocationExpressionSyntax,
+            IReadOnlyList<InvocationExpressionSyntax>> perCompilation =
+            ConfigurationCallCache.GetValue(semanticModel.Compilation, _ => new());
+
+        if (perCompilation.TryGetValue(createMapInvocation, out IReadOnlyList<InvocationExpressionSyntax>? cached))
         {
             return cached;
         }
@@ -582,7 +595,7 @@ internal static class MappingConfigurationHelpers
         }
 
         IReadOnlyList<InvocationExpressionSyntax> result = mappingCalls;
-        return ConfigurationCallCache.GetValue(createMapInvocation, _ => result);
+        return perCompilation.GetValue(createMapInvocation, _ => result);
     }
 
     public static string? GetSelectedTopLevelMemberName(SyntaxNode expression)


### PR DESCRIPTION
Final roadmap item — `MappingModel` phase D, which I had previously measured and deferred.

## The cost

Callers ask *"is this destination member configured?"* once per member. Each question re-walked the whole fluent chain, binding every call in it. With M configuration calls and M members that is **M² semantic binds** for an answer that cannot change between questions.

Eight call sites do this inside per-member loops: AM001, AM003, AM005, AM020, AM021 and their fixers.

## Measured before and after, n=5 each

| Fixture | Before | After |
| --- | --- | --- |
| 60 `ForMember` calls | 5.12x (4.55–5.68) | **3.82x (3.37–4.16)** |
| 20 `ForMember` calls | 1.65x (1.49–1.81) | 1.94x (1.77–2.08) |
| Scaling gap (60/20) | 3.10 | **1.97** |

The long-chain case improves **25% with non-overlapping ranges**, and the superlinearity this targets roughly halves.

**Short chains are ~18% worse** — there is little to memoise at that size, so the lookup costs more than the walk it replaces. That is a real regression, it is in the changelog, and the trade is deliberate: the budget exists to bound the pathological case and the absolute cost on short chains is small.

I re-measured the baseline at n=5 rather than reusing my earlier n=3 numbers, so the comparison is like-for-like.

## Behaviour unchanged — and the evidence for it

2441 tests pass and **`sample-diagnostics.json` is byte-identical**. That snapshot captures every diagnostic the samples project produces, so it would move if any ownership decision had shifted. For a change touching logic shared by five analyzers, that is the assertion worth leaning on.

## Cache correctness (review caught this)

My first version keyed the cache on the syntax node alone, with a comment asserting a node "belongs to one compilation and pairs with one semantic model". **That is false.** Roslyn reuses an unchanged tree across compilations — an IDE does exactly this when a reference or another document changes — so the cache could serve results bound against a previous semantic model and the rules reading it would report stale diagnostics.

Now keyed by `Compilation` first, then syntax node, both levels weak so entries are collected with their compilation and tree.

### No regression test, stated plainly

I could not write one that demonstrates the original bug. The obvious construction — same tree in a compilation without the AutoMapper reference, then one with it — never populates the cache on the first pass, because the analyzers bail at `IsCreateMapInvocation` before reaching the chain walk. That test passed with the fix **and** passed with the key deliberately made compilation-agnostic, so it discriminates nothing and is not included.

A test that cannot fail is worse than no test. The fix ships on the reasoning, and this says so rather than implying coverage that does not exist.

## Validation

- 2441 tests green; both projects build with `-warnaserror`; catalog, snapshot, and compatibility checks current.
