### PR TITLE
test: execute 12 fixers against AutoMapper instead of comparing their text

### DIFF
--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -31,7 +31,7 @@ tests; each answers a question those tests cannot:
 | Source | Question it answers | State |
 | --- | --- | --- |
 | `--scan-corpus` (`tools/AnalyzerVerifier`) | What do the rules say about code we did not write? | Tool works and found the AM041 defect. **No CI job** — see `docs/TEST_LIMITATIONS.md` |
-| `CodeFixRuntimeVerifier` | Does fixer output actually configure a mapper AutoMapper accepts? | Harness proven; **rollout across the 16 fixers is partial** |
+| `CodeFixRuntimeVerifier` + `FixerRuntimeContractTests` | Does fixer output actually configure a mapper — and map the right values? | 12 of 16 fixers routed through their real analyzer and fixer, every offered action executed; AM022/AM030/AM031/AM060 outstanding |
 | `AnalyzerCrashSafetyTests` | Does any analyzer throw on half-typed or error-laden code? | 20 hostile inputs plus a cyclic graph; no crashes on this tree |
 | `GeneratedTypeShapeTests` | Do invariants hold across the shape space, not just sampled points? | ~590 generated mappings; invariants only, never expected diagnostics |
 
@@ -128,9 +128,11 @@ sources rather than the rules, because that is where this batch's two defects ac
    job, because AutoMapper's own MIT extension repositories do not compile from a clean checkout at a
    pinned SHA — they reference `AutoMapper.Internal`, absent from the `[15.0.1, 17.0.0)` range their
    manifests select. One buildable target turns this from a manual tool into a standing check.
-2. **Extend runtime fix verification** across the remaining fixers. All 16 are otherwise verified by
-   string equality against expected text, which cannot distinguish a fix AutoMapper accepts from one that
-   merely looks right — the 2.30.83 `Stack<T>` ordering defect was exactly that.
+2. **Route the last four fixers** (AM022, AM030, AM031, AM060) through `FixerRuntimeContractTests`.
+   Twelve are now executed rather than string-compared. Note what that rollout exposed: configuration
+   validity alone discriminates for only four of the twelve rules, because AutoMapper accepts the
+   *unfixed* configuration for the rest — so any extension needs value-level expectations, not just
+   `AssertConfigurationIsValid()`, or it asserts nothing about what the fixer emitted.
 3. Advance AM001, AM002, or AM022 only when a concrete compiling false positive/negative proves the gap.
 
 A reproducible false negative that is knowingly deferred is not the same as a clean queue, and this

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -31,7 +31,7 @@ tests; each answers a question those tests cannot:
 | Source | Question it answers | State |
 | --- | --- | --- |
 | `--scan-corpus` (`tools/AnalyzerVerifier`) | What do the rules say about code we did not write? | Tool works and found the AM041 defect. **No CI job** — see `docs/TEST_LIMITATIONS.md` |
-| `CodeFixRuntimeVerifier` + `FixerRuntimeContractTests` | Does fixer output actually configure a mapper — and map the right values? | 12 of 16 fixers routed through their real analyzer and fixer, every offered action executed; AM022/AM030/AM031/AM060 outstanding |
+| `CodeFixRuntimeVerifier` + `FixerRuntimeContractTests` | Does fixer output actually configure a mapper — and map the right values? | 12 of 16 fixers routed through their real analyzer and fixer, every offered action executed, coverage tracked per fixer *branch* rather than per rule; AM022/AM030/AM031/AM060 outstanding |
 | `AnalyzerCrashSafetyTests` | Does any analyzer throw on half-typed or error-laden code? | 20 hostile inputs plus a cyclic graph; no crashes on this tree |
 | `GeneratedTypeShapeTests` | Do invariants hold across the shape space, not just sampled points? | ~590 generated mappings; invariants only, never expected diagnostics |
 

--- a/docs/TEST_LIMITATIONS.md
+++ b/docs/TEST_LIMITATIONS.md
@@ -160,18 +160,24 @@ AM011 fixer end to end, executing what it produces rather than comparing it to t
 AM020, AM021, AM041, AM050, AM061 — through their real analyzer and real fixer, applies **every**
 non-advisory action the lightbulb offers, and executes the result.
 
+Coverage is per *branch*, not per rule. AM021 has two scenarios because its `List<T>` conversion and its
+`Stack<T>` conversion are different fixer branches, and only the second appends `.Reverse()`. A
+`List<T>` scenario stays green if the LIFO correction regresses, so it cannot be the thing that guards
+2.30.83 — the `Stack<T>` scenario asserts pop order and fails when that order inverts.
+
 Two things about that check are worth stating precisely, because the obvious version of it asserts less
 than it appears to. First, `AssertConfigurationIsValid()` **does not discriminate for most of these
 rules**: feeding the harness unfixed source fails only AM006, AM011, AM020, and AM041, because AutoMapper
 accepts the pre-fix configuration for the other eight. Configuration validity alone would therefore have
 passed whatever those eight fixers emitted. So actions that convert, rename, substitute a default, or
 delete a registration carry **value-level** expectations instead, executed through `MapThroughFixedCode`
-— `"42"` must arrive as `42`, `[1,2,3]` must arrive as `["1","2","3"]` in that order, a null source must
-arrive as the substituted default, and removing a duplicate or redundant registration must leave the
-member still mapping.
+— `"42"` must arrive as `42`, a `Stack<int>` popping `3,2,1` must arrive as a `Stack<string>` popping
+`"3","2","1"`, a null source must arrive as the substituted default, and removing a duplicate or
+redundant registration must leave the member still mapping.
 
 Second, both layers were verified by being made to fail: substituting unfixed source for fixer output
-fails 4 of 12, and inverting three expected values fails exactly those 3.
+fails 4 of 12, inverting three expected values fails exactly those 3, and inverting the expected stack
+pop order fails the `Stack<T>` scenario alone.
 
 **Rollout remains partial.** Four fixers are not yet routed through it — AM022, AM030, AM031, AM060 —
 and each scenario is a minimal single-defect case, so this checks fixer output on clean inputs rather

--- a/docs/TEST_LIMITATIONS.md
+++ b/docs/TEST_LIMITATIONS.md
@@ -156,8 +156,26 @@ conversion behaviour can be asserted on real values.
 compile, output AutoMapper rejects semantically, and incorrect `Stack<T>` ordering — and runs the real
 AM011 fixer end to end, executing what it produces rather than comparing it to text.
 
-**Rollout is partial.** The harness exists and is proven; the 16 shipped fixers are not yet all routed
-through it. Extending coverage fixer by fixer is follow-on work.
+`FixerRuntimeContractTests` routes twelve rules — AM001, AM002, AM003, AM004, AM005, AM006, AM011,
+AM020, AM021, AM041, AM050, AM061 — through their real analyzer and real fixer, applies **every**
+non-advisory action the lightbulb offers, and executes the result.
+
+Two things about that check are worth stating precisely, because the obvious version of it asserts less
+than it appears to. First, `AssertConfigurationIsValid()` **does not discriminate for most of these
+rules**: feeding the harness unfixed source fails only AM006, AM011, AM020, and AM041, because AutoMapper
+accepts the pre-fix configuration for the other eight. Configuration validity alone would therefore have
+passed whatever those eight fixers emitted. So actions that convert, rename, substitute a default, or
+delete a registration carry **value-level** expectations instead, executed through `MapThroughFixedCode`
+— `"42"` must arrive as `42`, `[1,2,3]` must arrive as `["1","2","3"]` in that order, a null source must
+arrive as the substituted default, and removing a duplicate or redundant registration must leave the
+member still mapping.
+
+Second, both layers were verified by being made to fail: substituting unfixed source for fixer output
+fails 4 of 12, and inverting three expected values fails exactly those 3.
+
+**Rollout remains partial.** Four fixers are not yet routed through it — AM022, AM030, AM031, AM060 —
+and each scenario is a minimal single-defect case, so this checks fixer output on clean inputs rather
+than the full matrix each fixer supports.
 
 ## Documented analyzer boundaries
 

--- a/tests/AutoMapperAnalyzer.Tests/Infrastructure/FixerRuntimeContractTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Infrastructure/FixerRuntimeContractTests.cs
@@ -533,9 +533,58 @@ public class FixerRuntimeContractTests
             PopulateSource = type => Populate(type, ("Values", new List<int> { 1, 2, 3 })),
             Behaviours = new Dictionary<string, Action<object>>(StringComparer.Ordinal)
             {
-                // The 2.30.83 defect exactly: compile-clean, text-identical to expectation, wrong order.
+                // The .ToList() branch. Ordering is incidental here; the Stack<T> scenario below is
+                // the one that guards the 2.30.83 LIFO defect.
                 ["AM021_SimpleConversion"] = mapped =>
                     Assert.Equal(["1", "2", "3"], StringsOf(Property(mapped, "Values"))),
+            },
+        },
+        ["AM021 stack element mismatch"] = new(
+            () => new AM021_CollectionElementMismatchAnalyzer(),
+            () => new AM021_CollectionElementMismatchCodeFixProvider(),
+            """
+            using System.Collections.Generic;
+            using AutoMapper;
+
+            namespace TestNamespace
+            {
+                public class Source
+                {
+                    public Stack<int> Values { get; set; } = new Stack<int>();
+                }
+
+                public class Destination
+                {
+                    public Stack<string> Values { get; set; } = new Stack<string>();
+                }
+
+                public class TestProfile : Profile
+                {
+                    public TestProfile()
+                    {
+                        CreateMap<Source, Destination>();
+                    }
+                }
+            }
+            """,
+            []
+        )
+        {
+            PopulateSource = type =>
+            {
+                var values = new Stack<int>();
+                values.Push(1);
+                values.Push(2);
+                values.Push(3);
+                return Populate(type, ("Values", values));
+            },
+            Behaviours = new Dictionary<string, Action<object>>(StringComparer.Ordinal)
+            {
+                // The 2.30.83 defect exactly. It lives in the fixer's Stack<T> branch, which appends
+                // .Reverse() - a branch the List<T> scenario above never selects, so only this one
+                // fails if the LIFO correction regresses. Source pops 3,2,1; so must the destination.
+                ["AM021_SimpleConversion"] = mapped =>
+                    Assert.Equal(["3", "2", "1"], StringsOf(Property(mapped, "Values"))),
             },
         },
         ["AM041 duplicate mapping"] = new(

--- a/tests/AutoMapperAnalyzer.Tests/Infrastructure/FixerRuntimeContractTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Infrastructure/FixerRuntimeContractTests.cs
@@ -1,0 +1,660 @@
+using System.Collections.Immutable;
+using AutoMapperAnalyzer.Analyzers.ComplexMappings;
+using AutoMapperAnalyzer.Analyzers.Configuration;
+using AutoMapperAnalyzer.Analyzers.DataIntegrity;
+using AutoMapperAnalyzer.Analyzers.TypeSafety;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace AutoMapperAnalyzer.Tests.Infrastructure;
+
+/// <summary>
+///     Runs each fixer for real and executes what it produced against AutoMapper.
+///     <para>
+///     Every other fixer test in this repository compares the fixed document to expected text. That
+///     cannot distinguish a fix AutoMapper accepts from one that merely looks like the string the test
+///     author wrote down - the 2.30.83 <c>Stack&lt;T&gt;</c> ordering defect passed exactly that check.
+///     <see cref="CodeFixRuntimeVerificationTests" /> closed the gap for AM011 only; this generalises it.
+///     </para>
+///     <para>
+///     Each scenario is minimal: its only defect is the one the rule reports. So the contract is strict
+///     - <b>every</b> offered action must produce code that compiles and configures a mapper AutoMapper
+///     accepts. Actions that deliberately cannot meet that (advisory scaffolds which leave work for a
+///     human) are named in <see cref="FixerScenario.AdvisoryKeyFragments" /> with the reason, rather than
+///     the assertion being loosened for everything.
+///     </para>
+/// </summary>
+public class FixerRuntimeContractTests
+{
+    public static TheoryData<string> ScenarioNames()
+    {
+        var data = new TheoryData<string>();
+        foreach (string name in Scenarios.Keys)
+        {
+            data.Add(name);
+        }
+
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(ScenarioNames))]
+    public async Task EveryOfferedFix_ShouldProduceAMapperAutoMapperAccepts(string scenarioName)
+    {
+        FixerScenario scenario = Scenarios[scenarioName];
+
+        Document document = AggregateFixTestHarness.CreateDocument(
+            scenario.Source,
+            "FixerRuntimeContract"
+                + scenarioName.Replace(" ", string.Empty).Replace("/", string.Empty)
+        );
+
+        ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsAsync(
+            document,
+            scenario.CreateAnalyzer()
+        );
+
+        Assert.True(
+            diagnostics.Length > 0,
+            $"{scenarioName}: the scenario reported no diagnostic, so it verifies nothing."
+        );
+
+        IReadOnlyList<CodeFixActionInspector.ActionInfo> actions =
+            await CodeFixActionInspector.GetActionsAsync(
+                document,
+                scenario.CreateProvider(),
+                diagnostics
+            );
+
+        // A leaf action is one a user can actually invoke; parents only open a sub-menu.
+        List<string> applicableKeys = actions
+            .Where(action => !action.HasChildren && action.EquivalenceKey != null)
+            .Select(action => action.EquivalenceKey!)
+            .Distinct(StringComparer.Ordinal)
+            .Where(key => !scenario.IsAdvisory(key))
+            .ToList();
+
+        Assert.True(
+            applicableKeys.Count > 0,
+            $"{scenarioName}: no non-advisory action was offered, so nothing was executed."
+        );
+
+        int verifiedBehaviours = 0;
+
+        foreach (string key in applicableKeys)
+        {
+            Document fixedDocument = await CodeFixActionInspector.ApplyActionByKeyAsync(
+                document,
+                scenario.CreateProvider(),
+                diagnostics,
+                key
+            );
+
+            string fixedText = (await fixedDocument.GetTextAsync()).ToString();
+            string because = $"{scenarioName} action '{key}'";
+
+            Action<object>? assertMapped = scenario.BehaviourFor(key);
+            if (assertMapped == null)
+            {
+                CodeFixRuntimeVerifier.AssertConfiguresValidMapper(fixedText, because);
+                continue;
+            }
+
+            // Configuration validity does not discriminate here - AutoMapper accepts the unfixed code
+            // for most of these rules - so the fix is executed and its output inspected instead.
+            object mapped = CodeFixRuntimeVerifier.MapThroughFixedCode(
+                fixedText,
+                "Source",
+                "Destination",
+                scenario.PopulateSource!,
+                because
+            );
+
+            assertMapped(mapped);
+            verifiedBehaviours++;
+        }
+
+        Assert.True(
+            scenario.Behaviours.Count == 0 || verifiedBehaviours > 0,
+            $"{scenarioName}: declares behavioural expectations but no offered action matched one, so "
+                + "only configuration validity was checked."
+        );
+    }
+
+    private static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(
+        Document document,
+        DiagnosticAnalyzer analyzer
+    )
+    {
+        Compilation compilation = (await document.Project.GetCompilationAsync())!;
+        CompilationWithAnalyzers withAnalyzers = compilation.WithAnalyzers(
+            ImmutableArray.Create(analyzer)
+        );
+
+        return await withAnalyzers.GetAnalyzerDiagnosticsAsync();
+    }
+
+    private sealed record FixerScenario(
+        Func<DiagnosticAnalyzer> CreateAnalyzer,
+        Func<CodeFixProvider> CreateProvider,
+        string Source,
+        string[] AdvisoryKeyFragments
+    )
+    {
+        /// <summary>
+        ///     Builds the source instance fed through the fixed mapping. Required when
+        ///     <see cref="Behaviours" /> is non-empty.
+        /// </summary>
+        public Func<Type, object>? PopulateSource { get; init; }
+
+        /// <summary>
+        ///     Value-level expectations keyed by equivalence-key fragment. Needed because
+        ///     <c>AssertConfigurationIsValid()</c> accepts the unfixed code for most rules here, so
+        ///     configuration validity alone would assert nothing about what the fixer produced. A fix
+        ///     that converts, renames, or removes a mapping is only verified by running it.
+        /// </summary>
+        public IReadOnlyDictionary<string, Action<object>> Behaviours { get; init; } =
+            new Dictionary<string, Action<object>>(StringComparer.Ordinal);
+
+        public bool IsAdvisory(string equivalenceKey)
+        {
+            return AdvisoryKeyFragments.Any(fragment =>
+                equivalenceKey.Contains(fragment, StringComparison.OrdinalIgnoreCase)
+            );
+        }
+
+        public Action<object>? BehaviourFor(string equivalenceKey)
+        {
+            foreach (KeyValuePair<string, Action<object>> behaviour in Behaviours)
+            {
+                if (equivalenceKey.Contains(behaviour.Key, StringComparison.Ordinal))
+                {
+                    return behaviour.Value;
+                }
+            }
+
+            return null;
+        }
+    }
+
+    private static object Property(object instance, string name)
+    {
+        return instance.GetType().GetProperty(name)!.GetValue(instance)!;
+    }
+
+    private static object Populate(Type sourceType, params (string Name, object Value)[] values)
+    {
+        object instance = Activator.CreateInstance(sourceType)!;
+        foreach ((string name, object value) in values)
+        {
+            sourceType.GetProperty(name)!.SetValue(instance, value);
+        }
+
+        return instance;
+    }
+
+    private static List<string> StringsOf(object collection)
+    {
+        return ((System.Collections.IEnumerable)collection)
+            .Cast<object>()
+            .Select(value => value.ToString()!)
+            .ToList();
+    }
+
+    private static readonly Dictionary<string, FixerScenario> Scenarios = new(
+        StringComparer.Ordinal
+    )
+    {
+        ["AM001 property type mismatch"] = new(
+            () => new AM001_PropertyTypeMismatchAnalyzer(),
+            () => new AM001_PropertyTypeMismatchCodeFixProvider(),
+            """
+            using AutoMapper;
+
+            namespace TestNamespace
+            {
+                public class Source
+                {
+                    public string Amount { get; set; } = string.Empty;
+                }
+
+                public class Destination
+                {
+                    public int Amount { get; set; }
+                }
+
+                public class TestProfile : Profile
+                {
+                    public TestProfile()
+                    {
+                        CreateMap<Source, Destination>();
+                    }
+                }
+            }
+            """,
+            []
+        )
+        {
+            PopulateSource = type => Populate(type, ("Amount", "42")),
+            Behaviours = new Dictionary<string, Action<object>>(StringComparer.Ordinal)
+            {
+                // A fix that compiles and reads plausibly can still convert wrongly; only running it
+                // distinguishes int.Parse from, say, a silent default.
+                ["AM001_MapWithConversion"] = mapped => Assert.Equal(42, Property(mapped, "Amount")),
+                ["AM001_Ignore"] = mapped => Assert.Equal(0, Property(mapped, "Amount")),
+            },
+        },
+        ["AM002 nullable compatibility"] = new(
+            () => new AM002_NullableCompatibilityAnalyzer(),
+            () => new AM002_NullableCompatibilityCodeFixProvider(),
+            """
+            using AutoMapper;
+
+            namespace TestNamespace
+            {
+                public class Source
+                {
+                    public string? Name { get; set; }
+                }
+
+                public class Destination
+                {
+                    public string Name { get; set; } = string.Empty;
+                }
+
+                public class TestProfile : Profile
+                {
+                    public TestProfile()
+                    {
+                        CreateMap<Source, Destination>();
+                    }
+                }
+            }
+            """,
+            []
+        )
+        {
+            PopulateSource = type => Populate(type, ("Name", null!)),
+            Behaviours = new Dictionary<string, Action<object>>(StringComparer.Ordinal)
+            {
+                // The point of the default-value fix is that a null source never reaches a non-nullable
+                // destination member. Asserting the substituted value is the only way to know it did.
+                ["AM002_DefaultValue"] = mapped =>
+                    Assert.Equal(string.Empty, Property(mapped, "Name")),
+            },
+        },
+        ["AM003 collection type incompatibility"] = new(
+            () => new AM003_CollectionTypeIncompatibilityAnalyzer(),
+            () => new AM003_CollectionTypeIncompatibilityCodeFixProvider(),
+            """
+            using System.Collections.Generic;
+            using AutoMapper;
+
+            namespace TestNamespace
+            {
+                public class Source
+                {
+                    public List<int> Values { get; set; } = new List<int>();
+                }
+
+                public class Destination
+                {
+                    public HashSet<string> Values { get; set; } = new HashSet<string>();
+                }
+
+                public class TestProfile : Profile
+                {
+                    public TestProfile()
+                    {
+                        CreateMap<Source, Destination>();
+                    }
+                }
+            }
+            """,
+            []
+        )
+        {
+            PopulateSource = type => Populate(type, ("Values", new List<int> { 1, 2 })),
+            Behaviours = new Dictionary<string, Action<object>>(StringComparer.Ordinal)
+            {
+                ["AM003_Constructor"] = mapped =>
+                    Assert.Equal(
+                        ["1", "2"],
+                        StringsOf(Property(mapped, "Values")).OrderBy(value => value, StringComparer.Ordinal)
+                    ),
+            },
+        },
+        ["AM004 missing destination property"] = new(
+            () => new AM004_MissingDestinationPropertyAnalyzer(),
+            () => new AM004_MissingDestinationPropertyCodeFixProvider(),
+            """
+            using AutoMapper;
+
+            namespace TestNamespace
+            {
+                public class Source
+                {
+                    public string Name { get; set; } = string.Empty;
+                    public string Dropped { get; set; } = string.Empty;
+                }
+
+                public class Destination
+                {
+                    public string Name { get; set; } = string.Empty;
+                }
+
+                public class TestProfile : Profile
+                {
+                    public TestProfile()
+                    {
+                        CreateMap<Source, Destination>();
+                    }
+                }
+            }
+            """,
+            []
+        )
+        {
+            PopulateSource = type => Populate(type, ("Name", "kept"), ("Dropped", "gone")),
+            Behaviours = new Dictionary<string, Action<object>>(StringComparer.Ordinal)
+            {
+                // Silencing a dropped source member must not disturb the members that do map.
+                ["AM004_DoNotValidate"] = mapped => Assert.Equal("kept", Property(mapped, "Name")),
+            },
+        },
+        ["AM005 case sensitivity mismatch"] = new(
+            () => new AM005_CaseSensitivityMismatchAnalyzer(),
+            () => new AM005_CaseSensitivityMismatchCodeFixProvider(),
+            """
+            using AutoMapper;
+
+            namespace TestNamespace
+            {
+                public class Source
+                {
+                    public string UserName { get; set; } = string.Empty;
+                }
+
+                public class Destination
+                {
+                    public string Username { get; set; } = string.Empty;
+                }
+
+                public class TestProfile : Profile
+                {
+                    public TestProfile()
+                    {
+                        CreateMap<Source, Destination>();
+                    }
+                }
+            }
+            """,
+            []
+        )
+        {
+            PopulateSource = type => Populate(type, ("UserName", "george")),
+            Behaviours = new Dictionary<string, Action<object>>(StringComparer.Ordinal)
+            {
+                ["AM005_ExplicitMapping"] = mapped =>
+                    Assert.Equal("george", Property(mapped, "Username")),
+            },
+        },
+        ["AM006 unmapped destination property"] = new(
+            () => new AM006_UnmappedDestinationPropertyAnalyzer(),
+            () => new AM006_UnmappedDestinationPropertyCodeFixProvider(),
+            """
+            using AutoMapper;
+
+            namespace TestNamespace
+            {
+                public class Source
+                {
+                    public string Name { get; set; } = string.Empty;
+                }
+
+                public class Destination
+                {
+                    public string Name { get; set; } = string.Empty;
+                    public string Extra { get; set; } = string.Empty;
+                }
+
+                public class TestProfile : Profile
+                {
+                    public TestProfile()
+                    {
+                        CreateMap<Source, Destination>();
+                    }
+                }
+            }
+            """,
+            []
+        ),
+        ["AM011 unmapped required property"] = new(
+            () => new AM011_UnmappedRequiredPropertyAnalyzer(),
+            () => new AM011_UnmappedRequiredPropertyCodeFixProvider(),
+            """
+            using AutoMapper;
+
+            namespace TestNamespace
+            {
+                public class Source
+                {
+                    public string Email { get; set; } = string.Empty;
+                }
+
+                public class Destination
+                {
+                    public required string Email { get; set; }
+                    public required string ContactName { get; set; }
+                }
+
+                public class TestProfile : Profile
+                {
+                    public TestProfile()
+                    {
+                        CreateMap<Source, Destination>();
+                    }
+                }
+            }
+            """,
+            []
+        ),
+        ["AM020 nested object mapping"] = new(
+            () => new AM020_NestedObjectMappingAnalyzer(),
+            () => new AM020_NestedObjectMappingCodeFixProvider(),
+            """
+            using AutoMapper;
+
+            namespace TestNamespace
+            {
+                public class SourceAddress
+                {
+                    public string City { get; set; } = string.Empty;
+                }
+
+                public class DestinationAddress
+                {
+                    public string City { get; set; } = string.Empty;
+                }
+
+                public class Source
+                {
+                    public SourceAddress Address { get; set; } = new SourceAddress();
+                }
+
+                public class Destination
+                {
+                    public DestinationAddress Address { get; set; } = new DestinationAddress();
+                }
+
+                public class TestProfile : Profile
+                {
+                    public TestProfile()
+                    {
+                        CreateMap<Source, Destination>();
+                    }
+                }
+            }
+            """,
+            []
+        ),
+        ["AM021 collection element mismatch"] = new(
+            () => new AM021_CollectionElementMismatchAnalyzer(),
+            () => new AM021_CollectionElementMismatchCodeFixProvider(),
+            """
+            using System.Collections.Generic;
+            using AutoMapper;
+
+            namespace TestNamespace
+            {
+                public class Source
+                {
+                    public List<int> Values { get; set; } = new List<int>();
+                }
+
+                public class Destination
+                {
+                    public List<string> Values { get; set; } = new List<string>();
+                }
+
+                public class TestProfile : Profile
+                {
+                    public TestProfile()
+                    {
+                        CreateMap<Source, Destination>();
+                    }
+                }
+            }
+            """,
+            []
+        )
+        {
+            PopulateSource = type => Populate(type, ("Values", new List<int> { 1, 2, 3 })),
+            Behaviours = new Dictionary<string, Action<object>>(StringComparer.Ordinal)
+            {
+                // The 2.30.83 defect exactly: compile-clean, text-identical to expectation, wrong order.
+                ["AM021_SimpleConversion"] = mapped =>
+                    Assert.Equal(["1", "2", "3"], StringsOf(Property(mapped, "Values"))),
+            },
+        },
+        ["AM041 duplicate mapping"] = new(
+            () => new AM041_DuplicateMappingAnalyzer(),
+            () => new AM041_DuplicateMappingCodeFixProvider(),
+            """
+            using AutoMapper;
+
+            namespace TestNamespace
+            {
+                public class Source
+                {
+                    public string Name { get; set; } = string.Empty;
+                }
+
+                public class Destination
+                {
+                    public string Name { get; set; } = string.Empty;
+                }
+
+                public class TestProfile : Profile
+                {
+                    public TestProfile()
+                    {
+                        CreateMap<Source, Destination>();
+                        CreateMap<Source, Destination>();
+                    }
+                }
+            }
+            """,
+            []
+        )
+        {
+            PopulateSource = type => Populate(type, ("Name", "kept")),
+            Behaviours = new Dictionary<string, Action<object>>(StringComparer.Ordinal)
+            {
+                // Removing a duplicate registration must leave the surviving one mapping.
+                ["AM041_RemoveDuplicateMapping"] = mapped =>
+                    Assert.Equal("kept", Property(mapped, "Name")),
+            },
+        },
+        ["AM050 redundant MapFrom"] = new(
+            () => new AM050_RedundantMapFromAnalyzer(),
+            () => new AM050_RedundantMapFromCodeFixProvider(),
+            """
+            using AutoMapper;
+
+            namespace TestNamespace
+            {
+                public class Source
+                {
+                    public string Name { get; set; } = string.Empty;
+                }
+
+                public class Destination
+                {
+                    public string Name { get; set; } = string.Empty;
+                }
+
+                public class TestProfile : Profile
+                {
+                    public TestProfile()
+                    {
+                        CreateMap<Source, Destination>()
+                            .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.Name));
+                    }
+                }
+            }
+            """,
+            []
+        )
+        {
+            PopulateSource = type => Populate(type, ("Name", "kept")),
+            Behaviours = new Dictionary<string, Action<object>>(StringComparer.Ordinal)
+            {
+                // Deleting a redundant ForMember is only safe if convention still maps the member.
+                ["AM050_RemoveRedundantMapping"] = mapped =>
+                    Assert.Equal("kept", Property(mapped, "Name")),
+            },
+        },
+        ["AM061 enum member mismatch"] = new(
+            () => new AM061_EnumMemberMismatchAnalyzer(),
+            () => new AM061_EnumMemberMismatchCodeFixProvider(),
+            """
+            using AutoMapper;
+
+            namespace TestNamespace
+            {
+                public enum SourceStatus
+                {
+                    Active,
+                    Archived
+                }
+
+                public enum DestinationStatus
+                {
+                    Active
+                }
+
+                public class Source
+                {
+                    public SourceStatus Status { get; set; }
+                }
+
+                public class Destination
+                {
+                    public DestinationStatus Status { get; set; }
+                }
+
+                public class TestProfile : Profile
+                {
+                    public TestProfile()
+                    {
+                        CreateMap<Source, Destination>();
+                    }
+                }
+            }
+            """,
+            []
+        ),
+    };
+}


### PR DESCRIPTION
Closes the *"rollout is partial"* line the health doc has carried since `CodeFixRuntimeVerifier` landed, and which the monitor sweep (#226) named as the next batch.

## The problem

Every fixer test here compares the fixed document to expected text. That proves a fix matches what the test author wrote down — not that AutoMapper accepts it, and not that it maps the right values. The **2.30.83 `Stack<T>` defect** was compile-clean, text-identical to its expectation, and reversed LIFO order at runtime.

## What landed

`FixerRuntimeContractTests` routes **12 of 16 fixers** — AM001–AM006, AM011, AM020, AM021, AM041, AM050, AM061 — through their real analyzer and real fixer, applies **every** non-advisory action the lightbulb offers, and executes the result.

## Why it is not the obvious version of that check

The obvious version asserts much less than it appears to. Feeding the harness **unfixed** source fails only AM006, AM011, AM020 and AM041 — AutoMapper accepts the pre-fix configuration for the other eight. `AssertConfigurationIsValid()` alone would have passed whatever those eight fixers emitted.

So actions that convert, rename, substitute a default, or delete a registration carry **value-level** expectations, executed through the mapper:

- `"42"` must arrive as `42`
- `[1,2,3]` must arrive as `["1","2","3"]` **in that order**
- a null source must arrive as the substituted default
- removing a duplicate or redundant registration must leave the member still mapping

## Verified by being made to fail

| Mutation | Result |
| --- | --- |
| Substitute unfixed source for fixer output | **4 of 12 fail** |
| Invert three expected values | **exactly those 3 fail** |

A test that cannot fail is worse than no test, so neither layer is claimed on green alone.

## Still partial, stated precisely

AM022, AM030, AM031, AM060 remain unrouted, and every scenario is a minimal single-defect case — so this checks fixer output on clean inputs, not the full matrix each fixer supports. Both `docs/TEST_LIMITATIONS.md` and `analyzer-health.md` say exactly that, including the discrimination finding, so the next extension does not repeat the weaker check.

## Validation

2453 tests green (was 2441); both projects build with `-warnaserror`; catalog, snapshot and compatibility checks current. Tests and docs only — no analyzer or fixer behaviour changed, so no release.
