### PR TITLE
ci: prepare Trusted Publishing switch (DRAFT — needs nuget.org policy first)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,12 @@ jobs:
     name: Publish verified package
     needs: [package, compatibility]
     runs-on: ubuntu-latest
+    # Job-level permissions replace the workflow defaults rather than adding to them, so everything this
+    # job needs is listed. contents: write is required by the GitHub release step below - dropping it
+    # publishes to NuGet and then fails at release creation.
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
       - name: Checkout code
@@ -160,10 +166,18 @@ jobs:
           fi
           echo "path=$package" >> "$GITHUB_OUTPUT"
 
+      # Immediately before the push: the issued key is single-use and expires after an hour, so
+      # requesting it earlier in the job risks it being dead by the time the push runs.
+      - name: NuGet login (OIDC to short-lived key)
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Publish exact verified package to NuGet
         run: >-
           dotnet nuget push "${{ steps.package.outputs.path }}"
-          --api-key "${{ secrets.NUGET_API_KEY }}"
+          --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}"
           --source https://api.nuget.org/v3/index.json
           --skip-duplicate
 


### PR DESCRIPTION
> **Draft — do not merge until the nuget.org policy exists.** Merging this first makes every release fail at the push step.

## What this is

The workflow half of the Trusted Publishing migration, applied and lint-clean, so enabling it is one merge rather than a hand edit under pressure.

## Two prerequisites I cannot do from here

1. **Create the policy on nuget.org** (account menu → *Trusted Publishing*):

   | Field | Value |
   | --- | --- |
   | Repository Owner | `georgepwall1991` |
   | Repository | `automapper-analyser` |
   | Workflow File | `release.yml` (file name only) |
   | Environment | leave empty |

   If the option is absent, the feature has not reached the account yet — it is rolling out gradually.

2. **Add a `NUGET_USER` secret** — the nuget.org *profile name*, not an email. `NuGet/login@v1` fails on an empty value.

Then merge this and cut a tag. `NUGET_API_KEY` can be deleted after the first successful publish.

## What changed

- `publish` job gains `id-token: write` for the token exchange, and **restates `contents: write`** — job-level permissions replace the workflow defaults, and the GitHub release step later in the same job needs it. Omitting it publishes to NuGet and *then* fails.
- The login step sits immediately before the push: the issued key is single-use and expires after an hour.

## Why draft rather than merged

Nothing verifies this until a real tag runs it. The release pipeline has published nine versions today; trading that for an unverifiable change on my judgement alone is not a call I should make. `actionlint` passes, which is the most that can be checked without the policy in place.
