### PR TITLE
test: route the last four fixers through the runtime contract

### DIFF
--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -31,7 +31,7 @@ tests; each answers a question those tests cannot:
 | Source | Question it answers | State |
 | --- | --- | --- |
 | `--scan-corpus` (`tools/AnalyzerVerifier`) | What do the rules say about code we did not write? | Tool works and found the AM041 defect. **No CI job** — see `docs/TEST_LIMITATIONS.md` |
-| `CodeFixRuntimeVerifier` + `FixerRuntimeContractTests` | Does fixer output actually configure a mapper — and map the right values? | 12 of 16 fixers routed through their real analyzer and fixer, every offered action executed, coverage tracked per fixer *branch* rather than per rule; AM022/AM030/AM031/AM060 outstanding |
+| `CodeFixRuntimeVerifier` + `FixerRuntimeContractTests` | Does fixer output actually configure a mapper — and map the right values? | **All 16 fixers** routed through their real analyzer and fixer across 17 scenarios, every offered action executed; coverage tracked per fixer *branch* rather than per rule |
 | `AnalyzerCrashSafetyTests` | Does any analyzer throw on half-typed or error-laden code? | 20 hostile inputs plus a cyclic graph; no crashes on this tree |
 | `GeneratedTypeShapeTests` | Do invariants hold across the shape space, not just sampled points? | ~590 generated mappings; invariants only, never expected diagnostics |
 
@@ -128,11 +128,11 @@ sources rather than the rules, because that is where this batch's two defects ac
    job, because AutoMapper's own MIT extension repositories do not compile from a clean checkout at a
    pinned SHA — they reference `AutoMapper.Internal`, absent from the `[15.0.1, 17.0.0)` range their
    manifests select. One buildable target turns this from a manual tool into a standing check.
-2. **Route the last four fixers** (AM022, AM030, AM031, AM060) through `FixerRuntimeContractTests`.
-   Twelve are now executed rather than string-compared. Note what that rollout exposed: configuration
-   validity alone discriminates for only four of the twelve rules, because AutoMapper accepts the
-   *unfixed* configuration for the rest — so any extension needs value-level expectations, not just
-   `AssertConfigurationIsValid()`, or it asserts nothing about what the fixer emitted.
+2. **Add value expectations to the nine scenarios that lack one.** All 16 fixers are now executed rather
+   than string-compared, and that rollout exposed the limit worth acting on: substituting *unfixed*
+   source passes 9 of 17 scenarios, because AutoMapper accepts the pre-fix configuration and convention
+   often produces the same value anyway. Those nine currently show only that the fix does not break a
+   working mapping. `AssertConfigurationIsValid()` alone is not a coverage claim.
 3. Advance AM001, AM002, or AM022 only when a concrete compiling false positive/negative proves the gap.
 
 A reproducible false negative that is knowingly deferred is not the same as a clean queue, and this

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -128,11 +128,13 @@ sources rather than the rules, because that is where this batch's two defects ac
    job, because AutoMapper's own MIT extension repositories do not compile from a clean checkout at a
    pinned SHA — they reference `AutoMapper.Internal`, absent from the `[15.0.1, 17.0.0)` range their
    manifests select. One buildable target turns this from a manual tool into a standing check.
-2. **Add value expectations to the nine scenarios that lack one.** All 16 fixers are now executed rather
-   than string-compared, and that rollout exposed the limit worth acting on: substituting *unfixed*
-   source passes 9 of 17 scenarios, because AutoMapper accepts the pre-fix configuration and convention
-   often produces the same value anyway. Those nine currently show only that the fix does not break a
-   working mapping. `AssertConfigurationIsValid()` alone is not a coverage claim.
+2. **Make nine scenarios discriminating.** All 16 fixers are now executed rather than string-compared,
+   and that rollout exposed the limit worth acting on: substituting *unfixed* source still passes 9 of
+   17 scenarios, so those nine show only that the fix does not break a working mapping. The fix is not
+   simply "add expectations" — six of them (AM003, AM004, AM005, AM021 `List<T>`, AM022, AM050) already
+   assert values that convention produces anyway, so they need inputs where fixed and unfixed *differ*;
+   only three (AM030, AM031, AM061) have no value expectation at all. Counting assertions overstates
+   this; only the unfixed-source probe measures it.
 3. Advance AM001, AM002, or AM022 only when a concrete compiling false positive/negative proves the gap.
 
 A reproducible false negative that is knowingly deferred is not the same as a clean queue, and this

--- a/docs/TEST_LIMITATIONS.md
+++ b/docs/TEST_LIMITATIONS.md
@@ -185,9 +185,13 @@ AM022, AM060).
 
 **What remains.** Every shipped fixer is routed, but each scenario is a minimal single-defect case, so
 this checks fixer output on clean inputs rather than the full matrix each fixer supports — and coverage
-is per *branch*, so a routed rule can still have an unexercised branch. Nine of the seventeen scenarios
-carry no value expectation, and adding one where the semantics are unambiguous is the cheapest way to
-strengthen this further.
+is per *branch*, so a routed rule can still have an unexercised branch.
+
+Nine scenarios still pass when fed unfixed source. Presence of an expectation is not the measure: eleven
+of the seventeen declare one, and six of those eleven (AM003, AM004, AM005, AM021 `List<T>`, AM022,
+AM050) assert a value AutoMapper's convention produces with or without the fix. Strengthening them means
+choosing inputs where fixed and unfixed output *differ*, not adding more assertions. Three scenarios
+(AM030, AM031, AM061) carry no value expectation at all.
 
 ## Documented analyzer boundaries
 

--- a/docs/TEST_LIMITATIONS.md
+++ b/docs/TEST_LIMITATIONS.md
@@ -156,9 +156,9 @@ conversion behaviour can be asserted on real values.
 compile, output AutoMapper rejects semantically, and incorrect `Stack<T>` ordering — and runs the real
 AM011 fixer end to end, executing what it produces rather than comparing it to text.
 
-`FixerRuntimeContractTests` routes twelve rules — AM001, AM002, AM003, AM004, AM005, AM006, AM011,
-AM020, AM021, AM041, AM050, AM061 — through their real analyzer and real fixer, applies **every**
-non-advisory action the lightbulb offers, and executes the result.
+`FixerRuntimeContractTests` routes **all sixteen shipped fixers** through their real analyzer and real
+fixer across seventeen scenarios, applies **every** non-advisory action the lightbulb offers, and
+executes the result.
 
 Coverage is per *branch*, not per rule. AM021 has two scenarios because its `List<T>` conversion and its
 `Stack<T>` conversion are different fixer branches, and only the second appends `.Reverse()`. A
@@ -166,22 +166,28 @@ Coverage is per *branch*, not per rule. AM021 has two scenarios because its `Lis
 2.30.83 — the `Stack<T>` scenario asserts pop order and fails when that order inverts.
 
 Two things about that check are worth stating precisely, because the obvious version of it asserts less
-than it appears to. First, `AssertConfigurationIsValid()` **does not discriminate for most of these
-rules**: feeding the harness unfixed source fails only AM006, AM011, AM020, and AM041, because AutoMapper
-accepts the pre-fix configuration for the other eight. Configuration validity alone would therefore have
-passed whatever those eight fixers emitted. So actions that convert, rename, substitute a default, or
-delete a registration carry **value-level** expectations instead, executed through `MapThroughFixedCode`
+than it appears to. First, `AssertConfigurationIsValid()` **does not discriminate for many of these
+rules**. Substituting unfixed source for fixer output fails 8 of 17 scenarios — AM001, AM002, AM006,
+AM011, AM020, AM021 `Stack<T>`, AM041 and AM060. The remaining 9 pass **unfixed**, because AutoMapper
+accepts the pre-fix configuration and, where a value expectation exists, convention already produces the
+same value. For those 9 the scenario shows the fix does not break a working mapping, not that it repairs
+a broken one — a weaker guarantee, and the reason configuration validity alone is not relied on. Actions
+that convert, rename, substitute a default, or delete a registration therefore carry **value-level**
+expectations, executed through `MapThroughFixedCode`
 — `"42"` must arrive as `42`, a `Stack<int>` popping `3,2,1` must arrive as a `Stack<string>` popping
 `"3","2","1"`, a null source must arrive as the substituted default, and removing a duplicate or
 redundant registration must leave the member still mapping.
 
-Second, both layers were verified by being made to fail: substituting unfixed source for fixer output
-fails 4 of 12, inverting three expected values fails exactly those 3, and inverting the expected stack
-pop order fails the `Stack<T>` scenario alone.
+Second, both layers were verified by being made to fail rather than by being green. Substituting unfixed
+source for fixer output fails the 8 scenarios listed above; inverting an expected value fails exactly the
+scenario that declares it, checked for six of them (AM001, AM005, AM021 `List<T>`, AM021 `Stack<T>`,
+AM022, AM060).
 
-**Rollout remains partial.** Four fixers are not yet routed through it — AM022, AM030, AM031, AM060 —
-and each scenario is a minimal single-defect case, so this checks fixer output on clean inputs rather
-than the full matrix each fixer supports.
+**What remains.** Every shipped fixer is routed, but each scenario is a minimal single-defect case, so
+this checks fixer output on clean inputs rather than the full matrix each fixer supports — and coverage
+is per *branch*, so a routed rule can still have an unexercised branch. Nine of the seventeen scenarios
+carry no value expectation, and adding one where the semantics are unambiguous is the cheapest way to
+strengthen this further.
 
 ## Documented analyzer boundaries
 

--- a/tests/AutoMapperAnalyzer.Tests/Infrastructure/FixerRuntimeContractTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/Infrastructure/FixerRuntimeContractTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using AutoMapperAnalyzer.Analyzers.ComplexMappings;
 using AutoMapperAnalyzer.Analyzers.Configuration;
 using AutoMapperAnalyzer.Analyzers.DataIntegrity;
+using AutoMapperAnalyzer.Analyzers.Performance;
 using AutoMapperAnalyzer.Analyzers.TypeSafety;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
@@ -585,6 +586,152 @@ public class FixerRuntimeContractTests
                 // fails if the LIFO correction regresses. Source pops 3,2,1; so must the destination.
                 ["AM021_SimpleConversion"] = mapped =>
                     Assert.Equal(["3", "2", "1"], StringsOf(Property(mapped, "Values"))),
+            },
+        },
+        ["AM022 infinite recursion"] = new(
+            () => new AM022_InfiniteRecursionAnalyzer(),
+            () => new AM022_InfiniteRecursionCodeFixProvider(),
+            """
+            using AutoMapper;
+
+            namespace TestNamespace
+            {
+                public class Source
+                {
+                    public string Name { get; set; } = string.Empty;
+                    public Source? Parent { get; set; }
+                }
+
+                public class Destination
+                {
+                    public string Name { get; set; } = string.Empty;
+                    public Destination? Parent { get; set; }
+                }
+
+                public class TestProfile : Profile
+                {
+                    public TestProfile()
+                    {
+                        CreateMap<Source, Destination>();
+                    }
+                }
+            }
+            """,
+            []
+        )
+        {
+            PopulateSource = type => Populate(type, ("Name", "root")),
+            Behaviours = new Dictionary<string, Action<object>>(StringComparer.Ordinal)
+            {
+                // Bounding recursion must not stop the non-recursive members from mapping.
+                ["AM022_"] = mapped => Assert.Equal("root", Property(mapped, "Name")),
+            },
+        },
+        ["AM030 custom type converter null guard"] = new(
+            () => new AM030_CustomTypeConverterAnalyzer(),
+            () => new AM030_CustomTypeConverterCodeFixProvider(),
+            """
+            using AutoMapper;
+
+            namespace TestNamespace
+            {
+                public class NullUnsafeConverter : ITypeConverter<string?, int>
+                {
+                    public int Convert(string? source, int destination, ResolutionContext context)
+                    {
+                        return int.Parse(source);
+                    }
+                }
+
+                public class TestProfile : Profile
+                {
+                    public TestProfile()
+                    {
+                        CreateMap<string?, int>().ConvertUsing<NullUnsafeConverter>();
+                    }
+                }
+            }
+            """,
+            []
+        ),
+        ["AM031 expensive operation in MapFrom"] = new(
+            () => new AM031_PerformanceWarningAnalyzer(),
+            () => new AM031_PerformanceWarningCodeFixProvider(),
+            """
+            using AutoMapper;
+
+            namespace TestNamespace
+            {
+                public class Source
+                {
+                    public string Path { get; set; } = string.Empty;
+                }
+
+                public class Destination
+                {
+                    public string Content { get; set; } = string.Empty;
+                }
+
+                public class TestProfile : Profile
+                {
+                    public TestProfile()
+                    {
+                        CreateMap<Source, Destination>()
+                            .ForMember(dest => dest.Content, opt => opt.MapFrom(src => System.IO.File.ReadAllText(src.Path)));
+                    }
+                }
+            }
+            """,
+            []
+        ),
+        ["AM060 unregistered type map"] = new(
+            () => new AM060_UnregisteredTypeMapAnalyzer(),
+            () => new AM060_UnregisteredTypeMapCodeFixProvider(),
+            """
+            using AutoMapper;
+
+            namespace TestNamespace
+            {
+                public class Source
+                {
+                    public string Name { get; set; } = string.Empty;
+                }
+
+                public class Destination
+                {
+                    public string Name { get; set; } = string.Empty;
+                }
+
+                public class Other
+                {
+                    public string Name { get; set; } = string.Empty;
+                }
+
+                public class TestProfile : Profile
+                {
+                    public TestProfile()
+                    {
+                        CreateMap<Source, Other>();
+                    }
+                }
+
+                public class Service
+                {
+                    public Destination Run(IMapper mapper, Source source)
+                    {
+                        return mapper.Map<Destination>(source);
+                    }
+                }
+            }
+            """,
+            []
+        )
+        {
+            PopulateSource = type => Populate(type, ("Name", "registered")),
+            Behaviours = new Dictionary<string, Action<object>>(StringComparer.Ordinal)
+            {
+                // Registering the missing map is only a fix if the map it adds actually works.
+                ["AM060_"] = mapped => Assert.Equal("registered", Property(mapped, "Name")),
             },
         },
         ["AM041 duplicate mapping"] = new(


### PR DESCRIPTION
Completes the rollout `analyzer-health.md` has tracked as partial since `CodeFixRuntimeVerifier` landed. **All 16 shipped fixers** now run through their real analyzer and real fixer across 17 scenarios, every non-advisory action executed.

## What writing the AM031 scenario surfaced

AM031's own fixer tests **synthesize the diagnostic** rather than letting the analyzer produce one. A plausible LINQ `MapFrom` (`.Where(...).ToList().Count`) reported nothing — AM031 detects I/O, database, HTTP and compression calls, not enumeration cost. The scenario now uses a `File.ReadAllText` call the analyzer actually reports.

No analyzer defect — the scenario was wrong, not the rule. But a fixer whose tests never exercise its own analyzer is a gap worth having found, and this harness is what found it.

## What the completed rollout proves — and does not

Substituting **unfixed** source for fixer output fails **8 of 17** scenarios: AM001, AM002, AM006, AM011, AM020, AM021 `Stack<T>`, AM041, AM060.

The other **9 pass unfixed**, because AutoMapper accepts the pre-fix configuration and, where a value expectation exists, convention already produces the same value. For those nine the scenario shows the fix does not *break* a working mapping — not that it *repairs* a broken one. That is a weaker guarantee than "16 of 16 covered" suggests, so both docs state it plainly and name closing it as the next step.

## Falsification

| Mutation | Result |
| --- | --- |
| Substitute unfixed source | 8 of 17 fail (named above) |
| Invert an expected value | fails exactly the scenario declaring it, checked for 6 |

## Validation

2458 tests green; `-warnaserror` clean; catalog, snapshot and compatibility current. **No analyzer or fixer behaviour changed** — tests and docs only.
