### PR TITLE
fix: AM011 reports required members an included child map explicitly ignores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,12 @@ or severity changes).
     application order this scope does not model - a false negative there is the deliberate trade on an
     `Error` rule.
 
-  Four negative tests pin those boundaries alongside the two flipped cases.
+  The `Ignore()` call must resolve to the configuration lambda's own options parameter. Matching any
+  zero-argument call named `Ignore` would also match an unrelated helper — `o => o.Condition((src, dest,
+  sm, dm) => Settings.Ignore())` — and reading that as a map-level ignore would turn a valid mapping into
+  an Error-severity false positive. Cross-review caught that before release; it has its own test.
+
+  Five negative tests pin those boundaries alongside the two flipped cases.
 
 ## [2.30.96] - 2026-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## Unreleased
 
+## [2.30.97] - 2026-07-29
+
+AM011 now reports a required destination member that an included child map explicitly ignores (no rule ID
+or severity changes).
+
+### Fixed
+
+- **`IncludeMembers` child-map `Ignore()` no longer suppresses AM011.** When a child map declared
+  `ForMember(d => d.Name, o => o.Ignore())` or `ForAllMembers(o => o.Ignore())`, AM011 stayed silent even
+  though AutoMapper rejects that configuration at startup. The repository documented this as a known
+  limitation and asserted it in two `*_KnownLimitation` tests; the premise was re-verified against the
+  real AutoMapper runtime before changing anything, rather than trusted from the note.
+
+  The distinction that makes this safe is between *reading* and *inferring*. 2.30.88 deliberately refused
+  to infer that a child map fails to supply a member, because approximating that produced Error-severity
+  false positives. An explicit `Ignore()` is not an inference - the map states it does not supply the
+  member. Everything that cannot be read this way still suppresses:
+
+  - unresolved `IncludeMembers` selectors, unchanged;
+  - ambiguous child maps (two registrations for the same pair), which cannot be read at all;
+  - `ForPath(d => d.Detail.Name, ...)`, which designates a nested path and must not be mistaken for the
+    top-level member sharing its name;
+  - a map carrying both an explicit `MapFrom` and a map-wide `Ignore`, where the outcome depends on
+    application order this scope does not model - a false negative there is the deliberate trade on an
+    `Error` rule.
+
+  Four negative tests pin those boundaries alongside the two flipped cases.
+
 ## [2.30.96] - 2026-07-29
 
 Faster analysis of profiles with long fluent chains (no rule ID, severity, or diagnostic changes).

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ When the analyzer cannot prove a mapping shape statically, it **stays quiet**. H
 ## Install
 
 ```xml
-<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.96">
+<PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.97">
   <PrivateAssets>all</PrivateAssets>
   <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 </PackageReference>
@@ -48,7 +48,7 @@ When the analyzer cannot prove a mapping shape statically, it **stays quiet**. H
 Or:
 
 ```bash
-dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.96
+dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.97
 ```
 
 **No runtime dependency** is added to your app. The package is a development-time Roslyn analyzer (plus code fixes). Open any file with AutoMapper configuration and diagnostics appear in supported IDEs and `dotnet build`.
@@ -119,7 +119,7 @@ Analyzer targets **.NET Standard 2.0**. Matrix details: [docs/COMPATIBILITY.md](
 
 ---
 
-## Latest Release: v2.30.96
+## Latest Release: v2.30.97
 
 **Faster analysis of profiles with long fluent chains**
 
@@ -161,7 +161,7 @@ Analyzer targets **.NET Standard 2.0**. Matrix details: [docs/COMPATIBILITY.md](
 
 ### Recent highlights
 
-- **v2.30.96**: Faster analysis of profiles with long fluent chains.
+- **v2.30.97**: Faster analysis of profiles with long fluent chains.
 - **v2.30.95**: Corrects the provenance verification command — verify the GitHub release asset, not the NuGet download.
 - **v2.30.94**: The published package carries verifiable build provenance.
 - **v2.30.93**: Every diagnostic now links to its documentation section — IDEs offer "learn more" on all 23 rules.
@@ -280,7 +280,7 @@ Reference one from your project file:
 
 ```xml
 <ItemGroup>
-  <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.96"
+  <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.97"
                     PrivateAssets="all" GeneratePathProperty="true" />
   <GlobalAnalyzerConfigFiles
     Include="$(PkgAutoMapperAnalyzer_Analyzers)\config\AutoMapperAnalyzer.Minimal.globalconfig" />

--- a/analyzer-health.md
+++ b/analyzer-health.md
@@ -1,12 +1,12 @@
 # Analyzer Health
 
-Reviewed: 2026-07-29 (monitor sweep after **2.30.88–2.30.96**; the evidence base changed materially — see *How defects are found*)
+Reviewed: 2026-07-29 (monitor sweep after **2.30.88–2.30.97**; the evidence base changed materially — see *How defects are found*)
 
 This is a deliberately harsh health audit for the **23** implemented AutoMapper analyzer rule IDs in this repository (16 before the 2.30.62 performance split). Several rule IDs still expose multiple diagnostic descriptors, especially `AM002` and `AM022`; the scorecard rates the public rule ID as the user experiences it.
 
 Every implemented rule currently has an analyzer and a code fix provider. Scores are 1-5, where `5` means reference-quality and hard to improve, `3` means usable but meaningfully incomplete, and `1` means unreliable or underbuilt.
 
-**Ship status:** production-acceptable. **2.30.96** configuration calls resolved once per mapping (long-chain analysis ~25% cheaper); **2.30.95** corrected provenance verification instructions; **2.30.94** published packages carry verifiable build provenance; **2.30.93** every diagnostic carries a documentation help link; **2.30.92** syntactic gate before symbol binding (measured against the new throughput baseline); **2.30.91** AM041 respects independent `MapperConfiguration` containers (first defect found by third-party corpus scanning); **2.30.90** severity presets for brownfield adoption; **2.30.89** AutoMapper 15/16 added to the verified compatibility contract; **2.30.88** `IncludeMembers` awareness closes an Error-severity AM011 false positive plus matching AM004/AM006 gaps; **2.30.87** discoverability assets (CreateMap metadata, funnel README, product-flow visuals); **2.30.86** AM020 computed receivers are captured exactly once before missing nested-map insertion; **2.30.85** AM021 nested collection safety and dependency refresh; **2.30.84** new AM060 unregistered type map at call site + AM061 enum member mismatch rules (Codex cross-reviewed, two rounds); **2.30.83** AM021 Stack conversion order safety; **2.30.82** AM021 direct-statement and conditional-region safety; **2.30.81** AM020 conditional block-body insertion safety; **2.30.80** AM020 expression-bodied void-method fixer parity; **2.30.79** AM020 expression-bodied Profile constructor fixer parity; **2.30.78** AM020 stable configuration receiver fixes. Every rule now has minimum health 4. Full suite green; catalog/snapshots and package smoke verification are current.
+**Ship status:** production-acceptable. **2.30.97** AM011 reports required members an included child map explicitly ignores, closing the one residual this queue still carried; **2.30.96** configuration calls resolved once per mapping (long-chain analysis ~25% cheaper); **2.30.95** corrected provenance verification instructions; **2.30.94** published packages carry verifiable build provenance; **2.30.93** every diagnostic carries a documentation help link; **2.30.92** syntactic gate before symbol binding (measured against the new throughput baseline); **2.30.91** AM041 respects independent `MapperConfiguration` containers (first defect found by third-party corpus scanning); **2.30.90** severity presets for brownfield adoption; **2.30.89** AutoMapper 15/16 added to the verified compatibility contract; **2.30.88** `IncludeMembers` awareness closes an Error-severity AM011 false positive plus matching AM004/AM006 gaps; **2.30.87** discoverability assets (CreateMap metadata, funnel README, product-flow visuals); **2.30.86** AM020 computed receivers are captured exactly once before missing nested-map insertion; **2.30.85** AM021 nested collection safety and dependency refresh; **2.30.84** new AM060 unregistered type map at call site + AM061 enum member mismatch rules (Codex cross-reviewed, two rounds); **2.30.83** AM021 Stack conversion order safety; **2.30.82** AM021 direct-statement and conditional-region safety; **2.30.81** AM020 conditional block-body insertion safety; **2.30.80** AM020 expression-bodied void-method fixer parity; **2.30.79** AM020 expression-bodied Profile constructor fixer parity; **2.30.78** AM020 stable configuration receiver fixes. Every rule now has minimum health 4. Full suite green; catalog/snapshots and package smoke verification are current.
 
 ## How defects are found
 
@@ -111,15 +111,15 @@ Use this table as the hardening queue. Ranking = **Importance × (5 − min(Anal
 
 **Recommended next hardening batch:**
 
-One rule-level residual is retained rather than closed, and it is deliberately deferred rather than
-merely unproven: **AM011 does not report when an `IncludeMembers` child map ignores a required member**
-(`ForMember(... Ignore())` or `ForAllMembers(... Ignore())`). AutoMapper rejects that configuration at
-startup, so it is a real false negative, reproduced by `IncludeMembersTests.*_KnownLimitation` — which
-assert the shipped behaviour, not the ideal one — and recorded in `docs/TEST_LIMITATIONS.md`. It stays
-deferred because every attempt to infer that a child map *fails* to supply a member produced
-Error-severity false positives during 2.30.88, and on an `Error` rule a false positive breaks builds
-while this false negative merely fails to prevent a startup error the consumer still sees. Reopen it
-only with a design that cannot fire on an unresolvable child map.
+The AM011 `IncludeMembers`-child-`Ignore` false negative this section carried as *deferred* is **closed
+in 2.30.97**, and how it was closed is the reusable part. The reopening condition recorded here was "a
+design that cannot fire on an unresolvable child map". Reading an explicit `ForMember(... Ignore())` or
+`ForAllMembers(... Ignore())` meets it, because an explicit `Ignore` is a statement by the map rather
+than an inference about it — which is precisely what 2.30.88 refused to do and was right to refuse. The
+premise was re-verified against the real AutoMapper runtime before any code changed, rather than trusted
+from the note asserting it, and four negative tests pin the boundaries that still suppress: unresolved
+selectors, ambiguous child maps, `ForPath` nested ignores, and maps carrying both a `MapFrom` and a
+map-wide `Ignore`.
 
 Beyond that, the rule-by-rule queue is at monitor priority. The productive work is in the evidence
 sources rather than the rules, because that is where this batch's two defects actually came from.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -722,7 +722,7 @@ dotnet pack --configuration Release
 
 # Test package locally
 cd test-install/NetCoreTest
-dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.96-local
+dotnet add package AutoMapperAnalyzer.Analyzers --version 2.30.97-local
 ```
 
 ---
@@ -906,4 +906,4 @@ dotnet build
 
 **Last Updated**: 2026-05-14
 **Maintainer**: George Wall
-**Version**: 2.30.96
+**Version**: 2.30.97

--- a/docs/CI-CD.md
+++ b/docs/CI-CD.md
@@ -118,8 +118,8 @@ The split exists because GitHub cannot resolve local reusable workflows (`uses: 
 ### Package Versioning
 
 - **Format**: Major.Minor.Patch (SemVer)
-- **Current**: 2.30.96
-- **Pre-release**: 2.30.96-preview, 2.30.96-beta
+- **Current**: 2.30.97
+- **Pre-release**: 2.30.97-preview, 2.30.97-beta
 
 ### Trusted Publishing (not enabled — requires an account-side policy first)
 
@@ -298,7 +298,7 @@ dotnet run --project tools/AnalyzerVerifier -- --update-catalog --update-snapsho
 dotnet pack --configuration Release --output ./packages
 
 # Verify the packed analyzer against one compatibility case (matrix in tools/package-compatibility.json)
-dotnet run --project tools/AnalyzerVerifier -- --verify-package-compatibility ./packages/AutoMapperAnalyzer.Analyzers.2.30.96.nupkg --case net10-am14
+dotnet run --project tools/AnalyzerVerifier -- --verify-package-compatibility ./packages/AutoMapperAnalyzer.Analyzers.2.30.97.nupkg --case net10-am14
 
 # Run samples
 dotnet run --project samples/AutoMapperAnalyzer.Samples

--- a/docs/DIAGNOSTIC_RULES.md
+++ b/docs/DIAGNOSTIC_RULES.md
@@ -1883,7 +1883,7 @@ using System.Diagnostics.CodeAnalysis;
 
 1. **Check package reference**:
    ```xml
-   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.96">
+   <PackageReference Include="AutoMapperAnalyzer.Analyzers" Version="2.30.97">
        <PrivateAssets>all</PrivateAssets>
        <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
    </PackageReference>
@@ -1922,5 +1922,5 @@ If analyzer slows down builds:
 ---
 
 **Last Updated**: 2026-05-15
-**Version**: 2.30.96
+**Version**: 2.30.97
 **Maintainer**: George Wall

--- a/docs/RULE_CATALOG.md
+++ b/docs/RULE_CATALOG.md
@@ -2,7 +2,7 @@
 
 This file is generated from `RuleCatalog`.
 
-Package version: `2.30.96`
+Package version: `2.30.97`
 
 | Rule ID | Descriptor Title | Severity | Category | Analyzer | Code Fix | Trust | Sample | Docs |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/docs/TEST_LIMITATIONS.md
+++ b/docs/TEST_LIMITATIONS.md
@@ -199,10 +199,16 @@ choosing inputs where fixed and unfixed output *differ*, not adding more asserti
 diagnostic: the included type's declared shape, its flattening convention, and an explicit
 `ForMember`/`ForPath(... MapFrom(...))` on the uniquely registered child map.
 
-It deliberately does **not** infer that a child map *fails* to supply a member — for example when the
-child map ignores it via `ForMember(... Ignore())` or `ForAllMembers(... Ignore())`. AutoMapper does
-reject those configurations at startup, so this is a real false negative, and
-`IncludeMembersTests.*_KnownLimitation` assert the shipped behaviour rather than the ideal one.
+Since **2.30.97** it also reads the one child-map fact that can be read rather than inferred: an explicit
+`ForMember(d => d.X, o => o.Ignore())` or `ForAllMembers(o => o.Ignore())` states that the map does not
+supply the member, AutoMapper rejects such configurations at startup, and AM011 now reports it.
+
+It still deliberately does **not** *infer* that a child map fails to supply a member. These stay
+suppressing, each pinned by a negative test: unresolved selectors; ambiguous child maps (two
+registrations for the same pair); `ForPath` ignores of a nested member sharing a top-level name; and a
+map carrying both an explicit `MapFrom` and a map-wide `Ignore`, where the result depends on an
+application order this scope does not model. On an `Error`-severity rule a false negative in an
+ambiguous case is preferable to a false positive.
 
 ### Deferred configuration through a mapping local (pre-existing, repo-wide)
 

--- a/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/AutoMapperAnalyzer.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,4 +1,4 @@
-## Release 2.30.96
+## Release 2.30.97
 
 ### New Rules
 

--- a/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
+++ b/src/AutoMapperAnalyzer.Analyzers/AutoMapperAnalyzer.Analyzers.csproj
@@ -17,7 +17,7 @@
         <!-- Fallback for local builds: 2.0.YYYYMMDD-local -->
         <MajorVersion>2</MajorVersion>
         <MinorVersion>30</MinorVersion>
-        <PatchVersion>96</PatchVersion>
+        <PatchVersion>97</PatchVersion>
         <BuildNumber Condition="'$(BuildNumber)' == ''"
         >$([System.DateTime]::Now.ToString('yyyyMMdd'))
         </BuildNumber
@@ -32,11 +32,11 @@
         <RepositoryUrl>https://github.com/georgepwall1991/automapper-analyser</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-                <PackageReleaseNotes>Version 2.30.96 - faster analysis of profiles with long fluent chains
-- Configuration calls are resolved once per CreateMap instead of re-walked for every destination member
-- A 60-ForMember profile costs about 25% less analysis time; the gap between long and short chains roughly halves
-- Short chains are marginally slower, where there is little to cache
-- No rule ID, severity, or diagnostic changes
+                <PackageReleaseNotes>Version 2.30.97 - AM011 reports required members an included map explicitly ignores
+- IncludeMembers: a child map with ForMember(... Ignore()) or ForAllMembers(... Ignore()) no longer suppresses AM011
+- AutoMapper rejects those configurations at startup, so AM011 previously stayed silent on a real defect
+- Reads an explicit Ignore only; unresolved includes, ambiguous child maps, ForPath nested ignores and maps carrying both MapFrom and a map-wide Ignore all stay suppressing
+- No rule ID or severity changes
 </PackageReleaseNotes>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>icon.png</PackageIcon>

--- a/src/AutoMapperAnalyzer.Analyzers/Helpers/MappingChainAnalysisHelper.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Helpers/MappingChainAnalysisHelper.cs
@@ -617,6 +617,62 @@ public static class MappingChainAnalysisHelper
     }
 
     /// <summary>
+    ///     True when the map explicitly states it does not supply the named destination member, through
+    ///     <c>ForMember(d =&gt; d.X, o =&gt; o.Ignore())</c> or a map-wide <c>ForAllMembers(o =&gt;
+    ///     o.Ignore())</c>.
+    ///     <para>
+    ///     Only direct <c>ForMember</c> selectors count. <c>ForPath</c> is excluded because its selector
+    ///     designates a nested path, so a top-level name match there would not mean the top-level member
+    ///     was ignored. Anything this cannot read returns false and leaves the caller suppressing.
+    ///     </para>
+    /// </summary>
+    private static bool IsDestinationMemberExplicitlyIgnoredByMap(
+        InvocationExpressionSyntax mapInvocation,
+        string destinationMemberName,
+        SemanticModel semanticModel)
+    {
+        foreach (InvocationExpressionSyntax chainedInvocation in GetScopedChainInvocations(
+                     mapInvocation, semanticModel, stopAtReverseMapBoundary: true))
+        {
+            if (chainedInvocation.ArgumentList.Arguments.Count == 1 &&
+                IsAutoMapperMethodInvocation(chainedInvocation, semanticModel, "ForAllMembers") &&
+                ContainsIgnoreCall(chainedInvocation.ArgumentList.Arguments[0].Expression))
+            {
+                return true;
+            }
+
+            if (chainedInvocation.ArgumentList.Arguments.Count <= 1 ||
+                !IsAutoMapperMethodInvocation(chainedInvocation, semanticModel, "ForMember"))
+            {
+                continue;
+            }
+
+            string? selectedMember = GetTopLevelSelectedMemberName(
+                chainedInvocation.ArgumentList.Arguments[0].Expression, semanticModel);
+            if (!string.Equals(selectedMember, destinationMemberName, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (ContainsIgnoreCall(chainedInvocation.ArgumentList.Arguments[1].Expression))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsIgnoreCall(ExpressionSyntax configurationExpression)
+    {
+        return configurationExpression.DescendantNodesAndSelf()
+            .OfType<InvocationExpressionSyntax>()
+            .Any(invocation => invocation.Expression is MemberAccessExpressionSyntax memberAccess &&
+                               memberAccess.Name.Identifier.ValueText == "Ignore" &&
+                               invocation.ArgumentList.Arguments.Count == 0);
+    }
+
+    /// <summary>
     ///     Resolves the top-level member a destination selector designates. Lambda member accesses walk
     ///     back to the root member so a nested path is not mistaken for the member it terminates in;
     ///     string and nameof forms already resolve to their top-level segment.
@@ -762,12 +818,17 @@ public static class MappingChainAnalysisHelper
         ///     AutoMapper's flattening convention. An unresolved include satisfies every member so the
         ///     caller fails closed.
         ///     <para>
-        ///     Deliberately reasons about the included type's shape only, never its child map. Deciding
-        ///     what a child map actually supplies means modelling its full member resolution
-        ///     (ForMember/MapFrom, ForAllMembers, reverse-generated registrations, semantic Ignore
-        ///     binding); approximating it produced Error-severity false positives. Shape-only keeps this
-        ///     purely suppressing, so it can never add a diagnostic. Known cost: a child map that ignores
-        ///     or does not supply the member is not diagnosed here.
+        ///     Reasons about the included type's shape, plus the one child-map fact that can be read
+        ///     rather than inferred: an explicit <c>Ignore()</c>. Deciding in general what a child map
+        ///     supplies means modelling its full member resolution (reverse-generated registrations,
+        ///     semantic binding, conditional configuration), and approximating that produced
+        ///     Error-severity false positives, so absence of configuration still suppresses.
+        ///     <para>
+        ///     An explicit <c>ForMember(d =&gt; d.X, o =&gt; o.Ignore())</c> or <c>ForAllMembers(o =&gt;
+        ///     o.Ignore())</c> on a uniquely resolved child map is a statement, not an inference: the map
+        ///     says it does not supply the member, and AutoMapper rejects the configuration at startup.
+        ///     Unresolved includes and unresolvable child maps are untouched by this and still satisfy
+        ///     every member, so the path that caused the false positives cannot be reached.
         ///     </para>
         /// </summary>
         internal bool SatisfiesDestinationMember(string destinationMemberName)
@@ -790,6 +851,18 @@ public static class MappingChainAnalysisHelper
                         includedMember.Map, destinationMemberName, includedMember.SemanticModel))
                 {
                     return true;
+                }
+
+                // Checked after the supply test, so a map carrying both an explicit MapFrom and a
+                // map-wide Ignore stays suppressed. Which of the two wins depends on the order
+                // AutoMapper applies them, and that is not modelled here; on an Error-severity rule a
+                // false negative in that ambiguous case is preferable to a false positive.
+                if (includedMember.Map != null &&
+                    includedMember.SemanticModel != null &&
+                    IsDestinationMemberExplicitlyIgnoredByMap(
+                        includedMember.Map, destinationMemberName, includedMember.SemanticModel))
+                {
+                    continue;
                 }
 
                 List<IPropertySymbol> includedProperties = AutoMapperAnalysisHelpers

--- a/src/AutoMapperAnalyzer.Analyzers/Helpers/MappingChainAnalysisHelper.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/Helpers/MappingChainAnalysisHelper.cs
@@ -663,13 +663,38 @@ public static class MappingChainAnalysisHelper
         return false;
     }
 
+    /// <summary>
+    ///     True when the configuration lambda calls <c>Ignore()</c> on its own options parameter.
+    ///     <para>
+    ///     The receiver check is what makes this safe on an <c>Error</c> rule. Any zero-argument call
+    ///     named <c>Ignore</c> would also match an unrelated helper - <c>o =&gt; o.Condition((src, dest,
+    ///     sm, dm) =&gt; Settings.Ignore())</c> - and reading that as the map ignoring the member turns a
+    ///     valid mapping into a false positive. Only <c>o =&gt; o.Ignore()</c> is AutoMapper's Ignore.
+    ///     </para>
+    /// </summary>
     private static bool ContainsIgnoreCall(ExpressionSyntax configurationExpression)
     {
-        return configurationExpression.DescendantNodesAndSelf()
+        string? optionsParameter = configurationExpression switch
+        {
+            SimpleLambdaExpressionSyntax simpleLambda => simpleLambda.Parameter.Identifier.ValueText,
+            ParenthesizedLambdaExpressionSyntax parenthesizedLambda
+                when parenthesizedLambda.ParameterList.Parameters.Count == 1 =>
+                parenthesizedLambda.ParameterList.Parameters[0].Identifier.ValueText,
+            _ => null
+        };
+
+        if (optionsParameter == null)
+        {
+            return false;
+        }
+
+        return configurationExpression.DescendantNodes()
             .OfType<InvocationExpressionSyntax>()
             .Any(invocation => invocation.Expression is MemberAccessExpressionSyntax memberAccess &&
                                memberAccess.Name.Identifier.ValueText == "Ignore" &&
-                               invocation.ArgumentList.Arguments.Count == 0);
+                               invocation.ArgumentList.Arguments.Count == 0 &&
+                               memberAccess.Expression is IdentifierNameSyntax receiver &&
+                               receiver.Identifier.ValueText == optionsParameter);
     }
 
     /// <summary>
@@ -823,6 +848,7 @@ public static class MappingChainAnalysisHelper
         ///     supplies means modelling its full member resolution (reverse-generated registrations,
         ///     semantic binding, conditional configuration), and approximating that produced
         ///     Error-severity false positives, so absence of configuration still suppresses.
+        ///     </para>
         ///     <para>
         ///     An explicit <c>ForMember(d =&gt; d.X, o =&gt; o.Ignore())</c> or <c>ForAllMembers(o =&gt;
         ///     o.Ignore())</c> on a uniquely resolved child map is a statement, not an inference: the map

--- a/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
+++ b/src/AutoMapperAnalyzer.Analyzers/RuleCatalog.cs
@@ -131,7 +131,7 @@ public static class RuleCatalog
     /// <summary>
     ///     Current package version used by docs/package drift tests.
     /// </summary>
-    public const string CurrentPackageVersion = "2.30.96";
+    public const string CurrentPackageVersion = "2.30.97";
 
     /// <summary>
     ///     Implemented rules, grouped by public diagnostic ID.

--- a/tests/AutoMapperAnalyzer.Tests/DataIntegrity/IncludeMembersTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/DataIntegrity/IncludeMembersTests.cs
@@ -720,6 +720,57 @@ public class IncludeMembersTests
     }
 
     [Fact]
+    public async Task AM011_ShouldNotReportDiagnostic_WhenAnUnrelatedIgnoreHelperIsCalledInConfiguration()
+    {
+        const string testCode = """
+            using AutoMapper;
+
+            namespace TestNamespace
+            {
+                public static class Settings
+                {
+                    public static bool Ignore() => false;
+                }
+
+                public class Inner
+                {
+                    public string Name { get; set; }
+                }
+
+                public class Source
+                {
+                    public Inner Inner { get; set; }
+                }
+
+                public class Destination
+                {
+                    public required string Name { get; set; }
+                }
+
+                public class TestProfile : Profile
+                {
+                    public TestProfile()
+                    {
+                        CreateMap<Inner, Destination>()
+                            .ForMember(d => d.Name, o => o.Condition((src, dest, sm, dm) => !Settings.Ignore()));
+                        CreateMap<Source, Destination>().IncludeMembers(s => s.Inner);
+                    }
+                }
+            }
+            """;
+
+        // A zero-argument Ignore() that is not AutoMapper's - here an unrelated helper inside a
+        // Condition - must not be read as the map ignoring the member. Scanning descendants for any
+        // call named Ignore would turn this valid mapping into an Error-severity false positive, so
+        // the call has to resolve to the configuration lambda's own options parameter.
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM011_UnmappedRequiredPropertyAnalyzer>()
+            .WithSource(testCode)
+            .ExpectNoDiagnostics()
+            .RunAsync();
+    }
+
+    [Fact]
     public async Task AM011_ShouldNotReportDiagnostic_WhenIgnoreTargetsADifferentMember()
     {
         const string testCode = """

--- a/tests/AutoMapperAnalyzer.Tests/DataIntegrity/IncludeMembersTests.cs
+++ b/tests/AutoMapperAnalyzer.Tests/DataIntegrity/IncludeMembersTests.cs
@@ -584,7 +584,7 @@ public class IncludeMembersTests
     }
 
     [Fact]
-    public async Task AM011_ShouldNotReportDiagnostic_WhenIncludedMapIgnoresTheMember_KnownLimitation()
+    public async Task AM011_ShouldReportDiagnostic_WhenIncludedMapIgnoresTheMember()
     {
         const string testCode = """
             using AutoMapper;
@@ -617,15 +617,16 @@ public class IncludeMembersTests
             }
             """;
 
-        // KNOWN LIMITATION (documented in docs/TEST_LIMITATIONS.md): the included type declares 'Name'
-        // but its own map ignores it, so AutoMapper does reject this at configuration time. Deciding
-        // that statically requires modelling the child map's full member resolution; approximating it
-        // produced Error-severity false positives on valid maps, so the scope reasons about the included
-        // type's shape only and stays purely suppressing. This asserts the shipped behaviour.
+        // The included type declares 'Name', but its own map explicitly ignores it, so AutoMapper
+        // rejects this configuration at startup - verified against the real runtime, not assumed.
+        // Reading an explicit Ignore is not the same as inferring that a child map fails to supply a
+        // member: it requires a uniquely resolved child map and a direct ForMember on that exact
+        // member, so it cannot fire on the unresolvable maps that caused the earlier false positives.
         await DiagnosticTestFramework
             .ForAnalyzer<AM011_UnmappedRequiredPropertyAnalyzer>()
             .WithSource(testCode)
-            .ExpectNoDiagnostics()
+            .ExpectDiagnostic(AM011_UnmappedRequiredPropertyAnalyzer.UnmappedRequiredPropertyRule, 17, 32,
+                "Name")
             .RunAsync();
     }
 
@@ -719,7 +720,199 @@ public class IncludeMembersTests
     }
 
     [Fact]
-    public async Task AM011_ShouldNotReportDiagnostic_WhenIncludedMapIgnoresAllMembers_KnownLimitation()
+    public async Task AM011_ShouldNotReportDiagnostic_WhenIgnoreTargetsADifferentMember()
+    {
+        const string testCode = """
+            using AutoMapper;
+
+            namespace TestNamespace
+            {
+                public class Inner
+                {
+                    public string Name { get; set; }
+                    public string Other { get; set; }
+                }
+
+                public class Source
+                {
+                    public Inner Inner { get; set; }
+                }
+
+                public class Destination
+                {
+                    public required string Name { get; set; }
+                    public string Other { get; set; }
+                }
+
+                public class TestProfile : Profile
+                {
+                    public TestProfile()
+                    {
+                        CreateMap<Inner, Destination>().ForMember(d => d.Other, o => o.Ignore());
+                        CreateMap<Source, Destination>().IncludeMembers(s => s.Inner);
+                    }
+                }
+            }
+            """;
+
+        // An Ignore on a different member says nothing about 'Name', which the included type supplies.
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM011_UnmappedRequiredPropertyAnalyzer>()
+            .WithSource(testCode)
+            .ExpectNoDiagnostics()
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM011_ShouldNotReportDiagnostic_WhenExplicitMapFromFollowsIgnoreAllMembers()
+    {
+        const string testCode = """
+            using AutoMapper;
+
+            namespace TestNamespace
+            {
+                public class Inner
+                {
+                    public string Name { get; set; }
+                }
+
+                public class Source
+                {
+                    public Inner Inner { get; set; }
+                }
+
+                public class Destination
+                {
+                    public required string Name { get; set; }
+                }
+
+                public class TestProfile : Profile
+                {
+                    public TestProfile()
+                    {
+                        CreateMap<Inner, Destination>()
+                            .ForAllMembers(o => o.Ignore());
+                        CreateMap<Inner, Destination>()
+                            .ForMember(d => d.Name, o => o.MapFrom(s => s.Name));
+                        CreateMap<Source, Destination>().IncludeMembers(s => s.Inner);
+                    }
+                }
+            }
+            """;
+
+        // Two registrations for the same pair leave the child map ambiguous, so nothing about it can be
+        // read and the scope must stay suppressing - the fail-closed path an Error rule depends on.
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM011_UnmappedRequiredPropertyAnalyzer>()
+            .WithSource(testCode)
+            .ExpectNoDiagnostics()
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM011_ShouldNotReportDiagnostic_WhenMapFromSuppliesMemberAfterIgnoreAllMembers()
+    {
+        const string testCode = """
+            using AutoMapper;
+
+            namespace TestNamespace
+            {
+                public class Inner
+                {
+                    public string Name { get; set; }
+                }
+
+                public class Source
+                {
+                    public Inner Inner { get; set; }
+                }
+
+                public class Destination
+                {
+                    public required string Name { get; set; }
+                }
+
+                public class TestProfile : Profile
+                {
+                    public TestProfile()
+                    {
+                        CreateMap<Inner, Destination>()
+                            .ForMember(d => d.Name, o => o.MapFrom(s => s.Name))
+                            .ForAllMembers(o => o.Ignore());
+                        CreateMap<Source, Destination>().IncludeMembers(s => s.Inner);
+                    }
+                }
+            }
+            """;
+
+        // Both an explicit MapFrom and a map-wide Ignore are present. Which one wins depends on the
+        // order AutoMapper applies them, which this scope does not model, so it stays suppressing rather
+        // than risk an Error-severity false positive. A false negative here is the deliberate trade.
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM011_UnmappedRequiredPropertyAnalyzer>()
+            .WithSource(testCode)
+            .ExpectNoDiagnostics()
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM011_ShouldNotReportDiagnostic_WhenForPathIgnoresANestedMemberOfTheSameName()
+    {
+        const string testCode = """
+            using AutoMapper;
+
+            namespace TestNamespace
+            {
+                public class Detail
+                {
+                    public string Name { get; set; }
+                }
+
+                public class Inner
+                {
+                    public string Name { get; set; }
+                    public Detail Detail { get; set; }
+                }
+
+                public class DestinationDetail
+                {
+                    public string Name { get; set; }
+                }
+
+                public class Source
+                {
+                    public Inner Inner { get; set; }
+                }
+
+                public class Destination
+                {
+                    public required string Name { get; set; }
+                    public DestinationDetail Detail { get; set; }
+                }
+
+                public class TestProfile : Profile
+                {
+                    public TestProfile()
+                    {
+                        CreateMap<Detail, DestinationDetail>();
+                        CreateMap<Inner, Destination>().ForPath(d => d.Detail.Name, o => o.Ignore());
+                        CreateMap<Source, Destination>().IncludeMembers(s => s.Inner);
+                    }
+                }
+            }
+            """;
+
+        // ForPath designates a nested path, so ignoring Detail.Name must not be read as ignoring the
+        // top-level Name that shares its identifier.
+        await DiagnosticTestFramework
+            .ForAnalyzer<AM011_UnmappedRequiredPropertyAnalyzer>()
+            .WithSource(testCode)
+            .ExpectNoDiagnostics()
+            .RunAsync();
+    }
+
+    [Fact]
+    public async Task AM011_ShouldReportDiagnostic_WhenIncludedMapIgnoresAllMembers()
     {
         const string testCode = """
             using AutoMapper;
@@ -752,12 +945,13 @@ public class IncludeMembersTests
             }
             """;
 
-        // KNOWN LIMITATION (see the ForMember variant above): map-wide ignore on the included map is not
-        // modelled, for the same false-positive-avoidance reason. Asserts the shipped behaviour.
+        // Map-wide ignore, same reasoning as the ForMember variant above: an explicit ForAllMembers
+        // Ignore states that the child map supplies nothing, so the required member is unmapped.
         await DiagnosticTestFramework
             .ForAnalyzer<AM011_UnmappedRequiredPropertyAnalyzer>()
             .WithSource(testCode)
-            .ExpectNoDiagnostics()
+            .ExpectDiagnostic(AM011_UnmappedRequiredPropertyAnalyzer.UnmappedRequiredPropertyRule, 17, 32,
+                "Name")
             .RunAsync();
     }
 


### PR DESCRIPTION
Closes the one residual the hardening queue still carried, and the first change today that ships a package.

## The gap

When an `IncludeMembers` child map declared `ForMember(d => d.Name, o => o.Ignore())` or `ForAllMembers(o => o.Ignore())`, **AM011 stayed silent** — while AutoMapper rejects that configuration at startup. A real defect reaching consumers at runtime.

## Why it is safe to close now

The health doc recorded the reopening condition as *"a design that cannot fire on an unresolvable child map"*. Reading an explicit `Ignore()` meets it, because the distinction is between **reading and inferring**.

2.30.88 deliberately refused to *infer* that a child map fails to supply a member — approximating that produced Error-severity false positives, and that refusal was correct. An explicit `Ignore()` is not an inference: the map states it does not supply the member.

## Premise verified, not trusted

The note claiming AutoMapper rejects these configurations, and the tests asserting the silence, were written by the same pass that deferred the work. So the premise was **re-executed against the real AutoMapper runtime** before any code changed. It holds — AutoMapper rejects it.

## What still suppresses — one negative test each

| Case | Why |
| --- | --- |
| Unresolved `IncludeMembers` selector | unchanged fail-closed path |
| Ambiguous child map (two registrations for one pair) | nothing readable |
| `ForPath(d => d.Detail.Name, ...)` | designates a nested path, not the top-level member sharing its name |
| Both `MapFrom` and map-wide `Ignore` | outcome depends on application order this scope does not model |

On an `Error` rule a false negative in an ambiguous case beats a false positive.

## Validation

TDD — the two `*_KnownLimitation` tests were flipped first and failed alone, then the implementation turned them green. **2462 tests pass**, both projects `-warnaserror` clean, catalog/snapshot/compatibility current, and the sample-diagnostics snapshot is **unchanged**.
